### PR TITLE
feat(messages): show more messages in Output

### DIFF
--- a/src/multiline_messages_manager.ts
+++ b/src/multiline_messages_manager.ts
@@ -9,12 +9,9 @@ export class MutlilineMessagesManager implements Disposable, NeovimRedrawProcess
 
     private channel: OutputChannel;
 
-    private isDisplayed = false;
-
     public constructor(private logger: Logger) {
-        this.channel = window.createOutputChannel(`${EXT_NAME} Messages`);
+        this.channel = window.createOutputChannel(`${EXT_NAME}`);
         this.disposables.push(this.channel);
-        this.disposables.push(window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor));
     }
 
     public dispose(): void {
@@ -28,9 +25,6 @@ export class MutlilineMessagesManager implements Disposable, NeovimRedrawProcess
                     let str = "";
                     for (const [type, content, clear] of args as [string, [number, string][], boolean][]) {
                         if (type === "return_prompt") {
-                            continue;
-                        }
-                        if (type) {
                             continue;
                         }
                         if (clear) {
@@ -47,11 +41,9 @@ export class MutlilineMessagesManager implements Disposable, NeovimRedrawProcess
                     // remove empty last line (since we always put \n at the end)
                     const lines = str.split("\n").slice(1);
                     if (lines.length > 1) {
-                        this.showChannel();
-                        this.channel.append(str);
-                    } else if (this.isDisplayed) {
-                        this.channel.append(str);
+                        this.channel.show(true)
                     }
+                    this.channel.append(str);
                     break;
                 }
                 case "msg_history_show": {
@@ -67,49 +59,11 @@ export class MutlilineMessagesManager implements Disposable, NeovimRedrawProcess
                             }
                         }
                     }
-                    this.showChannel();
+                    this.channel.show(true)
                     this.channel.append(str);
                     break;
                 }
             }
         }
-    }
-
-    private showChannel(): void {
-        if (this.isDisplayed) {
-            return;
-        }
-        this.isDisplayed = true;
-        this.channel.clear();
-        this.channel.appendLine("VSCode-Neovim:");
-        this.channel.show();
-    }
-
-    private hideChannel(): void {
-        this.channel.hide();
-    }
-
-    private onDidChangeActiveTextEditor = (editor: TextEditor | undefined): void => {
-        if (!editor || !this.isEditorIsChannel(editor)) {
-            if (this.isDisplayed) {
-                this.hideChannel();
-            }
-            this.isDisplayed = false;
-        } else {
-            this.isDisplayed = true;
-        }
-    };
-
-    private isEditorIsChannel(editor: TextEditor): boolean {
-        const doc = editor.document;
-        if (doc.uri.scheme !== "output") {
-            return false;
-        }
-        const line = doc.lineAt(0);
-        // no other way i'm aware of to check if a document is the our channel document
-        if (line.text.startsWith("VSCode-Neovim:")) {
-            return true;
-        }
-        return false;
     }
 }


### PR DESCRIPTION
## Problem:
The vscode-neovim Output channel has some weird behavior:
1. It auto-closes when it loses focus.
2. It clears itself (e.g. on `:messages`) instead of just appending.
3. It doesn't log most Nvim messages.

This makes the Output channel not very useful except for one-off
invocations `:messages`.

## Solution:
1. Always append.
2. Only *show* the Output channel, don't move the cursor there.
3. Don't try to be clever about clearing the Output channel or
   auto-hiding it.
   - This allows the user to keep the Output channel open and see
     results of sequential commands (like a REPL, as `:` is intended).
4. Print all messages (except `return_prompt`).

closes #880
ref #334

@asvetliakov any objections here?