### PR TITLE
Fix normal mode freezing after switching windows

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -4,6 +4,8 @@ import { debounce } from "lodash-es";
 import { Buffer, NeovimClient, Window } from "neovim";
 import { ATTACH } from "neovim/lib/api/Buffer";
 import {
+    CancellationToken,
+    CancellationTokenSource,
     commands,
     Disposable,
     EndOfLine,
@@ -45,6 +47,7 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
      */
     private changeLayoutPromise?: Promise<void>;
     private changeLayoutPromiseResolve?: () => void;
+    private cancelTokenSource: CancellationTokenSource = new CancellationTokenSource();
     /**
      * Currently opened editors
      * !Note: Order can be any, it doesn't relate to visible order
@@ -102,7 +105,8 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
 
     public async forceResync(): Promise<void> {
         this.logger.debug(`${LOG_PREFIX}: force resyncing layout`);
-        await this.syncLayout();
+        // this.cancelTokenSource will always be cancelled when the visible editors change
+        await this.syncLayout(this.cancelTokenSource.token);
         await this.syncActiveEditor();
     }
 
@@ -305,7 +309,12 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
         if (!this.changeLayoutPromise) {
             this.changeLayoutPromise = new Promise((res) => (this.changeLayoutPromiseResolve = res));
         }
-        this.syncLayoutDebounced();
+
+        // Cancel the previous syncLayout call, and then create a new token source for the new
+        // syncLayout call
+        this.cancelTokenSource.cancel();
+        this.cancelTokenSource = new CancellationTokenSource();
+        this.syncLayoutDebounced(this.cancelTokenSource.token);
     };
 
     private onDidChangeActiveTextEditor = (): void => {
@@ -313,7 +322,7 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
         this.syncActiveEditorDebounced();
     };
 
-    private syncLayout = async (): Promise<void> => {
+    private syncLayout = async (cancelToken: CancellationToken): Promise<void> => {
         this.logger.debug(`${LOG_PREFIX}: syncing layout`);
         // store in copy, just in case
         const currentVisibleEditors = [...window.visibleTextEditors];
@@ -419,6 +428,14 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
 
         // remember new visible editors
         this.openedEditors = currentVisibleEditors;
+
+        if (cancelToken.isCancellationRequested) {
+            // If the visible editors has changed since we started, don't resolve the promise,
+            // because syncActiveEditor assumes that this promise is only resolved when the
+            // layout is synced, and currently the layout is synced based on outdated data
+            this.logger.debug(`${LOG_PREFIX}: Cancellation requested in syncLayout, returning`);
+            return;
+        }
         if (this.changeLayoutPromiseResolve) {
             this.changeLayoutPromiseResolve();
         }
@@ -439,7 +456,10 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
         }
         const winId = this.textEditorToWinId.get(activeEditor);
         if (!winId) {
-            this.logger.warn(
+            // If we reach here, then the current window in Neovim is out of sync with the
+            // active editor, which manifests itself as the editor being completely unresponsive
+            // when in normal mode
+            this.logger.error(
                 `${LOG_PREFIX}: Unable to determine neovim windows id for editor viewColumn: ${
                     activeEditor.viewColumn
                 }, docUri: ${activeEditor.document.uri.toString()}`,


### PR DESCRIPTION
This fixes a race condition that causes the extension to freeze in normal mode if someone changes tabs fast enough.

The race condition happens because the code in `syncLayout` doesn't handle the case where the visible editors and the active editor changes while `syncLayout` is still running correctly. In that case, while `syncLayout` is running due to the initial change, it will resolve `changeLayoutPromise` after the visible editors change. That causes `syncActiveEditor` to try to set the current window in Neovim, but will use the new active editor, so it will fail since that new editor wasn't in the list of visible editors when `syncLayout` was run, meaning that the Neovim window for that editor wasn't set up.

This PR:
- fixes the race condition by using a cancellation token to avoid resolving `changeLayoutPromise` if the list of visible editors has changed, which avoids `syncActiveEditor` continuing until `syncLayout` is rerun with the correct visible editors
- turns the logged warning about `syncActiveEditor` not finding a corresponding Neovim window for the active editor into an error since we should never get to that point unless something has gone wrong and it makes future freezes like this easier to debug

I'm open to suggestions on alternatives to using a cancellation token to fix the race condition, since that was the first method I thought of but I'm not sure if there are better methods to do the same thing.

Fixes #912