### PR TITLE
Fix command line history up/down

### DIFF
--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -223,7 +223,7 @@ export class CommandLineController implements Disposable {
     };
 
     private onHistoryUp = async (): Promise<void> => {
-        await this.neovimClient.input("<Up>");
+        await this.neovimClient.input("<S-Up>");
         const res = await this.neovimClient.callFunction("getcmdline", []);
         if (res) {
             this.input.value = res;
@@ -232,7 +232,7 @@ export class CommandLineController implements Disposable {
     };
 
     private onHistoryDown = async (): Promise<void> => {
-        await this.neovimClient.input("<Down>");
+        await this.neovimClient.input("<S-Down>");
         const res = await this.neovimClient.callFunction("getcmdline", []);
         if (res) {
             this.input.value = res;

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -20,6 +20,10 @@ export class CommandLineController implements Disposable {
 
     private completionTimer?: NodeJS.Timeout;
 
+    private currentCommand: string = "";
+
+    private historyLocation: number = 0;
+
     private completionItems: QuickPickItem[] = [];
 
     private mode = "";
@@ -109,6 +113,9 @@ export class CommandLineController implements Disposable {
     private onChange = (e: string): void => {
         if (!this.isDisplayed) {
             return;
+        }
+        if(this.historyLocation == 0) {
+            this.currentCommand = e;
         }
         const mode = this.mode;
         if (mode === ":" && (e.charAt(0) === "?" || e.charAt(0) === "/") && this.input.items.length) {
@@ -226,6 +233,7 @@ export class CommandLineController implements Disposable {
         await this.neovimClient.input("<S-Up>");
         const res = await this.neovimClient.callFunction("getcmdline", []);
         if (res) {
+            this.historyLocation++;
             this.input.value = res;
             this.input.show();
         }
@@ -235,7 +243,13 @@ export class CommandLineController implements Disposable {
         await this.neovimClient.input("<S-Down>");
         const res = await this.neovimClient.callFunction("getcmdline", []);
         if (res) {
-            this.input.value = res;
+            if (this.historyLocation > 0) {
+                this.historyLocation--;
+                this.input.value = res;
+            }
+            if(this.historyLocation == 0) {
+               this.input.value = this.currentCommand; 
+            }
             this.input.show();
         }
     };

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -20,9 +20,9 @@ export class CommandLineController implements Disposable {
 
     private completionTimer?: NodeJS.Timeout;
 
-    private currentCommand: string = "";
+    private currentCommand = "";
 
-    private historyLocation: number = 0;
+    private historyLocation = 0;
 
     private completionItems: QuickPickItem[] = [];
 
@@ -114,7 +114,7 @@ export class CommandLineController implements Disposable {
         if (!this.isDisplayed) {
             return;
         }
-        if(this.historyLocation == 0) {
+        if (this.historyLocation == 0) {
             this.currentCommand = e;
         }
         const mode = this.mode;
@@ -247,8 +247,8 @@ export class CommandLineController implements Disposable {
                 this.historyLocation--;
                 this.input.value = res;
             }
-            if(this.historyLocation == 0) {
-               this.input.value = this.currentCommand; 
+            if (this.historyLocation == 0) {
+                this.input.value = this.currentCommand;
             }
             this.input.show();
         }


### PR DESCRIPTION
Fixes #708 and #689
 command line history navigation

## Problem
The current API calls are \<Up\> and \<Down\>
These calls find commands in history that can be prefixed by the current command in the input.
This causes the effect of the history getting stuck on the last command in history.

## Solution
To fix this \<S-Up\> and \<S-Down\> calls are used instead in order to get the typical history navigation.

