### PR TITLE
feat: allow get visible range lines on plugin.

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -13,12 +13,13 @@ import {
     Uri,
     ViewColumn,
     window,
-    workspace,
+    workspace
 } from "vscode";
-
 import { Logger } from "./logger";
 import { NeovimExtensionRequestProcessable, NeovimRedrawProcessable } from "./neovim_events_processable";
 import { calculateEditorColFromVimScreenCol, callAtomic, getNeovimCursorPosFromEditor } from "./utils";
+
+
 
 // !Note: document and editors in vscode events and namespace are reference stable
 // ! Integration notes:
@@ -194,7 +195,7 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
                     if (fileName === "__vscode_new__") {
                         doc = await workspace.openTextDocument();
                     } else {
-                        const normalizedName = fileName.trim()
+                        const normalizedName = fileName.trim();
                         const filePath = this.findPathFromFileName(normalizedName);
                         doc = await workspace.openTextDocument(filePath);
                     }
@@ -273,6 +274,24 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
                         // todo: show error
                     }
                 }
+                break;
+            }
+            // set a visble range line to buffer varrible
+            case "visible-range": {
+                const currEditor = window.activeTextEditor;
+                if (!currEditor) {
+                    return;
+                }
+                await this.client.call("nvim_buf_set_var", [
+                    0,
+                    "vscode_range_startline",
+                    currEditor.visibleRanges[0].start.line,
+                ]);
+                await this.client.call("nvim_buf_set_var", [
+                    0,
+                    "vscode_range_endline",
+                    currEditor.visibleRanges[0].end.line,
+                ]);
                 break;
             }
         }


### PR DESCRIPTION

By default vscode-neovim control the scroll and set viewport of neovim is 201.

This PR help plugin to get a visible line range on editor by calling

```lua
vim.fn.VSCodeExtensionNotify('visible-range')

```

and use `vim.b.vscode_range_startline` `vim.b.vscode_range_endline` to get visible range.
