### PR TITLE
fix(scrolling): fix c-u/c-y/c-f/c-b by deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,11 +119,6 @@
                     "default": false,
                     "markdownDescription": "Use neovim installed in WSL. If you enable this setting, specify the path to the neovim executable installed in WSL `neovimExecutablePaths.linux` setting"
                 },
-                "vscode-neovim.revealCursorScrollLine": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "If 'true' reveals the cursor when scrolling by line and if it is outside view port"
-                },
                 "vscode-neovim.logPath": {
                     "type": "string",
                     "default": "",

--- a/package.json
+++ b/package.json
@@ -291,24 +291,8 @@
                 "title": "Neovim: Send key in cmdline"
             },
             {
-                "command": "vscode-neovim.ctrl-b",
-                "title": "Neovim: ctrl-b"
-            },
-            {
-                "command": "vscode-neovim.ctrl-d",
-                "title": "Neovim: ctrl-d"
-            },
-            {
                 "command": "vscode-neovim.ctrl-e",
                 "title": "Neovim: ctrl-e"
-            },
-            {
-                "command": "vscode-neovim.ctrl-f",
-                "title": "Neovim: ctrl-f"
-            },
-            {
-                "command": "vscode-neovim.ctrl-u",
-                "title": "Neovim: ctrl-u"
             },
             {
                 "command": "vscode-neovim.ctrl-y",
@@ -689,14 +673,16 @@
                 "args": "<C-a>"
             },
             {
-                "command": "vscode-neovim.ctrl-b",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+b",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
+                "args": "<C-b>"
             },
             {
-                "command": "vscode-neovim.ctrl-d",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+d",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
+                "args": "<C-d>"
             },
             {
                 "command": "vscode-neovim.ctrl-e",
@@ -704,9 +690,10 @@
                 "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
             },
             {
-                "command": "vscode-neovim.ctrl-f",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+f",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
+                "args": "<C-f>"
             },
             {
                 "command": "vscode-neovim.send",
@@ -727,9 +714,10 @@
                 "args": "<C-r>"
             },
             {
-                "command": "vscode-neovim.ctrl-u",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+u",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
+                "args": "<C-u>"
             },
             {
                 "command": "vscode-neovim.send",

--- a/package.json
+++ b/package.json
@@ -297,18 +297,6 @@
             {
                 "command": "vscode-neovim.ctrl-y",
                 "title": "Neovim: ctrl-y"
-            },
-            {
-                "command": "vscode-neovim.shift-m",
-                "title": "Neovim: shift-m"
-            },
-            {
-                "command": "vscode-neovim.shift-l",
-                "title": "Neovim: shift-l"
-            },
-            {
-                "command": "vscode-neovim:shift-h",
-                "title": "Neovim: shift-h"
             }
         ],
         "keybindings": [

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -13,18 +13,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     public constructor(client: NeovimClient, revealCursorScrollLine: boolean) {
         this.client = client;
         this.revealCursorScrollLine = revealCursorScrollLine;
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-f", () => this.scrollPage("page", "down")),
-        );
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-b", () => this.scrollPage("page", "up")),
-        );
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-d", () => this.scrollPage("halfPage", "down")),
-        );
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-u", () => this.scrollPage("halfPage", "up")),
-        );
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-e", () => this.scrollLine("down")));
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-y", () => this.scrollLine("up")));
     }
@@ -48,11 +36,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 this.goToLine(to);
                 break;
             }
-            case "scroll": {
-                const [by, to] = args as ["page" | "halfPage", "up" | "down"];
-                this.scrollPage(by, to);
-                break;
-            }
             case "scroll-line": {
                 const [to] = args as ["up" | "down"];
                 this.scrollLine(to);
@@ -70,10 +53,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     }
 
     /// SCROLL COMMANDS ///
-    private scrollPage = (by: "page" | "halfPage", to: "up" | "down"): void => {
-        vscode.commands.executeCommand("editorScroll", { to, by, revealCursor: true });
-    };
-
     private scrollLine = (to: "up" | "down"): void => {
         vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: this.revealCursorScrollLine });
     };

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -4,15 +4,9 @@ import { NeovimClient } from "neovim";
 import { NeovimExtensionRequestProcessable } from "./neovim_events_processable";
 
 export class CommandsController implements Disposable, NeovimExtensionRequestProcessable {
-    private client: NeovimClient;
-
     private disposables: Disposable[] = [];
 
-    private revealCursorScrollLine: boolean;
-
-    public constructor(client: NeovimClient, revealCursorScrollLine: boolean) {
-        this.client = client;
-        this.revealCursorScrollLine = revealCursorScrollLine;
+    public constructor(private client: NeovimClient) {
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-e", () => this.scrollLine("down")));
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-y", () => this.scrollLine("up")));
     }
@@ -31,25 +25,12 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 this.revealLine(at, !!updateCursor);
                 break;
             }
-            case "scroll-line": {
-                const [to] = args as ["up" | "down"];
-                this.scrollLine(to);
-                break;
-            }
-            case "insert-line": {
-                const [type] = args as ["before" | "after"];
-                await this.client.command("startinsert");
-                await vscode.commands.executeCommand(
-                    type === "before" ? "editor.action.insertLineBefore" : "editor.action.insertLineAfter",
-                );
-                break;
-            }
         }
     }
 
     /// SCROLL COMMANDS ///
     private scrollLine = (to: "up" | "down"): void => {
-        vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: this.revealCursorScrollLine });
+        vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: true });
     };
 
     // zz, zt, zb and others

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -31,11 +31,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 this.revealLine(at, !!updateCursor);
                 break;
             }
-            case "move-cursor": {
-                const [to] = args as ["top" | "middle" | "bottom"];
-                this.goToLine(to);
-                break;
-            }
             case "scroll-line": {
                 const [to] = args as ["up" | "down"];
                 this.scrollLine(to);
@@ -55,30 +50,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     /// SCROLL COMMANDS ///
     private scrollLine = (to: "up" | "down"): void => {
         vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: this.revealCursorScrollLine });
-    };
-
-    private goToLine = (to: "top" | "middle" | "bottom"): void => {
-        const e = vscode.window.activeTextEditor;
-        if (!e) {
-            return;
-        }
-        const topVisible = e.visibleRanges[0].start.line;
-        const bottomVisible = e.visibleRanges[0].end.line;
-        const lineNum =
-            to === "top"
-                ? topVisible
-                : to === "bottom"
-                ? bottomVisible
-                : Math.floor(topVisible + (bottomVisible - topVisible) / 2);
-        const line = e.document.lineAt(lineNum);
-        e.selections = [
-            new vscode.Selection(
-                lineNum,
-                line.firstNonWhitespaceCharacterIndex,
-                lineNum,
-                line.firstNonWhitespaceCharacterIndex,
-            ),
-        ];
     };
 
     // zz, zt, zb and others

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -82,10 +82,6 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
      */
     private dotRepeatChange: DotRepeatChange | undefined;
     /**
-     * A hint for dot-repeat indicating of how the insert mode was started
-     */
-    private dotRepeatStartModeInsertHint?: "o" | "O";
-    /**
      * True when we're currently applying edits, so incoming changes will go into pending events queue
      */
     private applyingEdits = false;
@@ -123,12 +119,8 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
         return (this.textDocumentChangePromise.get(doc)?.length || 0) > 0;
     }
 
-    public async handleExtensionRequest(name: string, args: unknown[]): Promise<void> {
-        if (name === "insert-line") {
-            const [type] = args as ["before" | "after"];
-            this.dotRepeatStartModeInsertHint = type === "before" ? "O" : "o";
-            this.logger.debug(`${LOG_PREFIX}: Setting start insert mode hint - ${this.dotRepeatStartModeInsertHint}`);
-        }
+    public async handleExtensionRequest(): Promise<void> {
+        // skip
     }
 
     public async syncDocumentsWithNeovim(): Promise<void> {
@@ -273,13 +265,6 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
             );
         }
         let editStr = "";
-        if (dotRepeatChange.startMode) {
-            editStr += `<Esc>${dotRepeatChange.startMode}`;
-            // remove EOL from first change
-            if (dotRepeatChange.text.startsWith(dotRepeatChange.eol)) {
-                dotRepeatChange.text = dotRepeatChange.text.slice(dotRepeatChange.eol.length);
-            }
-        }
         if (dotRepeatChange.rangeLength) {
             editStr += [...new Array(dotRepeatChange.rangeLength).keys()].map(() => "<BS>").join("");
         }
@@ -570,12 +555,10 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
             return;
         }
 
-        const startModeHint = this.dotRepeatStartModeInsertHint;
         const activeEditor = window.activeTextEditor;
 
         // Store dot repeat
         if (activeEditor && activeEditor.document === document && this.modeManager.isInsertMode) {
-            this.dotRepeatStartModeInsertHint = undefined;
             const eol = document.eol === EndOfLine.LF ? "\n" : "\r\n";
             const cursor = activeEditor.selection.active;
             for (const change of contentChanges) {
@@ -583,7 +566,7 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
                     if (this.dotRepeatChange && isChangeSubsequentToChange(change, this.dotRepeatChange)) {
                         this.dotRepeatChange = accumulateDotRepeatChange(change, this.dotRepeatChange);
                     } else {
-                        this.dotRepeatChange = normalizeDotRepeatChange(change, eol, startModeHint);
+                        this.dotRepeatChange = normalizeDotRepeatChange(change, eol);
                     }
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const useCtrlKeysNormalMode = settings.get("useCtrlKeysForNormalMode", true);
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
     const useWsl = isWindows && settings.get("useWSL", false);
-    const revealCursorScrollLine = settings.get("revealCursorScrollLine", false);
     const neovimWidth = settings.get("neovimWidth", 1000);
     const customInit = getNeovimInitPath() ?? "";
     const clean = settings.get("neovimClean", false);
@@ -49,7 +48,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             neovimViewportHeight: 201,
             useWsl: ext.extensionKind === vscode.ExtensionKind.Workspace ? false : useWsl,
             neovimViewportWidth: neovimWidth,
-            revealCursorScrollLine: revealCursorScrollLine,
             logConf: {
                 logPath,
                 outputToConsole,

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -42,7 +42,6 @@ export interface ControllerSettings {
     clean: boolean;
     neovimViewportWidth: number;
     neovimViewportHeight: number;
-    revealCursorScrollLine: boolean;
     logConf: {
         level: "none" | "error" | "warn" | "debug";
         logPath: string;
@@ -183,7 +182,7 @@ export class MainController implements vscode.Disposable {
         const channel = await this.client.channelId;
         await this.client.setVar("vscode_channel", channel);
 
-        this.commandsController = new CommandsController(this.client, this.settings.revealCursorScrollLine);
+        this.commandsController = new CommandsController(this.client);
         this.disposables.push(this.commandsController);
 
         this.modeManager = new ModeManager(this.logger, this.client);

--- a/src/test/suite/vscode-integartion-specific.test.ts
+++ b/src/test/suite/vscode-integartion-specific.test.ts
@@ -100,7 +100,7 @@ describe("VSCode integration specific stuff", () => {
         );
         const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait(1000);
-        await vscode.commands.executeCommand("vscode-neovim.ctrl-f");
+        await sendVSCodeKeys("<C-f>", 0);
         await wait(1500);
 
         let visibleRange = editor.visibleRanges[0];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,10 +54,6 @@ export interface DotRepeatChange {
      */
     text: string;
     /**
-     * Set if it was the first change and started either through o or O
-     */
-    startMode?: "o" | "O";
-    /**
      * Text eol
      */
     eol: string;
@@ -416,16 +412,11 @@ export function getNeovimInitPath(): string | undefined {
     return getSystemSpecificSetting("neovimInitVimPaths", legacySettingInfo);
 }
 
-export function normalizeDotRepeatChange(
-    change: TextDocumentContentChangeEvent,
-    eol: string,
-    startMode?: "o" | "O",
-): DotRepeatChange {
+export function normalizeDotRepeatChange(change: TextDocumentContentChangeEvent, eol: string): DotRepeatChange {
     return {
         rangeLength: change.rangeLength,
         rangeOffset: change.rangeOffset,
         text: change.text,
-        startMode,
         eol,
     };
 }

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -16,19 +16,6 @@ nnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 xnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 
 
-function s:moveCursor(to)
-    " Native VSCode commands don't register jumplist. Fix by registering jumplist in Vim e.g. for subsequent use of <C-o>
-    normal! m'
-    call VSCodeExtensionNotify('move-cursor', a:to)
-endfunction
-
-nnoremap H <Cmd>call <SID>moveCursor('top')<CR>
-xnoremap H <Cmd>call <SID>moveCursor('top')<CR>
-nnoremap M <Cmd>call <SID>moveCursor('middle')<CR>
-xnoremap M <Cmd>call <SID>moveCursor('middle')<CR>
-nnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
-xnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
-
 " Disabled due to scroll problems (the ext binds them directly)
 " nnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
 " xnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -30,16 +30,6 @@ nnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
 xnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
 
 " Disabled due to scroll problems (the ext binds them directly)
-" nnoremap <silent> <expr> <C-d> VSCodeExtensionCall('scroll', 'halfPage', 'down')
-" xnoremap <silent> <expr> <C-d> VSCodeExtensionCall('scroll', 'halfPage', 'down')
-" nnoremap <silent> <expr> <C-u> VSCodeExtensionCall('scroll', 'halfPage', 'up')
-" xnoremap <silent> <expr> <C-u> VSCodeExtensionCall('scroll', 'halfPage', 'up')
-
-" nnoremap <silent> <expr> <C-f> VSCodeExtensionCall('scroll', 'page', 'down')
-" xnoremap <silent> <expr> <C-f> VSCodeExtensionCall('scroll', 'page', 'down')
-" nnoremap <silent> <expr> <C-b> VSCodeExtensionCall('scroll', 'page', 'up')
-" xnoremap <silent> <expr> <C-b> VSCodeExtensionCall('scroll', 'page', 'up')
-
 " nnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
 " xnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
 " nnoremap <silent> <expr> <C-y> VSCodeExtensionNotify('scroll-line', 'up')

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -14,10 +14,3 @@ nnoremap z- <Cmd>call <SID>reveal('bottom', 1)<CR>
 xnoremap z- <Cmd>call <SID>reveal('bottom', 1)<CR>
 nnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 xnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
-
-
-" Disabled due to scroll problems (the ext binds them directly)
-" nnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
-" xnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
-" nnoremap <silent> <expr> <C-y> VSCodeExtensionNotify('scroll-line', 'up')
-" xnoremap <silent> <expr> <C-y> VSCodeExtensionNotify('scroll-line', 'up')


### PR DESCRIPTION
# Problem
Window scroll commands don't move the cursor and instead just scroll the window. This differs from nvim behavior. This is because the extension intercepts the keybindings and applies vscode commands instead. The solution from #528 and #855 simply improves the logic in the plugin to move the cursor. However, this adds complexity and increases the separation from nvim.

# Solution
Remove all custom code for cursor scrolling and allow nvim to handle it itself. However, I have found two problems:

- due to `scrolloff=100`, the scrolling commands behave strangely, and don't reach the top of the screen. c-d scrolls twice as far as it should. However, this can't be avoided according to https://github.com/vscode-neovim/vscode-neovim/blob/52ff62612d3bb9ae2a50ce00b9e068c5d175abda/src/main_controller.ts#L55. @justinmk can you think of another solution that will avoid the enforcing of scrolloff? 
https://github.com/vscode-neovim/vscode-neovim/blob/d11c2ed69ab9ab26b82bb6d892443f8ece1fe940/vim/vscode-options.vim#L16
- C-b behaves very strangely, even with scrolloff=0. Sometimes, it moves *down* a line. It never makes it to the top. 

Fixes #293, #580, #528, and #855.