### PR TITLE
Fix command completion for path and command symbols

### DIFF
--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -218,7 +218,19 @@ export class CommandLineController implements Disposable {
         if (!sel) {
             return;
         }
-        this.input.value = this.input.value.split(" ").slice(0, -1).concat(sel.label).join(" ");
+        const selected = sel.label;
+        let lastInputEl = this.input.value;
+        // if there is more than one command, get the last one (command, path or space delimited)
+        const symbolCheck = /[\s\/\\!@#$:<'>%]/g
+        if (symbolCheck.test(lastInputEl)) {
+            lastInputEl = lastInputEl.split(symbolCheck).pop()!;
+        }
+        const isSubstring = selected.search(lastInputEl) 
+        if ((lastInputEl && isSubstring !== -1) || lastInputEl === "~") {
+            this.input.value = this.input.value.replace(lastInputEl, selected)
+        } else {
+            this.input.value += selected;
+        }
         this.onChange(this.input.value);
     };
 

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -221,13 +221,13 @@ export class CommandLineController implements Disposable {
         const selected = sel.label;
         let lastInputEl = this.input.value;
         // if there is more than one command, get the last one (command, path or space delimited)
-        const symbolCheck = /[\s\/\\!@#$:<'>%]/g
+        const symbolCheck = /[\s/\\!@#$:<'>%]/g;
         if (symbolCheck.test(lastInputEl)) {
             lastInputEl = lastInputEl.split(symbolCheck).pop()!;
         }
-        const isSubstring = selected.search(lastInputEl) 
+        const isSubstring = selected.search(lastInputEl);
         if ((lastInputEl && isSubstring !== -1) || lastInputEl === "~") {
-            this.input.value = this.input.value.replace(lastInputEl, selected)
+            this.input.value = this.input.value.replace(lastInputEl, selected);
         } else {
             this.input.value += selected;
         }


### PR DESCRIPTION
## Problem
Command completion uses space to delimit and replace the current command with the incoming completion item.
This causes completion with paths & command symbols to be completely replaced with the incoming completion. (if space is not used)

## Solution
Use path symbols and vim command symbols to delimit the current command, then compare the last delimited item with the incoming completion item.

Fixes #860