### PR TITLE
Improve efficiency applying small edits

### DIFF
--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -447,7 +447,7 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
                     }
                     this.documentSkipVersionOnChange.set(doc, doc.version + 1);
 
-                    // const cursor = editor.selection.active;
+                    const cursorBefore = editor.selection.active;
                     const success = await editor.edit(
                         (builder) => {
                             for (const range of ranges) {
@@ -521,6 +521,12 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
                     if (success) {
                         if (!editor.selection.anchor.isEqual(editor.selection.active)) {
                             editor.selections = [new Selection(editor.selection.active, editor.selection.active)];
+                        } else {
+                            // Some editor operations change cursor position. This confuses cursor
+                            // sync from Vim to Code (e.g. when cursor did not change in Vim but
+                            // changed in Code). Fix by forcing cursor position to stay the same
+                            // indepent of the diff operation in question.
+                            editor.selections = [new Selection(cursorBefore, cursorBefore)];
                         }
                         this.cursorAfterTextDocumentChange.set(editor.document, {
                             line: editor.selection.active.line,

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -479,20 +479,16 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
                                             range.start == range.end && range.newStart == range.newEnd;
 
                                         let editorOps;
-                                        let isSupportedOperation;
 
                                         if (changeSpansOneLineOnly) {
                                             editorOps = computeEditorOperationsFromDiff(diff(oldText, newText));
-
-                                            // Insert breaks cursor position after undo. Support only delete operation for now.
-                                            isSupportedOperation = editorOps.length == 1 && editorOps[0].op === -1;
                                         }
 
                                         // If supported, efficiently modify only part of line that has changed by
                                         // generating a diff and computing editor operations from it. This prevents
                                         // flashes of non syntax-highlighted text (e.g. when `x` or `cw`, only
                                         // remove a single char/the word).
-                                        if (editorOps && changeSpansOneLineOnly && isSupportedOperation) {
+                                        if (editorOps && changeSpansOneLineOnly) {
                                             applyEditorDiffOperations(builder, { editorOps, line: range.newStart });
                                         } else {
                                             builder.replace(

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,0 +1,75 @@
+import { strict as assert } from "assert";
+
+import vscode, { EndOfLine, TextEditor } from "vscode";
+import diff from "fast-diff";
+
+import { closeAllActiveEditors } from "../utils";
+import { applyEditorDiffOperations, computeEditorOperationsFromDiff } from "../../utils";
+
+describe("utils", () => {
+    afterEach(async () => {
+        await closeAllActiveEditors();
+    });
+
+    describe("applyEditsFromDiff()", function () {
+        it("deletes at beginning", async () => {
+            await assertTextChange("aaa bbb ccc", "bbb ccc");
+            await assertTextChange("pineapple", "apple");
+        });
+
+        it("deletes in middle", async () => {
+            await assertTextChange("aaa bbb ccc", "aaa ccc");
+            await assertTextChange("abc123def", "abcdef");
+        });
+
+        it("deletes at end", async () => {
+            await assertTextChange("aaa bbb ccc", "aaa bbb");
+            await assertTextChange("abc123def", "abc123");
+        });
+
+        it("inserts at beginning", async () => {
+            await assertTextChange("bbb ccc", "aaa bbb ccc");
+            await assertTextChange("abcdef", "123abcdef");
+        });
+
+        it("inserts in middle", async () => {
+            await assertTextChange("aaa ccc", "aaa bbb ccc");
+            await assertTextChange("abcdef", "abc123def");
+        });
+
+        it("inserts at end", async () => {
+            await assertTextChange("aaa bbb", "aaa bbb ccc");
+            await assertTextChange("abcdef", "abcdef123");
+        });
+
+        it("inserts and deletes", async () => {
+            await assertTextChange("yz", "xy");
+        });
+
+        it("supports complex diff", async () => {
+            await assertTextChange("The round pegs in the square holes", "The ones who see things differently");
+        });
+    });
+
+    async function assertTextChange(oldText: string, newText: string): Promise<void> {
+        const editor = await setupEditorWithText(oldText);
+        await editor.edit((builder) => {
+            const editorOps = computeEditorOperationsFromDiff(diff(oldText, newText));
+            applyEditorDiffOperations(builder, { editorOps, line: 0 });
+        });
+        assert.deepEqual(getEditorText(editor), [newText]);
+    }
+
+    async function setupEditorWithText(text: string): Promise<vscode.TextEditor> {
+        const doc = await vscode.workspace.openTextDocument({
+            content: [text].join("\n"),
+        });
+        return vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+    }
+
+    function getEditorText(editor: TextEditor): string[] {
+        const text = editor.document.getText();
+        const eol = editor.document.eol === EndOfLine.CRLF ? "\r\n" : "\n";
+        return text.split(eol);
+    }
+});


### PR DESCRIPTION
This is my attempt to fix #829. The idea is to use `fast-diff` (already in use by other parts of extension) to determine the minimum set of changes to a line required to sync back VS Code to Neovim (after a buffer event). This list of operations is then applied to the text builder object provided by `editor.edit()` (part of Code Extension API).