### PR TITLE
Fix dropped characters in search

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,10 @@
                 "title": "Neovim: Delete char cmdline"
             },
             {
+                "command": "vscode-neovim.match-cursor-search",
+                "title": "Neovim: Match cursor search"
+            },
+            {
                 "command": "vscode-neovim.complete-selection-cmdline",
                 "title": "Neovim: Complete selection cmdline"
             },
@@ -783,6 +787,11 @@
             {
                 "command": "vscode-neovim.delete-char-left-cmdline",
                 "key": "ctrl+h",
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
+            },
+            {
+                "command": "vscode-neovim.match-cursor-search",
+                "key": "ctrl+l",
                 "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {

--- a/package.json
+++ b/package.json
@@ -309,8 +309,8 @@
                 "title": "Neovim: Delete char cmdline"
             },
             {
-                "command": "vscode-neovim.match-cursor-search",
-                "title": "Neovim: Match cursor search"
+                "command": "vscode-neovim.match-cursor-search-cmdline",
+                "title": "Neovim: Match cursor search cmdline"
             },
             {
                 "command": "vscode-neovim.complete-selection-cmdline",
@@ -790,7 +790,7 @@
                 "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
-                "command": "vscode-neovim.match-cursor-search",
+                "command": "vscode-neovim.match-cursor-search-cmdline",
                 "key": "ctrl+l",
                 "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -45,7 +45,7 @@ export class CommandLineController implements Disposable {
         this.disposables.push(commands.registerCommand("vscode-neovim.delete-word-left-cmdline", this.deleteWord));
         this.disposables.push(commands.registerCommand("vscode-neovim.delete-all-cmdline", this.deleteAll));
         this.disposables.push(commands.registerCommand("vscode-neovim.delete-char-left-cmdline", this.deleteChar));
-        this.disposables.push(commands.registerCommand("vscode-neovim.match-cursor-search", this.matchCursor));
+        this.disposables.push(commands.registerCommand("vscode-neovim.match-cursor-search-cmdline", this.matchCursor));
         this.disposables.push(commands.registerCommand("vscode-neovim.history-up-cmdline", this.onHistoryUp));
         this.disposables.push(commands.registerCommand("vscode-neovim.history-down-cmdline", this.onHistoryDown));
         this.disposables.push(

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -205,7 +205,7 @@ export class CommandLineController implements Disposable {
     private matchCursor = (): void => {
         this.redrawExpected = true;
         this.callbacks.onMatchCursor();
-    }
+    };
 
     private clean(): void {
         if (this.completionTimer) {

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -77,10 +77,12 @@ export class CommandLineController implements Disposable {
             if (newTitle !== this.input.title) {
                 this.input.title = newTitle;
             }
+
             // we want take content for the search modes if <c-l> was used
-            if (this.redrawExpected && (this.mode === "/" || this.mode === "?")) {
-                this.input.value = initialContent;
+            if (this.redrawExpected) {
                 this.redrawExpected = false;
+                this.input.value = initialContent;
+                this.onChange(this.input.value);
             }
         }
     }

--- a/src/command_line_manager.ts
+++ b/src/command_line_manager.ts
@@ -52,28 +52,14 @@ export class CommandLineManager implements Disposable, NeovimRedrawProcessable {
                     if (this.cmdlineTimer) {
                         clearTimeout(this.cmdlineTimer);
                         this.cmdlineTimer = undefined;
-                        if (!this.commandLine) {
-                            this.commandLine = new CommandLineController(this.client, {
-                                onAccepted: this.onCmdAccept,
-                                onCanceled: this.onCmdCancel,
-                                onChanged: this.onCmdChange,
-                            });
-                        }
-                        this.commandLine.show(allContent, firstc, prompt);
+                        this.showCmd(allContent, firstc, prompt);
                     } else {
                         // if there is initial content and it's not currently displayed then it may come
                         // from some mapping. to prevent bad UI commandline transition we delay cmdline appearing here
                         if (allContent !== "" && allContent !== "'<,'>" && !this.commandLine) {
                             this.cmdlineTimer = setTimeout(() => this.showCmdOnTimer(allContent, firstc, prompt), 200);
                         } else {
-                            if (!this.commandLine) {
-                                this.commandLine = new CommandLineController(this.client, {
-                                    onAccepted: this.onCmdAccept,
-                                    onCanceled: this.onCmdCancel,
-                                    onChanged: this.onCmdChange,
-                                });
-                            }
-                            this.commandLine.show(allContent, firstc, prompt);
+                            this.showCmd(allContent, firstc, prompt);
                         }
                     }
                     break;
@@ -100,15 +86,20 @@ export class CommandLineManager implements Disposable, NeovimRedrawProcessable {
         }
     }
 
-    private showCmdOnTimer = (initialContent: string, firstc: string, prompt: string): void => {
+    private showCmd = (initialContent: string, firstc: string, prompt: string): void => {
         if (!this.commandLine) {
             this.commandLine = new CommandLineController(this.client, {
                 onAccepted: this.onCmdAccept,
                 onCanceled: this.onCmdCancel,
                 onChanged: this.onCmdChange,
+                onMatchCursor: this.onCmdMatchCursor,
             });
         }
         this.commandLine.show(initialContent, firstc, prompt);
+    };
+
+    private showCmdOnTimer = (initialContent: string, firstc: string, prompt: string): void => {
+        this.showCmd(initialContent, firstc, prompt);
         this.cmdlineTimer = undefined;
     };
 
@@ -126,5 +117,9 @@ export class CommandLineManager implements Disposable, NeovimRedrawProcessable {
 
     private onCmdAccept = (): void => {
         this.client.input("<CR>");
+    };
+
+    private onCmdMatchCursor = (): void => {
+        this.client.input("<C-l>");
     };
 }

--- a/src/command_line_manager.ts
+++ b/src/command_line_manager.ts
@@ -1,5 +1,5 @@
 import { NeovimClient } from "neovim";
-import { Disposable, OutputChannel, window } from "vscode";
+import { Disposable } from "vscode";
 
 import { CommandLineController } from "./command_line";
 import { Logger } from "./logger";
@@ -42,7 +42,7 @@ export class CommandLineManager implements Disposable, NeovimRedrawProcessable {
                         number,
                     ];
                     let allContent = content.map(([, str]) => str).join("");
-                    if (allContent.endsWith('\f')) {
+                    if (allContent.endsWith("\f")) {
                         allContent = allContent.slice(0, -1);
                     }
                     // !note: neovim can send cmdline_hide followed by cmdline_show events

--- a/src/command_line_manager.ts
+++ b/src/command_line_manager.ts
@@ -1,5 +1,5 @@
 import { NeovimClient } from "neovim";
-import { Disposable } from "vscode";
+import { Disposable, OutputChannel, window } from "vscode";
 
 import { CommandLineController } from "./command_line";
 import { Logger } from "./logger";
@@ -41,7 +41,10 @@ export class CommandLineManager implements Disposable, NeovimRedrawProcessable {
                         number,
                         number,
                     ];
-                    const allContent = content.map(([, str]) => str).join("");
+                    let allContent = content.map(([, str]) => str).join("");
+                    if (allContent.endsWith('\f')) {
+                        allContent = allContent.slice(0, -1);
+                    }
                     // !note: neovim can send cmdline_hide followed by cmdline_show events
                     // !since quickpick can be destroyed slightly at later time after handling cmdline_hide we want to create new command line
                     // !controller and input for every visible cmdline_show event

--- a/src/test/suite/command-line.test.ts
+++ b/src/test/suite/command-line.test.ts
@@ -3,7 +3,7 @@ import { strict as assert } from "assert";
 import vscode from "vscode";
 import { NeovimClient } from "neovim";
 
-import { attachTestNvimClient, sendVSCodeKeys, wait, closeAllActiveEditors, closeNvimClient, sendEscapeKey } from "../utils";
+import { attachTestNvimClient, sendVSCodeKeys, wait, closeAllActiveEditors, closeNvimClient } from "../utils";
 
 describe("Command line", () => {
     let client: NeovimClient;

--- a/src/test/suite/command-line.test.ts
+++ b/src/test/suite/command-line.test.ts
@@ -3,7 +3,7 @@ import { strict as assert } from "assert";
 import vscode from "vscode";
 import { NeovimClient } from "neovim";
 
-import { attachTestNvimClient, sendVSCodeKeys, wait, closeAllActiveEditors, closeNvimClient } from "../utils";
+import { attachTestNvimClient, sendVSCodeKeys, wait, closeAllActiveEditors, closeNvimClient, sendEscapeKey } from "../utils";
 
 describe("Command line", () => {
     let client: NeovimClient;
@@ -24,10 +24,31 @@ describe("Command line", () => {
         });
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait();
+
+        await sendVSCodeKeys("/");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await sendVSCodeKeys("\n");
+        assert.equal(await client.commandOutput("echo getreg('/')"), "1a");
+
         await sendVSCodeKeys("/a");
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
         await sendVSCodeKeys("\n");
         assert.equal(await client.commandOutput("echo getreg('/')"), "abc");
+
+        await sendVSCodeKeys(":%s/a");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await sendVSCodeKeys("/xyz/g");
+        await sendVSCodeKeys("\n");
+        assert.equal(await client.commandOutput("echo getreg('/')"), "abc");
+
+        await sendVSCodeKeys(":%s/");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await sendVSCodeKeys("xyz/abc/g");
+        await sendVSCodeKeys("\n");
+        assert.equal(await client.commandOutput("echo getreg('/')"), "xyz");
     });
 });

--- a/src/test/suite/command-line.test.ts
+++ b/src/test/suite/command-line.test.ts
@@ -1,0 +1,38 @@
+import { strict as assert } from "assert";
+import vscode from "vscode";
+import { NeovimClient } from "neovim";
+
+import {
+    attachTestNvimClient,
+    sendVSCodeKeys,
+    wait,
+    closeAllActiveEditors,
+    closeNvimClient,
+} from "../utils";
+
+describe("Command line", () => {
+    let client: NeovimClient;
+    before(async () => {
+        client = await attachTestNvimClient();
+    });
+    after(async () => {
+        await closeNvimClient(client);
+    });
+
+    afterEach(async () => {
+        await closeAllActiveEditors();
+    });
+
+    it("Ctrl+L", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["1abc", "", "2abc blah", "3abc blah blah", "4abc"].join("\n"),
+        });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+        await sendVSCodeKeys("/a");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search");
+        await sendVSCodeKeys("\n");
+        assert.equal(await client.commandOutput("echo getreg('/')"), "abc");
+    });
+});

--- a/src/test/suite/command-line.test.ts
+++ b/src/test/suite/command-line.test.ts
@@ -1,14 +1,9 @@
 import { strict as assert } from "assert";
+
 import vscode from "vscode";
 import { NeovimClient } from "neovim";
 
-import {
-    attachTestNvimClient,
-    sendVSCodeKeys,
-    wait,
-    closeAllActiveEditors,
-    closeNvimClient,
-} from "../utils";
+import { attachTestNvimClient, sendVSCodeKeys, wait, closeAllActiveEditors, closeNvimClient } from "../utils";
 
 describe("Command line", () => {
     let client: NeovimClient;

--- a/src/test/suite/command-line.test.ts
+++ b/src/test/suite/command-line.test.ts
@@ -25,8 +25,8 @@ describe("Command line", () => {
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait();
         await sendVSCodeKeys("/a");
-        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search");
-        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
         await sendVSCodeKeys("\n");
         assert.equal(await client.commandOutput("echo getreg('/')"), "abc");
     });

--- a/src/test/suite/command-line.test.ts
+++ b/src/test/suite/command-line.test.ts
@@ -3,7 +3,14 @@ import { strict as assert } from "assert";
 import vscode from "vscode";
 import { NeovimClient } from "neovim";
 
-import { attachTestNvimClient, sendVSCodeKeys, wait, closeAllActiveEditors, closeNvimClient } from "../utils";
+import {
+    attachTestNvimClient,
+    sendVSCodeKeys,
+    wait,
+    closeAllActiveEditors,
+    closeNvimClient,
+    sendVSCodeKeysAtomic,
+} from "../utils";
 
 describe("Command line", () => {
     let client: NeovimClient;
@@ -25,30 +32,41 @@ describe("Command line", () => {
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait();
 
-        await sendVSCodeKeys("/");
+        await sendVSCodeKeysAtomic("/1");
+        await wait(1000);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await wait(100);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
-        await sendVSCodeKeys("\n");
-        assert.equal(await client.commandOutput("echo getreg('/')"), "1a");
+        await wait(100);
+        await vscode.commands.executeCommand("vscode-neovim.commit-cmdline");
+        assert.equal(await client.commandOutput("echo getreg('/')"), "1ab");
 
-        await sendVSCodeKeys("/a");
+        await sendVSCodeKeysAtomic("/a");
+        await wait(1000);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await wait(100);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
-        await sendVSCodeKeys("\n");
+        await wait(100);
+        await vscode.commands.executeCommand("vscode-neovim.commit-cmdline");
         assert.equal(await client.commandOutput("echo getreg('/')"), "abc");
 
-        await sendVSCodeKeys(":%s/a");
+        await sendVSCodeKeysAtomic(":%s/a");
+        await wait(1000);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await wait(100);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await wait(100);
         await sendVSCodeKeys("/xyz/g");
-        await sendVSCodeKeys("\n");
+        await vscode.commands.executeCommand("vscode-neovim.commit-cmdline");
         assert.equal(await client.commandOutput("echo getreg('/')"), "abc");
 
-        await sendVSCodeKeys(":%s/");
+        await sendVSCodeKeysAtomic(":%s/");
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await wait(100);
         await vscode.commands.executeCommand("vscode-neovim.match-cursor-search-cmdline");
+        await wait(100);
         await sendVSCodeKeys("xyz/abc/g");
-        await sendVSCodeKeys("\n");
+        await vscode.commands.executeCommand("vscode-neovim.commit-cmdline");
         assert.equal(await client.commandOutput("echo getreg('/')"), "xyz");
     });
 });


### PR DESCRIPTION
Addresses #683.

Now the quickpick input is only updated upon a `cmdline_show` event from Neovim if the update is expected due to a recent `<c-l>` input.