### PR TITLE
Support <c-t> as navigateBack

### DIFF
--- a/package.json
+++ b/package.json
@@ -841,6 +841,12 @@
             },
             {
                 "command": "vscode-neovim.send",
+                "key": "ctrl+t",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
+                "args": "<C-t>"
+            },
+            {
+                "command": "vscode-neovim.send",
                 "key": "ctrl+j",
                 "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
                 "args": "<C-j>"

--- a/vim/vscode-jumplist.vim
+++ b/vim/vscode-jumplist.vim
@@ -1,4 +1,5 @@
 nnoremap <C-o> <Cmd>call VSCodeNotify("workbench.action.navigateBack")<CR>
 nnoremap <C-i> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
 nnoremap <Tab> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
+nnoremap <C-t> <Cmd>call VSCodeNotify("workbench.action.navigateBack")<CR>
 


### PR DESCRIPTION
C-t is used in vim as jumping back in tag stack. With LSP, this is
normally used for "navigating back". So adding this to vscode neovim for
the same convention.

However, as I tested, it does NOT currently work - it *can* send <c-t>
to neovim alright. But I got "E73: tag stack empty", as if c-t were
still bound to neovim's default c-t behavior (jump back in tag stack).
I expected it to have been mapped to `workbench.action.navigateBack`.
Any hint?

TEST:

```
npm install vsce
export PATH=`realpath node_modules/.bin`:$PATH
vsce package

code --install-extension vscode-neovim-0.0.83.vsix

```
