### PR TITLE
refactor(insert): remove custom insert mode bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,16 +286,16 @@
                 "title": "Neovim: send key"
             },
             {
+                "command": "vscode-neovim.sync-send",
+                "title": "Neovim: Sync pending insert-mode changes and send key"
+            },
+            {
                 "command": "vscode-neovim.compositeEscape1",
                 "title": "Composite escape key 1"
             },
             {
                 "command": "vscode-neovim.compositeEscape2",
                 "title": "Composite escape key 2"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "title": "Escape key"
             },
             {
                 "command": "vscode-neovim.commit-cmdline",
@@ -344,41 +344,38 @@
             {
                 "command": "vscode-neovim:shift-h",
                 "title": "Neovim: shift-h"
-            },
-            {
-                "command": "vscode-neovim.ctrl-a-insert",
-                "title": "Neovim: Ctrl-a-insert"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "title": "Neovim: Paste from register"
             }
         ],
         "keybindings": [
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init"
+                "when": "editorTextFocus && neovim.init",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal",
+                "args": "<Esc>"
             },
             {
                 "command": "vscode-neovim.send",
@@ -824,374 +821,58 @@
                 "args": "<C-/>"
             },
             {
-                "command": "vscode-neovim.ctrl-o-insert",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+o",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+o",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-o>"
             },
             {
-                "command": "deleteAllLeft",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+u",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+u",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-u>"
             },
             {
-                "command": "deleteWordLeft",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+w",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+w",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-w>"
             },
             {
-                "command": "deleteLeft",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+h",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
+                "args": "<C-h>"
             },
             {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+h",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
-                "args": "<C-j>"
-            },
-            {
-                "command": "editor.action.indentLines",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+t",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+t",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-t>"
             },
             {
-                "command": "editor.action.outdentLines",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+d",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+d",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-d>"
             },
             {
-                "command": "editor.action.insertLineAfter",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+j",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+j",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-j>"
             },
             {
-                "command": "vscode-neovim.ctrl-a-insert",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+a",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+a",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-a>"
             },
             {
-                "command": "vscode-neovim.send",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+r",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-r>"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 0",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "0"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 1",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "1"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 2",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "2"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 3",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "3"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 4",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "4"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 5",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "5"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 6",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "6"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 7",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "7"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 8",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "8"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 9",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "9"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+'",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "\""
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+5",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "%"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+3",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "#"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+8",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "*"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+=",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "+"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r /",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "/"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+;",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": ":"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r -",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "-"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r .",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "."
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r =",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "="
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r a",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "a"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r b",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "b"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r c",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "c"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r d",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "d"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r e",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "e"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r f",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "f"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r g",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "g"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r h",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "h"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r i",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "i"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r j",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "j"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r k",
-                "when": "editorTextFocus && neovim.mode == insert &&& !neovim.recording & neovim.ctrlKeysInsert",
-                "args": "k"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r l",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "l"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r m",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "m"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r n",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "n"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r o",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "o"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r p",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "p"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r q",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "q"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r r",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "r"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r s",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "s"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r t",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "t"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r u",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "u"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r v",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "v"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r w",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "w"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r x",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "x"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r y",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "y"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r z",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "z"
             },
             {
                 "command": "cursorHome",

--- a/package.json
+++ b/package.json
@@ -283,15 +283,15 @@
         "commands": [
             {
                 "command": "vscode-neovim.send",
-                "title": "Neovim: send key"
+                "title": "Neovim: send key to neovim, syncing if in insert mode"
+            },
+            {
+                "command": "vscode-neovim.send-blocking",
+                "title": "Neovim: send multiple keys to neovim, used for insert mode paste"
             },
             {
                 "command": "vscode-neovim.escape",
-                "title": "Escape key"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "title": "Neovim: Paste from register"
+                "title": "Neovim send escape key to neovim, or other keys that will exit insert mode"
             },
             {
                 "command": "vscode-neovim.compositeEscape1",
@@ -868,7 +868,7 @@
                 "args": "<C-a>"
             },
             {
-                "command": "vscode-neovim.paste-register",
+                "command": "vscode-neovim.send-blocking",
                 "key": "ctrl+r",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-r>"

--- a/package.json
+++ b/package.json
@@ -286,10 +286,6 @@
                 "title": "Neovim: send key"
             },
             {
-                "command": "vscode-neovim.sync-send",
-                "title": "Neovim: Sync pending insert-mode changes and send key"
-            },
-            {
                 "command": "vscode-neovim.escape",
                 "title": "Escape key"
             },
@@ -830,43 +826,43 @@
                 "args": "<C-o>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+u",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-u>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+w",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-w>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+h",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-h>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+t",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-t>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+d",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-d>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+j",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-j>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+a",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-a>"

--- a/package.json
+++ b/package.json
@@ -290,6 +290,14 @@
                 "title": "Neovim: Sync pending insert-mode changes and send key"
             },
             {
+                "command": "vscode-neovim.escape",
+                "title": "Escape key"
+            },
+            {
+                "command": "vscode-neovim.paste-register",
+                "title": "Neovim: Paste from register"
+            },
+            {
                 "command": "vscode-neovim.compositeEscape1",
                 "title": "Composite escape key 1"
             },
@@ -348,34 +356,29 @@
         ],
         "keybindings": [
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
             },
             {
                 "command": "vscode-neovim.send",
@@ -821,7 +824,7 @@
                 "args": "<C-/>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+o",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-o>"
@@ -869,7 +872,7 @@
                 "args": "<C-a>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.paste-register",
                 "key": "ctrl+r",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-r>"

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -13,8 +13,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     public constructor(client: NeovimClient, revealCursorScrollLine: boolean) {
         this.client = client;
         this.revealCursorScrollLine = revealCursorScrollLine;
-
-        this.disposables.push(vscode.commands.registerCommand("vscode-neovim.send", (key) => this.sendToVim(key)));
         this.disposables.push(
             vscode.commands.registerCommand("vscode-neovim.ctrl-f", () => this.scrollPage("page", "down")),
         );
@@ -70,10 +68,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
             }
         }
     }
-
-    private sendToVim = (keys: string): void => {
-        this.client.input(keys);
-    };
 
     /// SCROLL COMMANDS ///
     private scrollPage = (by: "page" | "halfPage", to: "up" | "down"): void => {

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -14,11 +14,7 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
         this.client = client;
         this.revealCursorScrollLine = revealCursorScrollLine;
 
-        this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-a-insert", this.ctrlAInsert));
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.send", (key) => this.sendToVim(key)));
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.paste-register", (reg) => this.pasteFromRegister(reg)),
-        );
         this.disposables.push(
             vscode.commands.registerCommand("vscode-neovim.ctrl-f", () => this.scrollPage("page", "down")),
         );
@@ -78,32 +74,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     private sendToVim = (keys: string): void => {
         this.client.input(keys);
     };
-
-    private ctrlAInsert = async (): Promise<void> => {
-        // Insert previously inserted text from the insert mode
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return;
-        }
-        const lines: string[] = await this.client.callFunction("VSCodeGetLastInsertText");
-        if (!lines.length) {
-            return;
-        }
-        await editor.edit((b) => b.insert(editor.selection.active, lines.join("\n")));
-    };
-
-    private async pasteFromRegister(registerName: string): Promise<void> {
-        // copy content from register in insert mode
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return;
-        }
-        const content = await this.client.callFunction("VSCodeGetRegister", [registerName]);
-        if (content === "") {
-            return;
-        }
-        await editor.edit((b) => b.insert(editor.selection.active, content));
-    }
 
     /// SCROLL COMMANDS ///
     private scrollPage = (by: "page" | "halfPage", to: "up" | "down"): void => {

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -232,7 +232,7 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
         await callAtomic(this.client, requests, this.logger, LOG_PREFIX);
     }
 
-    public async syncDotRepatWithNeovim(): Promise<void> {
+    public async syncDotRepeatWithNeovim(): Promise<void> {
         // dot-repeat executes last change across all buffers. So we'll create a temporary buffer & window,
         // replay last changes here to trick neovim and destroy it after
         if (!this.dotRepeatChange) {

--- a/src/test/suite/composite-escape.test.ts
+++ b/src/test/suite/composite-escape.test.ts
@@ -65,6 +65,7 @@ describe("Composite escape key", () => {
             },
             client,
         );
+        await sendVSCodeKeys("i");
         await vscode.commands.executeCommand("vscode-neovim.compositeEscape1", "j");
         await wait(50);
         await vscode.commands.executeCommand("vscode-neovim.compositeEscape1", "j");

--- a/src/test/suite/insert-mode-additions.test.ts
+++ b/src/test/suite/insert-mode-additions.test.ts
@@ -35,7 +35,7 @@ describe("Simulated insert keys", () => {
         await setCursor(0, 2);
         await sendVSCodeKeys("i123");
         await wait();
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-o>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-o>");
         await wait();
         await sendVSCodeKeys("h");
         await wait();
@@ -61,7 +61,7 @@ describe("Simulated insert keys", () => {
         await sendVSCodeSpecialKey("cursorLeft");
         await sendVSCodeSpecialKey("cursorLeft");
         await wait();
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-o>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-o>");
         await wait();
         await sendVSCodeKeys("x");
         await wait();
@@ -85,7 +85,7 @@ describe("Simulated insert keys", () => {
         await sendEscapeKey();
 
         await sendVSCodeKeys("o");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-a>");
         await wait();
 
         await sendEscapeKey();
@@ -148,7 +148,7 @@ describe("Simulated insert keys", () => {
         await wait();
 
         await sendVSCodeKeys("wi");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-w>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-w>");
         await wait();
 
         await sendEscapeKey();
@@ -161,7 +161,7 @@ describe("Simulated insert keys", () => {
         );
 
         await sendVSCodeKeys("ea");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-h>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-h>");
         await wait();
 
         await sendEscapeKey();
@@ -181,7 +181,7 @@ describe("Simulated insert keys", () => {
 
         await sendVSCodeKeys("wi");
         await sendVSCodeKeys("blah blah");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-u>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-u>");
         await wait();
 
         await sendEscapeKey();

--- a/src/test/suite/insert-mode-additions.test.ts
+++ b/src/test/suite/insert-mode-additions.test.ts
@@ -85,7 +85,7 @@ describe("Simulated insert keys", () => {
         await sendEscapeKey();
 
         await sendVSCodeKeys("o");
-        await vscode.commands.executeCommand("vscode-neovim.paste-register", "<C-a>");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
         await wait();
 
         await sendEscapeKey();
@@ -111,10 +111,32 @@ describe("Simulated insert keys", () => {
         await wait();
 
         await sendEscapeKey();
+        await sendVSCodeKeys("k");
         await assertContent(
             {
                 content: ["blah blah", "blah blah", ""],
-                cursor: [2, 0],
+                cursor: [1, 0],
+            },
+            client,
+        );
+    });
+
+    it("Ctrl-r <esc>", async () => {
+        const doc = await vscode.workspace.openTextDocument({ content: "blah blah" });
+        await vscode.window.showTextDocument(doc);
+        await wait();
+
+        await sendVSCodeKeys("I");
+        await vscode.commands.executeCommand("vscode-neovim.paste-register", "<C-r>");
+        await sendEscapeKey();
+        await sendVSCodeKeys("l");
+        await wait();
+        await sendEscapeKey();
+
+        await assertContent(
+            {
+                content: ["lblah blah"],
+                cursor: [0, 0],
             },
             client,
         );

--- a/src/test/suite/insert-mode-additions.test.ts
+++ b/src/test/suite/insert-mode-additions.test.ts
@@ -106,7 +106,7 @@ describe("Simulated insert keys", () => {
         await sendVSCodeKeys('"+yy');
         await sendVSCodeKeys("o", 500);
 
-        await vscode.commands.executeCommand("vscode-neovim.paste-register", "<C-r>");
+        await vscode.commands.executeCommand("vscode-neovim.send-blocking", "<C-r>");
         await sendVSCodeKeys("+");
         await wait();
 
@@ -127,7 +127,7 @@ describe("Simulated insert keys", () => {
         await wait();
 
         await sendVSCodeKeys("I");
-        await vscode.commands.executeCommand("vscode-neovim.paste-register", "<C-r>");
+        await vscode.commands.executeCommand("vscode-neovim.send-blocking", "<C-r>");
         await sendEscapeKey();
         await sendVSCodeKeys("l");
         await wait();

--- a/src/test/suite/insert-mode-additions.test.ts
+++ b/src/test/suite/insert-mode-additions.test.ts
@@ -141,4 +141,56 @@ describe("Simulated insert keys", () => {
             client,
         );
     });
+
+    it("Ctrl-w/Ctrl-h", async () => {
+        const doc = await vscode.workspace.openTextDocument({ content: "blah blah" });
+        await vscode.window.showTextDocument(doc);
+        await wait();
+
+        await sendVSCodeKeys("wi");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-w>");
+        await wait();
+
+        await sendEscapeKey();
+        await assertContent(
+            {
+                content: ["blah"],
+                cursor: [0, 0],
+            },
+            client,
+        );
+
+        await sendVSCodeKeys("ea");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-h>");
+        await wait();
+
+        await sendEscapeKey();
+        await assertContent(
+            {
+                content: ["bla"],
+                cursor: [0, 2],
+            },
+            client,
+        );
+    });
+
+    it("Ctrl-u", async () => {
+        const doc = await vscode.workspace.openTextDocument({ content: "blah blah" });
+        await vscode.window.showTextDocument(doc);
+        await wait();
+
+        await sendVSCodeKeys("wi");
+        await sendVSCodeKeys("blah blah");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-u>");
+        await wait();
+
+        await sendEscapeKey();
+        await assertContent(
+            {
+                content: ["blah blah"],
+                cursor: [0, 4],
+            },
+            client,
+        );
+    });
 });

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -446,7 +446,7 @@ describe("Insert mode and buffer syncronization", () => {
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait();
 
-        await sendVSCodeKeys("ea");
+        await sendVSCodeKeys("0ea");
         await sendVSCodeKeys("aaa");
 
         await Promise.all([sendEscapeKey(1000), sendVSCodeKeys("$")]);

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -494,7 +494,7 @@ describe("Insert mode and buffer syncronization", () => {
         await sendVSCodeKeys("a3");
         await sendEscapeKey(1000);
         await sendVSCodeKeys("a");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-a>");
         await wait();
 
         await sendEscapeKey(1000);
@@ -515,7 +515,7 @@ describe("Insert mode and buffer syncronization", () => {
         await sendVSCodeKeys("ea blah2");
         await sendEscapeKey(1000);
         await sendVSCodeKeys("A");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-a>");
         await wait();
 
         await sendEscapeKey(1000);
@@ -536,7 +536,7 @@ describe("Insert mode and buffer syncronization", () => {
         await sendVSCodeKeys("wiblah2\n");
         await sendEscapeKey(1000);
         await sendVSCodeKeys("A");
-        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-a>");
         await wait();
 
         await sendEscapeKey(1000);

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -14,7 +14,6 @@ import {
     copyVSCodeSelection,
     pasteVSCode,
     sendVSCodeKeysAtomic,
-    setCursor,
 } from "../utils";
 
 describe("Insert mode and buffer syncronization", () => {
@@ -495,7 +494,7 @@ describe("Insert mode and buffer syncronization", () => {
         await sendVSCodeKeys("a3");
         await sendEscapeKey(1000);
         await sendVSCodeKeys("a");
-        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
         await wait();
 
         await sendEscapeKey(1000);
@@ -516,7 +515,7 @@ describe("Insert mode and buffer syncronization", () => {
         await sendVSCodeKeys("ea blah2");
         await sendEscapeKey(1000);
         await sendVSCodeKeys("A");
-        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
         await wait();
 
         await sendEscapeKey(1000);
@@ -537,7 +536,7 @@ describe("Insert mode and buffer syncronization", () => {
         await sendVSCodeKeys("wiblah2\n");
         await sendEscapeKey(1000);
         await sendVSCodeKeys("A");
-        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert");
+        await vscode.commands.executeCommand("vscode-neovim.sync-send", "<C-a>");
         await wait();
 
         await sendEscapeKey(1000);
@@ -545,55 +544,6 @@ describe("Insert mode and buffer syncronization", () => {
         await assertContent(
             {
                 content: ["blah1 blah2", "blah3blah2", ""],
-            },
-            client,
-        );
-    });
-
-    it("Handles nvim cursor movement commands after sending ctrl+o key", async () => {
-        const doc = await vscode.workspace.openTextDocument({
-            content: "test",
-        });
-        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-        await wait();
-        await setCursor(0, 2);
-        await sendVSCodeKeys("i123");
-        await wait();
-        await vscode.commands.executeCommand("vscode-neovim.ctrl-o-insert");
-        await wait();
-        await sendVSCodeKeys("h");
-        await wait();
-        await assertContent(
-            {
-                mode: "i",
-                cursor: [0, 4],
-                content: ["te123st"],
-            },
-            client,
-        );
-    });
-
-    it("Handles nvim editing commands after sending ctrl+o key", async () => {
-        const doc = await vscode.workspace.openTextDocument({
-            content: "test",
-        });
-        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-        await wait();
-        await setCursor(0, 2);
-        await sendVSCodeKeys("i123");
-        await wait();
-        await sendVSCodeSpecialKey("cursorLeft");
-        await sendVSCodeSpecialKey("cursorLeft");
-        await wait();
-        await vscode.commands.executeCommand("vscode-neovim.ctrl-o-insert");
-        await wait();
-        await sendVSCodeKeys("x");
-        await wait();
-        await assertContent(
-            {
-                mode: "i",
-                cursor: [0, 3],
-                content: ["te13st"],
             },
             client,
         );

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -41,10 +41,12 @@ export class TypingManager implements Disposable {
         private modeManager: ModeManager,
         private changeManager: DocumentChangeManager,
     ) {
-        this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
+        this.registerType();
         this.disposables.push(
             commands.registerCommand("vscode-neovim.sync-send", (key) => this.onSyncSendCommand(key)),
         );
+        this.disposables.push(commands.registerCommand("vscode-neovim.escape", this.onEscapeKeyCommand));
+        this.disposables.push(commands.registerCommand("vscode-neovim.paste-register", this.onPasteRegisterCommand));
         this.disposables.push(
             commands.registerCommand("vscode-neovim.compositeEscape1", (key: string) =>
                 this.handleCompositeEscapeFirstKey(key),
@@ -63,6 +65,21 @@ export class TypingManager implements Disposable {
         this.disposables.forEach((d) => d.dispose());
     }
 
+    public registerType(): void {
+        if (!this.typeHandlerDisposable) {
+            this.logger.debug(`${LOG_PREFIX}: Enabling type handler`);
+            this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
+        }
+    }
+
+    public disposeType(): void {
+        if (this.typeHandlerDisposable) {
+            this.logger.debug(`${LOG_PREFIX}: Disabling type handler`);
+            this.typeHandlerDisposable.dispose();
+            this.typeHandlerDisposable = undefined;
+        }
+    }
+
     private onModeChange = (): void => {
         if (this.modeManager.isInsertMode && this.typeHandlerDisposable && !this.modeManager.isRecordingInInsertMode) {
             this.pendingKeysAfterEnter = "";
@@ -74,11 +91,7 @@ export class TypingManager implements Disposable {
                 );
                 this.changeManager.getDocumentChangeCompletionLock(editor.document)?.then(() => {
                     this.isEnteringInsertMode = false;
-                    if (this.typeHandlerDisposable && this.modeManager.isInsertMode) {
-                        this.logger.debug(`${LOG_PREFIX}: Waiting done, disposing type handler`);
-                        this.typeHandlerDisposable.dispose();
-                        this.typeHandlerDisposable = undefined;
-                    }
+                    if (this.modeManager.isInsertMode) this.disposeType();
                     if (this.pendingKeysAfterEnter) {
                         commands.executeCommand(this.modeManager.isInsertMode ? "default:type" : "type", {
                             text: this.pendingKeysAfterEnter,
@@ -87,45 +100,39 @@ export class TypingManager implements Disposable {
                     }
                 });
             } else {
-                this.logger.debug(`${LOG_PREFIX}: Disposing type handler`);
-                this.typeHandlerDisposable.dispose();
-                this.typeHandlerDisposable = undefined;
+                this.disposeType();
             }
         } else if (!this.modeManager.isInsertMode) {
             this.isEnteringInsertMode = false;
             this.isExitingInsertMode = false;
-            if (!this.typeHandlerDisposable) {
-                this.logger.debug(`${LOG_PREFIX}: Enabling type handler`);
-                this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
-            }
+            this.registerType();
         }
     };
 
-    private onVSCodeType = (_editor: TextEditor, edit: TextEditorEdit, type: { text: string }): void => {
-        if (!this.modeManager.isInsertMode || this.modeManager.isRecordingInInsertMode || this.isEnteringInsertMode) {
-            if (this.isEnteringInsertMode) {
-                this.pendingKeysAfterEnter += type.text;
-            } else {
-                this.client.input(normalizeInputString(type.text, !this.modeManager.isRecordingInInsertMode));
-            }
+    private onVSCodeType = async (_editor: TextEditor, edit: TextEditorEdit, type: { text: string }): Promise<void> => {
+        if (this.isEnteringInsertMode) {
+            this.pendingKeysAfterEnter += type.text;
         } else if (this.isExitingInsertMode) {
             this.pendingKeysAfterExit += type.text;
+        } else if (this.modeManager.isInsertMode && !this.modeManager.isRecordingInInsertMode) {
+            const mode = await this.client.mode;
+            if (mode.blocking) {
+                this.client.input(normalizeInputString(type.text, !this.modeManager.isRecordingInInsertMode));
+            } else {
+                this.disposeType();
+                commands.executeCommand("default:type", { text: type.text });
+            }
         } else {
-            commands.executeCommand("default:type", { text: type.text });
+            this.client.input(normalizeInputString(type.text, !this.modeManager.isRecordingInInsertMode));
         }
     };
 
-    private onSyncSendCommand = async (key: string): Promise<void> => {
+    private onSyncSendCommand = async (key: string, isExitingInsertMode = false): Promise<void> => {
         this.logger.debug(`${LOG_PREFIX}: Sync and send for: ${key}`);
-        if (this.modeManager.isInsertMode) {
+        const mode = await this.client.mode;
+        if (this.modeManager.isInsertMode && !mode.blocking) {
+            if (isExitingInsertMode) this.isExitingInsertMode = true;
             this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
-            this.isExitingInsertMode = true;
-            // rebind early to store fast pressed keys which may happen between sending changes to neovim and exiting insert mode
-            // see https://github.com/asvetliakov/vscode-neovim/issues/324
-            if (!this.typeHandlerDisposable) {
-                this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
-            }
-            // this.leaveMultipleCursorsForVisualMode = false;
             await this.changeManager.syncDocumentsWithNeovim();
             await this.changeManager.syncDotRepatWithNeovim();
         }
@@ -135,13 +142,25 @@ export class TypingManager implements Disposable {
         await this.client.input(`${key}${keys}`);
     };
 
+    private onEscapeKeyCommand = async (key = "<Esc>"): Promise<void> => {
+        // rebind early to store fast pressed keys which may happen between sending changes to neovim and exiting insert mode
+        // see https://github.com/asvetliakov/vscode-neovim/issues/324
+        this.registerType();
+        await this.onSyncSendCommand(key, true);
+    };
+
+    private onPasteRegisterCommand = async (): Promise<void> => {
+        this.registerType();
+        await this.onSyncSendCommand("<C-r>");
+    };
+
     private handleCompositeEscapeFirstKey = async (key: string): Promise<void> => {
         const now = new Date().getTime();
         if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
             // jj
             this.compositeEscapeFirstPressTimestamp = undefined;
             await commands.executeCommand("deleteLeft");
-            this.onSyncSendCommand("<esc>");
+            await this.onEscapeKeyCommand();
         } else {
             this.compositeEscapeFirstPressTimestamp = now;
             // insert character
@@ -154,7 +173,7 @@ export class TypingManager implements Disposable {
         if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
             this.compositeEscapeFirstPressTimestamp = undefined;
             await commands.executeCommand("deleteLeft");
-            this.onSyncSendCommand("<esc>");
+            await this.onEscapeKeyCommand();
         } else {
             await commands.executeCommand("default:type", { text: key });
         }

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -129,7 +129,7 @@ export class TypingManager implements Disposable {
         if (this.modeManager.isInsertMode && !(await this.client.mode).blocking) {
             this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
             await this.changeManager.syncDocumentsWithNeovim();
-            await this.changeManager.syncDotRepatWithNeovim();
+            if (this.isExitingInsertMode) await this.changeManager.syncDotRepeatWithNeovim();
             const keys = normalizeInputString(this.pendingKeysAfterExit);
             this.logger.debug(`${LOG_PREFIX}: Pending keys sent with ${key}: ${keys}`);
             this.pendingKeysAfterExit = "";

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -129,8 +129,7 @@ export class TypingManager implements Disposable {
 
     private onSyncSendCommand = async (key: string): Promise<void> => {
         this.logger.debug(`${LOG_PREFIX}: Sync and send for: ${key}`);
-        const mode = await this.client.mode;
-        if (this.modeManager.isInsertMode && !mode.blocking) {
+        if (this.modeManager.isInsertMode && !(await this.client.mode).blocking) {
             this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
             await this.changeManager.syncDocumentsWithNeovim();
             await this.changeManager.syncDotRepatWithNeovim();

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -113,8 +113,7 @@ export class TypingManager implements Disposable {
         } else if (this.isExitingInsertMode) {
             this.pendingKeysAfterExit += type.text;
         } else if (this.modeManager.isInsertMode && !this.modeManager.isRecordingInInsertMode) {
-            const mode = await this.client.mode;
-            if (mode.blocking) {
+            if ((await this.client.mode).blocking) {
                 this.client.input(normalizeInputString(type.text, !this.modeManager.isRecordingInInsertMode));
             } else {
                 this.disposeType();
@@ -156,14 +155,12 @@ export class TypingManager implements Disposable {
     private handleCompositeEscapeFirstKey = async (key: string): Promise<void> => {
         const now = new Date().getTime();
         if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
-            // jj
             this.compositeEscapeFirstPressTimestamp = undefined;
             await commands.executeCommand("deleteLeft");
             await this.onEscapeKeyCommand();
         } else {
             this.compositeEscapeFirstPressTimestamp = now;
-            // insert character
-            await commands.executeCommand("default:type", { text: key });
+            await commands.executeCommand("type", { text: key });
         }
     };
 
@@ -174,7 +171,7 @@ export class TypingManager implements Disposable {
             await commands.executeCommand("deleteLeft");
             await this.onEscapeKeyCommand();
         } else {
-            await commands.executeCommand("default:type", { text: key });
+            await commands.executeCommand("type", { text: key });
         }
     };
 }

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -129,7 +129,7 @@ export class TypingManager implements Disposable {
         if (this.modeManager.isInsertMode && !(await this.client.mode).blocking) {
             this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
             await this.changeManager.syncDocumentsWithNeovim();
-            if (this.isExitingInsertMode) await this.changeManager.syncDotRepeatWithNeovim();
+            await this.changeManager.syncDotRepeatWithNeovim();
             const keys = normalizeInputString(this.pendingKeysAfterExit);
             this.logger.debug(`${LOG_PREFIX}: Pending keys sent with ${key}: ${keys}`);
             this.pendingKeysAfterExit = "";

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -111,17 +111,6 @@ function! VSCodeSetTextDecorations(hlName, rowsCols)
     call VSCodeExtensionNotify('text-decorations', a:hlName, a:rowsCols)
 endfunction
 
-" Used for ctrl-a insert keybinding
-function! VSCodeGetLastInsertText()
-    let lines = split(getreg("."), "^@")
-    return lines
-endfunction
-
-" Used for ctrl-r [reg] insert keybindings
-function! VSCodeGetRegister(reg)
-    return getreg(a:reg)
-endfunction
-
 " This is called by extension when created new buffer
 function! s:onBufEnter(name, id)
     if exists('b:vscode_temp') && b:vscode_temp


### PR DESCRIPTION
# Problem
Currently, two sets of insert mode bindings are used:

1. custom vscode bindings:
commands like `C-w`, `C-r`, `<C-o>` are connected to vscode commands. These differ from nvim functionality and add to code bloat.
2. macro recording passthrough bindings:
when a macro is being recorded, the plugin directly sends the commands to nvim. This then applies the actions.

The problem with only using the nvim bindings is that when you type in insert mode, and then try to use the nvim bindings, nvim is not aware of the text you just typed, causing issues.

# Solution
Make a generic "sync-send" command for all insert-mode bindings that syncs changes and then allows nvim to handle the commands. This seems to work well for C-w and others. This also lets the ext handle C-r and others. 

# Issues
~~The code in typing_manager was not designed for this use and should be refactored. This PR is quite broken and using C-r freezes input. However, this shows promise.~~

C-r now works properly and everything else seems to work well!

Fixes #652 and #706