### PR TITLE
 fix(viewport_manager): fix logging messages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "ui",
         "workspace"
     ],
-    "version": "0.0.88",
+    "version": "0.0.89",
     "repository": {
         "type": "git",
         "url": "https://github.com/asvetliakov/vscode-neovim"
@@ -18,7 +18,7 @@
         "email": "devpieron@gmail.com"
     },
     "engines": {
-        "vscode": "^1.70.0"
+        "vscode": "^1.69.0"
     },
     "keywords": [
         "keybindings",

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -39,7 +39,6 @@ export class ViewportManager implements Disposable, NeovimRedrawProcessable, Neo
     public getCursorFromViewport(gridId: number): { line: number; col: number; isByteCol: boolean } | undefined {
         const view = this.gridViewport.get(gridId);
         if (!view) {
-            this.logger.error(`${LOG_PREFIX}: No viewport for gridId: ${gridId}`);
             return;
         }
         return { line: view.lnum - 1, col: view.col, isByteCol: true };
@@ -52,7 +51,6 @@ export class ViewportManager implements Disposable, NeovimRedrawProcessable, Neo
     public getGridOffset(gridId: number): { topLine: number; leftCol: number } | undefined {
         const view = this.gridViewport.get(gridId);
         if (!view) {
-            this.logger.error(`${LOG_PREFIX}: No viewport for gridId: ${gridId}`);
             return;
         }
         return { topLine: view.topline - 1, leftCol: view.leftcol };
@@ -64,7 +62,7 @@ export class ViewportManager implements Disposable, NeovimRedrawProcessable, Neo
                 const [winId, view] = args as [number, WinView];
                 const gridId = this.bufferManager.getGridIdForWinId(winId);
                 if (!gridId) {
-                    this.logger.warn(`${LOG_PREFIX}: No gird for winId: ${winId}`);
+                    this.logger.warn(`${LOG_PREFIX}: Unable to update scrolled view. No gird for winId: ${winId}`);
                     break;
                 }
                 this.gridViewport.set(gridId, view);


### PR DESCRIPTION
Fixes #976 by removing some messages. This makes the logging behavior more consistent with that of `buffer_manager`, letting downstream applications handle errors. Reported issue on Grid 1 should not affect editing experience as it is not displayed ([Grid 1 is the global grid used by default for the entire editor screen state](https://neovim.io/doc/user/ui.html#ui-linegrid)). 