### PR TITLE
combine CompositeEscape funcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,11 +282,7 @@
             },
             {
                 "command": "vscode-neovim.compositeEscape1",
-                "title": "Composite escape key 1"
-            },
-            {
-                "command": "vscode-neovim.compositeEscape2",
-                "title": "Composite escape key 2"
+                "title": "Composite escape"
             },
             {
                 "command": "vscode-neovim.escape",

--- a/src/test/suite/composite-escape.test.ts
+++ b/src/test/suite/composite-escape.test.ts
@@ -17,7 +17,7 @@ describe("Composite escape key", () => {
     before(async () => {
         client = await attachTestNvimClient();
         doc = await vscode.workspace.openTextDocument({
-            content: "",
+            content: "abc",
         });
         await vscode.window.showTextDocument(doc);
         await wait(1000);
@@ -27,7 +27,10 @@ describe("Composite escape key", () => {
         await closeNvimClient(client);
     });
 
-    beforeEach(async () => await sendVSCodeKeys("S"));
+    beforeEach(async () => {
+        // reset content to `abc` and remain in insert mode
+        await sendVSCodeKeys("Sabc");
+    });
 
     it("escapes on jk and removes 'j'", async () => {
         await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
@@ -36,7 +39,7 @@ describe("Composite escape key", () => {
         await wait(69);
         await assertContent(
             {
-                content: [""],
+                content: ["abc"],
                 mode: "n",
             },
             client,
@@ -50,7 +53,7 @@ describe("Composite escape key", () => {
         await wait(50);
         await assertContent(
             {
-                content: [""],
+                content: ["abc"],
                 mode: "n",
             },
             client,
@@ -72,7 +75,7 @@ describe("Composite escape key", () => {
         await sendEscapeKey();
         await assertContent(
             {
-                content: ["jj"],
+                content: ["abcjj"],
             },
             client,
         );
@@ -92,7 +95,7 @@ describe("Composite escape key", () => {
         await sendEscapeKey();
         await assertContent(
             {
-                content: ["jk"],
+                content: ["abcjk"],
             },
             client,
         );
@@ -105,7 +108,7 @@ describe("Composite escape key", () => {
         await wait(50);
         await assertContent(
             {
-                content: [""],
+                content: ["abc"],
                 mode: "n",
             },
             client,

--- a/src/test/suite/composite-escape.test.ts
+++ b/src/test/suite/composite-escape.test.ts
@@ -27,12 +27,12 @@ describe("Composite escape key", () => {
         await closeNvimClient(client);
     });
 
-    beforeEach(async () => await sendVSCodeKeys("S"))
+    beforeEach(async () => await sendVSCodeKeys("S"));
 
     it("escapes on jk and removes 'j'", async () => {
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
         await wait(50);
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'k'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "k" });
         await wait(69);
         await assertContent(
             {
@@ -44,9 +44,9 @@ describe("Composite escape key", () => {
     });
 
     it("escapes on jj if escOnDoubleTap=true and removes 'j'", async () => {
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
         await wait(50);
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j', escOnDoubleTap: true});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j", escOnDoubleTap: true });
         await wait(50);
         await assertContent(
             {
@@ -58,9 +58,9 @@ describe("Composite escape key", () => {
     });
 
     it("does not escape on jj if escOnDoubleTap unset (defaults to false) and does not delete 'jj'", async () => {
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
         await wait(50);
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
         await wait(50);
         await assertContent(
             {
@@ -79,9 +79,9 @@ describe("Composite escape key", () => {
     });
 
     it("handles default timeoutLen", async () => {
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
         await wait(250);
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'k'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "k" });
         await wait(50);
         await assertContent(
             {
@@ -99,10 +99,10 @@ describe("Composite escape key", () => {
     });
 
     it("handles custom timeoutLen", async () => {
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'j'});
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "j" });
         await wait(250);
-        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", {key: 'k', timeoutLen: 300});
-        await wait(50)
+        await vscode.commands.executeCommand("vscode-neovim.compositeEscape", { key: "k", timeoutLen: 300 });
+        await wait(50);
         await assertContent(
             {
                 content: [""],

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -9,9 +9,9 @@ import { normalizeInputString } from "./utils";
 const LOG_PREFIX = "TypingManager";
 
 interface CompositeEscapeArgs {
-    key: string,
-    timeoutLen?: number,
-    escOnDoubleTap?: boolean,
+    key: string;
+    timeoutLen?: number;
+    escOnDoubleTap?: boolean;
 }
 
 export class TypingManager implements Disposable {
@@ -44,7 +44,6 @@ export class TypingManager implements Disposable {
      * j or k, the first composite escape key that was pressed.
      */
     private compositeEscapeFirstPressKey?: string;
-    private orange?: any;
 
     public constructor(
         private logger: Logger,
@@ -52,15 +51,12 @@ export class TypingManager implements Disposable {
         private modeManager: ModeManager,
         private changeManager: DocumentChangeManager,
     ) {
-        //Create output channel
-        this.orange = window.createOutputChannel("Apple2");
-
         this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
         this.disposables.push(commands.registerCommand("vscode-neovim.ctrl-o-insert", this.onInsertCtrlOCommand));
         this.disposables.push(commands.registerCommand("vscode-neovim.escape", this.onEscapeKeyCommand));
         this.disposables.push(
             commands.registerCommand("vscode-neovim.compositeEscape", (x: CompositeEscapeArgs) => {
-                this.handleCompositeEscape(x.key, x.timeoutLen, x.escOnDoubleTap)
+                this.handleCompositeEscape(x.key, x.timeoutLen, x.escOnDoubleTap);
             }),
         );
         this.modeManager.onModeChange(this.onModeChange);
@@ -169,13 +165,11 @@ export class TypingManager implements Disposable {
         await this.client.input(`<c-o>${keys}`);
     };
 
-    private handleCompositeEscape = async (key: string, timeoutLen: number=200, escOnDoubleTap=false): Promise<void> => {
+    private handleCompositeEscape = async (key: string, timeoutLen = 200, escOnDoubleTap = false): Promise<void> => {
         const now = new Date().getTime();
-        if (this.compositeEscapeFirstPressKey &&
-            (
-                escOnDoubleTap ||
-                this.compositeEscapeFirstPressKey !== key
-            ) &&
+        if (
+            this.compositeEscapeFirstPressKey &&
+            (escOnDoubleTap || this.compositeEscapeFirstPressKey !== key) &&
             this.compositeEscapeFirstPressTimestamp &&
             now - this.compositeEscapeFirstPressTimestamp <= timeoutLen
         ) {


### PR DESCRIPTION
Allows any chord of any two characters to be mapped to `Esc`

Keymap args:
* `key` (required): specify which key is added to the list of keys that can be combined allows any chord of any two characters to be mapped to `Esc`.
* `timeoutLen` (optional, default `200`): specify timeout length in miliseconds. Specifically, it's the longest time between when the last key mapped to compositeEscape and the given key were pressed that will still trigger a remap to `Esc`.
* `escOnDoubleTap` (optional, default `false`): if `true`, specified key will trigger `Esc` if pressed 2x within `timeoutLen`.

### keybindings.json

```
    {
        "command": "vscode-neovim.compositeEscape",
        "key": "j",
        "when": "neovim.mode == insert && editorTextFocus",
        "args": {
            "key": "j",
            "timeoutLen": 300,
            "escOnDoubleTap": true
    },
    {
        "command": "vscode-neovim.compositeEscape",
        "key": "k",
        "when": "neovim.mode == insert && editorTextFocus",
        "args": "k"
    },
```

ISSUES:
* If you have, for example, j and k set as above, then typing `jk` in less than 300ms will trigger `Esc` but so will typing `jack`, and then `jac` would remain on screen. This is no different than the existing implementation and addressed reasonably by the addition of the `timeoutLen` arg.
* This implementation doesn't allow you to esc on `jk` and not `kj` also; if there's a need for this, lmk.