### PR TITLE
<c-u>/<c-d> moves cursor

### DIFF
--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -122,7 +122,7 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
         for (const range of visibleRanges) {
             visibleLineCount += range.end.line - range.start.line + 1;
         }
-        visibleLineCount = Math.ceil(visibleLineCount / (by === "halfPage" ? 2 : 1));
+        visibleLineCount = Math.floor(visibleLineCount / (by === "halfPage" ? 2 : 1));
 
         vscode.commands.executeCommand("editorScroll", { to, by, revealCursor: !cursorVisible });
         if (cursorVisible) {


### PR DESCRIPTION
This continues the work in #528 and addresses #293.

![halfPage](https://user-images.githubusercontent.com/3968357/162231807-c744cc15-3f65-4d35-a0bd-7f1bede8440f.gif)

The only way I found to get reliable behavior that plays nice with folds is using `cursorMove` and `by: "wrappedLine"`, which gracefully moves over folds. This is because we can only infer folds form visible ranges, which doesn't account for the folds that might be revealed as we scroll. Also, `visibleRanges` only updates after the smooth scrolling animation completes, so it's not feasible to examine it after scrolling for complete information before moving the cursor.

The tradeoff with this approach is that each wrapped line causes the cursor position to be off by one when scrolling. I think this is the best we're going to get for now.

At a glance I'm not sure we can meaningfully unit test this as it's dependent on editor size, which isn't exposed to us.

This is my first work on a VSCode extension, and in JavaScript, so feedback is appreciated.