### PR TITLE
Fix CTRL+U/D behavior to move cursor

### DIFF
--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -107,7 +107,15 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
 
     /// SCROLL COMMANDS ///
     private scrollPage = (by: "page" | "halfPage", to: "up" | "down"): void => {
-        vscode.commands.executeCommand("editorScroll", { to, by, revealCursor: true });
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+        const visibleRanges = editor.visibleRanges;
+        const scrollLines = Math.ceil(
+            (visibleRanges[0].end.line - visibleRanges[0].start.line) / (by === "halfPage" ? 2 : 1),
+        );
+        vscode.commands.executeCommand("cursorMove", { to, by: "line", value: scrollLines, revealCursor: true });
     };
 
     private scrollLine = (to: "up" | "down"): void => {


### PR DESCRIPTION
Fixes #293.

Note: calculation of a "page" is based on [this source from VSCodeVim](https://github.com/VSCodeVim/Vim/blob/d9517680785b926b69d8d65bb1b334ec71cc1f3c/src/configuration/configuration.ts#L399).