### PR TITLE
feat(messages): show Output less frequently

### DIFF
--- a/src/multiline_messages_manager.ts
+++ b/src/multiline_messages_manager.ts
@@ -40,7 +40,7 @@ export class MutlilineMessagesManager implements Disposable, NeovimRedrawProcess
                     }
                     // remove empty last line (since we always put \n at the end)
                     const lines = str.split("\n").slice(1);
-                    if (lines.length > 1) {
+                    if (lines.length > 2) {
                         this.channel.show(true);
                     }
                     this.channel.append(str);


### PR DESCRIPTION
Problem:
Nvim can produce multiline messages for common actions like search.

Solution:
Don't focus the Output view for fewer than 3 lines.

ref #881
ref https://github.com/vscode-neovim/vscode-neovim/pull/881#issuecomment-1124323231