### PR TITLE
Bump workflow node version from 12 to 14

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v1
               with:
-                  node-version: "12"
+                  node-version: "14"
             - name: Install Neovim
               uses: rhysd/action-setup-vim@v1
               id: vim
@@ -51,7 +51,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v1
               with:
-                  node-version: "12"
+                  node-version: "14"
             - name: Yarn install
               run: yarn --silent --frozen-lockfile
             - name: Install VSCE


### PR DESCRIPTION
## Problem
The _create_ job in the _build_test.yml_ workflow: fails on the _Install VSCE_ step due to node version 14 requirement
## Solution
Bumped node version from 12  to 14 in the workflow jobs