### PR TITLE
experimental: always listen to type commands in insert mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,16 +281,16 @@
                 "title": "Neovim: send key"
             },
             {
+                "command": "vscode-neovim.sync-send",
+                "title": "Neovim: Sync pending insert-mode changes and send key"
+            },
+            {
                 "command": "vscode-neovim.compositeEscape1",
                 "title": "Composite escape key 1"
             },
             {
                 "command": "vscode-neovim.compositeEscape2",
                 "title": "Composite escape key 2"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "title": "Escape key"
             },
             {
                 "command": "vscode-neovim.commit-cmdline",
@@ -339,41 +339,38 @@
             {
                 "command": "vscode-neovim:shift-h",
                 "title": "Neovim: shift-h"
-            },
-            {
-                "command": "vscode-neovim.ctrl-a-insert",
-                "title": "Neovim: Ctrl-a-insert"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "title": "Neovim: Paste from register"
             }
         ],
         "keybindings": [
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init"
+                "when": "editorTextFocus && neovim.init",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
+                "args": "<Esc>"
             },
             {
-                "command": "vscode-neovim.escape",
+                "command": "vscode-neovim.sync-send",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal",
+                "args": "<Esc>"
             },
             {
                 "command": "vscode-neovim.send",
@@ -819,374 +816,58 @@
                 "args": "<C-/>"
             },
             {
-                "command": "vscode-neovim.ctrl-o-insert",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+o",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+o",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-o>"
             },
             {
-                "command": "deleteAllLeft",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+u",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+u",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-u>"
             },
             {
-                "command": "deleteWordLeft",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+w",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+w",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-w>"
             },
             {
-                "command": "deleteLeft",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+h",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
+                "args": "<C-h>"
             },
             {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+h",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
-                "args": "<C-j>"
-            },
-            {
-                "command": "editor.action.indentLines",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+t",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+t",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-t>"
             },
             {
-                "command": "editor.action.outdentLines",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+d",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+d",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-d>"
             },
             {
-                "command": "editor.action.insertLineAfter",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+j",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+j",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-j>"
             },
             {
-                "command": "vscode-neovim.ctrl-a-insert",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+a",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+a",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-a>"
             },
             {
-                "command": "vscode-neovim.send",
+                "command": "vscode-neovim.sync-send",
                 "key": "ctrl+r",
-                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-r>"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 0",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "0"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 1",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "1"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 2",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "2"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 3",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "3"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 4",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "4"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 5",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "5"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 6",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "6"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 7",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "7"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 8",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "8"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r 9",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "9"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+'",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "\""
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+5",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "%"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+3",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "#"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+8",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "*"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+=",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "+"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r /",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "/"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r shift+;",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": ":"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r -",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "-"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r .",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "."
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r =",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "="
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r a",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "a"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r b",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "b"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r c",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "c"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r d",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "d"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r e",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "e"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r f",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "f"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r g",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "g"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r h",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "h"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r i",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "i"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r j",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "j"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r k",
-                "when": "editorTextFocus && neovim.mode == insert &&& !neovim.recording & neovim.ctrlKeysInsert",
-                "args": "k"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r l",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "l"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r m",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "m"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r n",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "n"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r o",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "o"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r p",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "p"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r q",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "q"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r r",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "r"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r s",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "s"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r t",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "t"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r u",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "u"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r v",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "v"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r w",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "w"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r x",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "x"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r y",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "y"
-            },
-            {
-                "command": "vscode-neovim.paste-register",
-                "key": "ctrl+r z",
-                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
-                "args": "z"
             },
             {
                 "command": "cursorHome",

--- a/package.json
+++ b/package.json
@@ -285,6 +285,10 @@
                 "title": "Neovim: Sync pending insert-mode changes and send key"
             },
             {
+                "command": "vscode-neovim.escape",
+                "title": "Escape key"
+            },
+            {
                 "command": "vscode-neovim.compositeEscape1",
                 "title": "Composite escape key 1"
             },
@@ -343,34 +347,29 @@
         ],
         "keybindings": [
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal",
-                "args": "<Esc>"
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
             },
             {
                 "command": "vscode-neovim.send",

--- a/package.json
+++ b/package.json
@@ -281,20 +281,8 @@
                 "title": "Neovim: send key"
             },
             {
-                "command": "vscode-neovim.sync-send",
-                "title": "Neovim: Sync pending insert-mode changes and send key"
-            },
-            {
                 "command": "vscode-neovim.escape",
                 "title": "Escape key"
-            },
-            {
-                "command": "vscode-neovim.compositeEscape1",
-                "title": "Composite escape key 1"
-            },
-            {
-                "command": "vscode-neovim.compositeEscape2",
-                "title": "Composite escape key 2"
             },
             {
                 "command": "vscode-neovim.commit-cmdline",
@@ -416,133 +404,133 @@
             {
                 "command": "vscode-neovim.send",
                 "key": "backspace",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<BS>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+backspace",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-BS>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+backspace",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<C-BS>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "delete",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Del>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+delete",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-Del>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+delete",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<C-Del>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "tab",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Tab>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+tab",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-Tab>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "down",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Down>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "up",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Up>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "left",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Left>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "right",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Right>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+down",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<C-Down>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+up",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<C-Up>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+right",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<C-Right>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+left",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<C-Left>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+down",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-Down>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+up",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-Up>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+left",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-Left>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+right",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<S-Right>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "home",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<Home>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "end",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "when": "editorTextFocus && neovim.init",
                 "args": "<End>"
             },
             {
@@ -815,55 +803,55 @@
                 "args": "<C-/>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+o",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-o>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+u",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-u>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+w",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-w>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+h",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-h>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+t",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-t>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+d",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-d>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+j",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-j>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+a",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-a>"
             },
             {
-                "command": "vscode-neovim.sync-send",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+r",
                 "when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
                 "args": "<C-r>"

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -14,11 +14,7 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
         this.client = client;
         this.revealCursorScrollLine = revealCursorScrollLine;
 
-        this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-a-insert", this.ctrlAInsert));
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.send", (key) => this.sendToVim(key)));
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.paste-register", (reg) => this.pasteFromRegister(reg)),
-        );
         this.disposables.push(
             vscode.commands.registerCommand("vscode-neovim.ctrl-f", () => this.scrollPage("page", "down")),
         );
@@ -78,32 +74,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     private sendToVim = (keys: string): void => {
         this.client.input(keys);
     };
-
-    private ctrlAInsert = async (): Promise<void> => {
-        // Insert previously inserted text from the insert mode
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return;
-        }
-        const lines: string[] = await this.client.callFunction("VSCodeGetLastInsertText");
-        if (!lines.length) {
-            return;
-        }
-        await editor.edit((b) => b.insert(editor.selection.active, lines.join("\n")));
-    };
-
-    private async pasteFromRegister(registerName: string): Promise<void> {
-        // copy content from register in insert mode
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return;
-        }
-        const content = await this.client.callFunction("VSCodeGetRegister", [registerName]);
-        if (content === "") {
-            return;
-        }
-        await editor.edit((b) => b.insert(editor.selection.active, content));
-    }
 
     /// SCROLL COMMANDS ///
     private scrollPage = (by: "page" | "halfPage", to: "up" | "down"): void => {

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -14,26 +14,6 @@ export class TypingManager implements Disposable {
      * Separate "type" command disposable since we init/dispose it often
      */
     private typeHandlerDisposable?: Disposable;
-    /**
-     * Flag indicating that we're going to exit insert mode and sync buffers into neovim
-     */
-    private isExitingInsertMode = false;
-    /**
-     * Flag indicating that we're going to enter insert mode and there are pending document changes
-     */
-    private isEnteringInsertMode = false;
-    /**
-     * Additional keys which were pressed after exiting insert mode. We'll replay them after buffer sync
-     */
-    private pendingKeysAfterExit = "";
-    /**
-     * Additional keys which were pressed after entering the insert mode
-     */
-    private pendingKeysAfterEnter = "";
-    /**
-     * Timestamp when the first composite escape key was pressed. Using timestamp because timer may be delayed if the extension host is busy
-     */
-    private compositeEscapeFirstPressTimestamp?: number;
 
     public constructor(
         private logger: Logger,
@@ -42,20 +22,7 @@ export class TypingManager implements Disposable {
         private changeManager: DocumentChangeManager,
     ) {
         this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
-        this.disposables.push(
-            commands.registerCommand("vscode-neovim.sync-send", (key) => this.onSyncSendCommand(key)),
-        );
         this.disposables.push(commands.registerCommand("vscode-neovim.escape", this.onEscapeKeyCommand));
-        this.disposables.push(
-            commands.registerCommand("vscode-neovim.compositeEscape1", (key: string) =>
-                this.handleCompositeEscapeFirstKey(key),
-            ),
-        );
-        this.disposables.push(
-            commands.registerCommand("vscode-neovim.compositeEscape2", (key: string) =>
-                this.handleCompositeEscapeSecondKey(key),
-            ),
-        );
         this.modeManager.onModeChange(this.onModeChange);
     }
 
@@ -65,97 +32,17 @@ export class TypingManager implements Disposable {
     }
 
     private onModeChange = (): void => {
-        if (this.modeManager.isInsertMode && this.typeHandlerDisposable && !this.modeManager.isRecordingInInsertMode) {
-            this.pendingKeysAfterEnter = "";
-            const editor = window.activeTextEditor;
-            if (editor && this.changeManager.hasDocumentChangeCompletionLock(editor.document)) {
-                this.isEnteringInsertMode = true;
-                this.logger.debug(
-                    `${LOG_PREFIX}: Waiting for document completion operation before disposing type handler`,
-                );
-                this.changeManager.getDocumentChangeCompletionLock(editor.document)?.then(() => {
-                    this.isEnteringInsertMode = false;
-                    if (this.typeHandlerDisposable && this.modeManager.isInsertMode) {
-                        this.logger.debug(`${LOG_PREFIX}: Waiting done, disposing type handler`);
-                        this.typeHandlerDisposable.dispose();
-                        this.typeHandlerDisposable = undefined;
-                    }
-                    if (this.pendingKeysAfterEnter) {
-                        commands.executeCommand(this.modeManager.isInsertMode ? "default:type" : "type", {
-                            text: this.pendingKeysAfterEnter,
-                        });
-                        this.pendingKeysAfterEnter = "";
-                    }
-                });
-            } else {
-                this.logger.debug(`${LOG_PREFIX}: Disposing type handler`);
-                this.typeHandlerDisposable.dispose();
-                this.typeHandlerDisposable = undefined;
-            }
-        } else if (!this.modeManager.isInsertMode) {
-            this.isEnteringInsertMode = false;
-            this.isExitingInsertMode = false;
-            if (!this.typeHandlerDisposable) {
-                this.logger.debug(`${LOG_PREFIX}: Enabling type handler`);
-                this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
-            }
+        if (!this.typeHandlerDisposable) {
+            this.logger.debug(`${LOG_PREFIX}: Enabling type handler`);
+            this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
         }
     };
 
     private onVSCodeType = (_editor: TextEditor, edit: TextEditorEdit, type: { text: string }): void => {
-        if (this.isExitingInsertMode || this.isEnteringInsertMode) {
-            this.pendingKeysAfterExit += type.text;
-        } else {
-            this.client.input(normalizeInputString(type.text, !this.modeManager.isRecordingInInsertMode));
-        }
-    };
-
-    private onSyncSendCommand = async (key: string): Promise<void> => {
-        this.logger.debug(`${LOG_PREFIX}: Sync and send for: ${key}`);
-        if (this.modeManager.isInsertMode) {
-            this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
-            // rebind early to store fast pressed keys which may happen between sending changes to neovim and exiting insert mode
-            // see https://github.com/asvetliakov/vscode-neovim/issues/324
-            if (!this.typeHandlerDisposable) {
-                this.typeHandlerDisposable = commands.registerTextEditorCommand("type", this.onVSCodeType);
-            }
-            // this.leaveMultipleCursorsForVisualMode = false;
-            await this.changeManager.syncDocumentsWithNeovim();
-            await this.changeManager.syncDotRepatWithNeovim();
-        }
-        const keys = normalizeInputString(this.pendingKeysAfterExit);
-        this.logger.debug(`${LOG_PREFIX}: Pending keys sent with ${key}: ${keys}`);
-        this.pendingKeysAfterExit = "";
-        await this.client.input(`${key}${keys}`);
+        this.client.input(normalizeInputString(type.text, !this.modeManager.isRecordingInInsertMode));
     };
 
     private onEscapeKeyCommand = async (): Promise<void> => {
-        if (this.modeManager.isInsertMode) this.isExitingInsertMode = true;
-        await this.onSyncSendCommand("<Esc>");
-    };
-
-    private handleCompositeEscapeFirstKey = async (key: string): Promise<void> => {
-        const now = new Date().getTime();
-        if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
-            // jj
-            this.compositeEscapeFirstPressTimestamp = undefined;
-            await commands.executeCommand("deleteLeft");
-            await this.onEscapeKeyCommand();
-        } else {
-            this.compositeEscapeFirstPressTimestamp = now;
-            // insert character
-            await commands.executeCommand("default:type", { text: key });
-        }
-    };
-
-    private handleCompositeEscapeSecondKey = async (key: string): Promise<void> => {
-        const now = new Date().getTime();
-        if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
-            this.compositeEscapeFirstPressTimestamp = undefined;
-            await commands.executeCommand("deleteLeft");
-            await this.onEscapeKeyCommand();
-        } else {
-            await commands.executeCommand("default:type", { text: key });
-        }
+        await this.client.input("<Esc>");
     };
 }

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -111,17 +111,6 @@ function! VSCodeSetTextDecorations(hlName, rowsCols)
     call VSCodeExtensionNotify('text-decorations', a:hlName, a:rowsCols)
 endfunction
 
-" Used for ctrl-a insert keybinding
-function! VSCodeGetLastInsertText()
-    let lines = split(getreg("."), "^@")
-    return lines
-endfunction
-
-" Used for ctrl-r [reg] insert keybindings
-function! VSCodeGetRegister(reg)
-    return getreg(a:reg)
-endfunction
-
 " This is called by extension when created new buffer
 function! s:onBufEnter(name, id)
     if exists('b:vscode_temp') && b:vscode_temp


### PR DESCRIPTION
This has many advantages:
- remove dot repeat workarounds
- remove unbind/rebind to type, and associated sync
- makes insert mode bindings work out of the box
- remove composite escape hacks
- much code removed/simplified (I'd say another 50% of what has been removed can still be removed)

Disadvantages (why the workaround was added in the first place):
- typing lag
- cursor jitter
- random bugs (this can be fixed by the PR)
- completions not appearing

However, now you can do 
```js
  "extensions.experimental.affinity": {
    "asvetliakov.vscode-neovim": 1
  }, 
```

which makes the typing much faster. There is still cursor jitter, but everything seems very responsive and working out of the box.
