### PR TITLE
Fix: go to file

### DIFF
--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -1,5 +1,3 @@
-
-
 function! s:vscodeFormat(...) abort
     if !a:0
         let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
@@ -42,12 +40,21 @@ nnoremap <expr> <Plug>VSCodeCommentaryLine <SID>vscodeCommentary() . '_'
 xnoremap <expr> <C-/> <SID>vscodeCommentary()
 nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
+function! s:vscodeGoToDefinition(str)
+    if exists('b:vscode_controlled') && b:vscode_controlled
+        call VSCodeNotify('editor.action.revealDefinition')
+    else
+        " Allow to function in help files
+        exe "normal! \<C-]>"
+    endif
+endfunction
+
 " gf/gF . Map to go to definition for now
 nnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 nnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap gf <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
-nnoremap gd <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
-nnoremap <C-]> <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+nnoremap gf <Cmd>call <SID>vscodeGoToDefinition()<CR>
+nnoremap gd <Cmd>call <SID>vscodeGoToDefinition()<CR>
+nnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition()<CR>
 nnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 nnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 nnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
@@ -55,9 +62,9 @@ nnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
 xnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 xnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-xnoremap gf <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
-xnoremap gd <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
-xnoremap <C-]> <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+xnoremap gf <Cmd>call <SID>vscodeGoToDefinition()<CR>
+xnoremap gd <Cmd>call <SID>vscodeGoToDefinition()<CR>
+xnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition()<CR>
 xnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 xnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 xnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -42,21 +42,12 @@ nnoremap <expr> <Plug>VSCodeCommentaryLine <SID>vscodeCommentary() . '_'
 xnoremap <expr> <C-/> <SID>vscodeCommentary()
 nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
-function! s:vscodeGoToDefinition(str)
-    if exists('b:vscode_controlled') && b:vscode_controlled
-        call VSCodeNotify('editor.action.' . a:str)
-    else
-        " Allow to function in help files
-        exe "normal! \<C-]>"
-    endif
-endfunction
-
 " gf/gF . Map to go to definition for now
 nnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 nnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap gf <Cmd>call <SID>vscodeGoToDefinition('revealDeclaration')<CR>
-nnoremap gd <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
-nnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
+nnoremap gf <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+nnoremap gd <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+nnoremap <C-]> <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
 nnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 nnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 nnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
@@ -64,9 +55,9 @@ nnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
 xnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 xnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-xnoremap gf <Cmd>call <SID>vscodeGoToDefinition('revealDeclaration')<CR>
-xnoremap gd <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
-xnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
+xnoremap gf <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+xnoremap gd <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+xnoremap <C-]> <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
 xnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 xnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 xnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>


### PR DESCRIPTION
`revealDeclaration` doesn't do anything when the cursor is over a file path. Whilst `revealDefinition` isn't perfect it still is closer to the native `gf` functionality.