### PR TITLE
only cd to cwd if not over ssh-remote

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -119,9 +119,10 @@ export class MainController implements vscode.Disposable {
             // load support script before user config (to allow to rebind keybindings/commands)
             "--cmd",
             `source ${neovimSupportScriptPath}`,
-            "-c",
-            `cd ${cwd}`,
         ];
+        if (vscode.env.remoteName != "ssh-remote") {
+            args.push("-c", `cd ${cwd}`);
+        }
         if (settings.useWsl) {
             args.unshift(settings.neovimPath);
         }


### PR DESCRIPTION
I was getting errors when opening folders over ssh-remote using this extension eg:

```
Error detected while processing command line:
E344: Cannot find directory "/home/edwardr/git/dotfiles" in cdpath
E472: Command failed
```

This is because the `-c cd ${cwd}` is trying to cd to a folder on my local machine but the path is from my remote machine, so it doesn't exist. This PR adds a check to prevent this from happening. 