### PR TITLE
fix issue '{count}gt command not jumping to correct tab #670'

### DIFF
--- a/vim/vscode-tab-commands.vim
+++ b/vim/vscode-tab-commands.vim
@@ -6,6 +6,11 @@ function! s:switchEditor(...) abort
     endfor
 endfunction
 
+function! s:gotoEditor(...) abort
+    let count = a:1
+    call VSCodeCall(count ? printf('workbench.action.openEditorAtIndex%d',count) : 'workbench.action.nextEditorInGroup')
+endfunction
+
 command! -complete=file -nargs=? Tabedit if empty(<q-args>) | call VSCodeNotify('workbench.action.quickOpen') | else | call VSCodeExtensionNotify('open-file', expand(<q-args>), 0) | endif
 command! -complete=file -nargs=? Tabnew call VSCodeExtensionNotify('open-file', '__vscode_new__', 0)
 command! Tabfind call VSCodeNotify('workbench.action.quickOpen')
@@ -34,7 +39,8 @@ AlterCommand tabfir[st] Tabfirst
 AlterCommand tabl[ast] Tablast
 AlterCommand tabm[ove] Tabmove
 
-nnoremap gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
-xnoremap gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
+
+nnoremap gt <Cmd>call <SID>gotoEditor(v:count, 'next')<CR>
+xnoremap gt <Cmd>call <SID>gotoEditor(v:count, 'next')<CR>
 nnoremap gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>
 xnoremap gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>


### PR DESCRIPTION
Fixes #670

The fix uses VSCode workbench.action.openEditorAtIndex# where # stands for tab number.
It's normally used for CMD+# switching among tabs so I don't know if it works beyond 9, but even if limited to 9 it's more accurate than current behavior.

It's my first time contributing to this amazing project so pardon me if I did something wrong. Please let me know if there is anything else that I can do for this PR.