### PR TITLE
Fix i_Ctrl-a

### DIFF
--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -529,6 +529,28 @@ describe("Insert mode and buffer syncronization", () => {
         );
     });
 
+    // currently fails
+    it.skip("Handles repeating last inserted text with newline", async () => {
+        const doc = await vscode.workspace.openTextDocument({ content: ["blah1 blah3"].join("\n") });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+
+        await sendVSCodeKeys("wiblah2\n");
+        await sendEscapeKey(1000);
+        await sendVSCodeKeys("A");
+        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert");
+        await wait();
+
+        await sendEscapeKey(1000);
+
+        await assertContent(
+            {
+                content: ["blah1 blah2", "blah3blah2"],
+            },
+            client,
+        );
+    });
+
     it("Handles nvim cursor movement commands after sending ctrl+o key", async () => {
         const doc = await vscode.workspace.openTextDocument({
             content: "test",

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -530,8 +530,8 @@ describe("Insert mode and buffer syncronization", () => {
     });
 
     // currently fails
-    it.skip("Handles repeating last inserted text with newline", async () => {
-        const doc = await vscode.workspace.openTextDocument({ content: ["blah1 blah3"].join("\n") });
+    it("Handles repeating last inserted text with newline", async () => {
+        const doc = await vscode.workspace.openTextDocument({ content: "blah1 blah3" });
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait();
 
@@ -545,7 +545,7 @@ describe("Insert mode and buffer syncronization", () => {
 
         await assertContent(
             {
-                content: ["blah1 blah2", "blah3blah2"],
+                content: ["blah1 blah2", "blah3blah2", ""],
             },
             client,
         );

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -529,7 +529,6 @@ describe("Insert mode and buffer syncronization", () => {
         );
     });
 
-    // currently fails
     it("Handles repeating last inserted text with newline", async () => {
         const doc = await vscode.workspace.openTextDocument({ content: "blah1 blah3" });
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -508,6 +508,27 @@ describe("Insert mode and buffer syncronization", () => {
         );
     });
 
+    it("Handles repeating last inserted text in middle of text", async () => {
+        const doc = await vscode.workspace.openTextDocument({ content: ["blah1 blah3"].join("\n") });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+
+        await sendVSCodeKeys("ea blah2");
+        await sendEscapeKey(1000);
+        await sendVSCodeKeys("A");
+        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert");
+        await wait();
+
+        await sendEscapeKey(1000);
+
+        await assertContent(
+            {
+                content: ["blah1 blah2 blah3 blah2"],
+            },
+            client,
+        );
+    });
+
     it("Handles nvim cursor movement commands after sending ctrl+o key", async () => {
         const doc = await vscode.workspace.openTextDocument({
             content: "test",

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -119,8 +119,8 @@ function! VSCodeGetLastInsertText()
         return []
     endif
     let lines = getline(lineStart, lineEnd)
+    let lines[-1] = lines[-1][:colEnd - 2]
     let lines[0] = lines[0][colStart - 1:]
-    let lines[-1] = lines[-1][:colEnd - 1]
     return lines
 endfunction
 

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -113,14 +113,7 @@ endfunction
 
 " Used for ctrl-a insert keybinding
 function! VSCodeGetLastInsertText()
-    let [lineStart, colStart] = getpos("'[")[1:2]
-    let [lineEnd, colEnd] = getpos("']")[1:2]
-    if (lineStart == 0)
-        return []
-    endif
-    let lines = getline(lineStart, lineEnd)
-    let lines[-1] = lines[-1][:colEnd - 2]
-    let lines[0] = lines[0][colStart - 1:]
+    let lines = split(getreg("."), "^@")
     return lines
 endfunction
 


### PR DESCRIPTION
Fixes #402 and solves #283.

Current implementation was correctly getting the boundaries for the inserted text, but it was removing the front text first, shifting the position of the remaining text and thus incorrectly removing the text coming after it.

By simply removing the tail first, the shift happens only after the inserted text has been trimmed, so it works correctly now.
And it needed to be substracted 2 instead to 1 for the tail range because of the `colEnd` position being actually +1 from the last letter of the inserted text and the array range getting until -1 of the specified end index. So the difference is actually 2.