### PR TITLE
Implement smart line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ editor commands, making the best use of both editors.
     -   [Wildmenu completion](#wildmenu-completion)
     -   [Multiple cursors](#multiple-cursors)
     -   [Keyboard Quickfix](#keyboard-quickfix)
+    -   [Smart Line Numbers](#smart-line-numbers)
     -   [Invoking VSCode actions from neovim](#invoking-vscode-actions-from-neovim)
         -   [Examples](#examples)
 -   [⌨️ Bindings](#️-bindings)
@@ -245,6 +246,23 @@ and add to your init.vim:
 
 ```vim
 nnoremap z= <Cmd>call VSCodeNotify('keyboard-quickfix.openQuickFix')<CR>
+```
+
+### Smart Line Numbers
+
+Some popular plugins like [vim-numbertoggle](https://github.com/jeffkreeftmeijer/vim-numbertoggle) or
+[numbers.vim](https://github.com/myusuf3/numbers.vim/) add a feature where relative line numbers are used in normal
+mode, but absolute numbers are used in insert mode.
+
+To replicate this functionality, first make relative numbers default by adding `"editor.lineNumbers": "relative"` to
+your vscode `settings.json`. Then, add the following to your `init.vim` to automatically switch between the two modes:
+
+```vim
+augroup smartnnumbers
+  autocmd!
+  autocmd BufEnter,InsertLeave * RelativeNumber
+  autocmd BufLeave,InsertEnter * Number
+augroup END
 ```
 
 ### Invoking VSCode actions from neovim

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -72,6 +72,11 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 );
                 break;
             }
+            case "set-numbers": {
+                const [mode] = args as ["on" | "relative" | "off"];
+                this.setNumbers(mode);
+                break;
+            }
         }
     }
 
@@ -157,6 +162,20 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                     line.firstNonWhitespaceCharacterIndex,
                 ),
             ];
+        }
+    };
+
+    private setNumbers = (mode: "on" | "relative" | "off"): void => {
+        const e = vscode.window.activeTextEditor;
+        if (!e) {
+            return;
+        }
+        if (mode === "on") {
+            e.options.lineNumbers = vscode.TextEditorLineNumbersStyle.On;
+        } else if (mode === "relative") {
+            e.options.lineNumbers = vscode.TextEditorLineNumbersStyle.Relative;
+        } else {
+            e.options.lineNumbers = vscode.TextEditorLineNumbersStyle.Off;
         }
     };
 }

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -44,3 +44,7 @@ xnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
 " xnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
 " nnoremap <silent> <expr> <C-y> VSCodeExtensionNotify('scroll-line', 'up')
 " xnoremap <silent> <expr> <C-y> VSCodeExtensionNotify('scroll-line', 'up')
+
+command! -nargs=? Number if empty(<q-args>) | call VSCodeExtensionNotify('set-numbers', 'on') | else | call VSCodeExtensionNotify('set-numbers', expand(<q-args>)) | endif
+command! RelativeNumber Number relative
+command! NoNumber Number off


### PR DESCRIPTION
Related: #175

- allow setting the editor line numbers from neovim
- provide example in the readme for smart line numbers

I'm a little stuck on what is the best approach for the vim commands. I don't know if there is a good way to override `set number`, `set rnu`, etc. Also, `:number` and `:nu` is already used for something else. Right now, the usage is `Number on/relative/off`, with aliases for `RelativeNumber` and `NoNumber`. I don't know if abbreviations are worth it, or if those aliases are worth it at all. 

I guess no one will use this exposed functionality outside of the smart line numbers autocmd, because they will just set it in vscode and forget it. So I'm not sure what is best.