### PR TITLE
feat(document_change_manager): replace `nvim_buf_set_lines` with `nvim_buf_set_text`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "vscode-neovim",
             "version": "0.0.90",
             "dependencies": {
+                "async-mutex": "^0.3.2",
                 "fast-diff": "^1.2.0",
                 "lodash-es": "^4.17.21",
                 "neovim": "^4.9.0",
@@ -909,6 +910,19 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
             "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+        },
+        "node_modules/async-mutex": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+            "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/async-mutex/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/azure-devops-node-api": {
             "version": "11.2.0",
@@ -6225,6 +6239,21 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
             "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+        },
+        "async-mutex": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+            "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+                }
+            }
         },
         "azure-devops-node-api": {
             "version": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -1285,6 +1285,7 @@
     },
     "dependencies": {
         "fast-diff": "^1.2.0",
+        "async-mutex": "^0.3.2",
         "lodash-es": "^4.17.21",
         "neovim": "^4.9.0",
         "ts-wcwidth": "^2.0.3"

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -12,6 +12,7 @@ import {
     window,
     workspace,
 } from "vscode";
+import { Mutex } from "async-mutex";
 
 import { BufferManager } from "./buffer_manager";
 import { Logger } from "./logger";
@@ -22,9 +23,9 @@ import {
     callAtomic,
     computeEditorOperationsFromDiff,
     diffLineToChars,
+    convertCharNumToByteNum,
     DotRepeatChange,
     getDocumentLineArray,
-    getNeovimCursorPosFromEditor,
     isChangeSubsequentToChange,
     isCursorChange,
     normalizeDotRepeatChange,
@@ -66,17 +67,13 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
     /**
      * Stores cursor pos after document change in neovim
      */
-    private cursorAfterTextDocumentChange: WeakMap<TextDocument, { line: number; character: number }> = new WeakMap();
+    private cursorAfterTextDocumentChange: WeakMap<TextDocument, Position> = new WeakMap();
     /**
      * Holds document content last known to neovim.
-     * ! The original content is needed to calculate the difference when exiting the insert mode
-     * ! It's possible to just fetch content from neovim and check instead of trackingg here, but this will add unnecessary lag
+     * ! This is used to convert vscode ranges to neovim bytes.
+     * ! It's possible to just fetch content from neovim and check instead of tracking here, but this will add unnecessary lag
      */
     private documentContentInNeovim: WeakMap<TextDocument, string> = new WeakMap();
-    /**
-     * Set of changed documents since last neovim sync
-     */
-    private changedDocuments: Set<TextDocument> = new Set();
     /**
      * Dot repeat workaround
      */
@@ -89,6 +86,10 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
      * True when we're currently applying edits, so incoming changes will go into pending events queue
      */
     private applyingEdits = false;
+    /**
+     * Lock edits being sent to neovim
+     */
+    public documentChangeLock = new Mutex();
 
     public constructor(private logger: Logger, private client: NeovimClient, private main: MainController) {
         this.main.bufferManager.onBufferEvent = this.onNeovimChangeEvent;
@@ -124,107 +125,6 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
             this.dotRepeatStartModeInsertHint = type === "before" ? "O" : "o";
             this.logger.debug(`${LOG_PREFIX}: Setting start insert mode hint - ${this.dotRepeatStartModeInsertHint}`);
         }
-    }
-
-    public async syncDocumentsWithNeovim(): Promise<void> {
-        this.logger.debug(`${LOG_PREFIX}: Syncing document changes with neovim`);
-
-        const requests: [string, unknown[]][] = [];
-        const changedDocs = [...this.changedDocuments];
-        this.changedDocuments.clear();
-
-        for (const doc of changedDocs) {
-            this.logger.debug(`${LOG_PREFIX}: Processing document ${doc.uri.toString()}`);
-            if (doc.isClosed) {
-                this.logger.warn(`${LOG_PREFIX}: Document ${doc.uri.toString()} is closed, skipping`);
-                continue;
-            }
-            let origText = this.documentContentInNeovim.get(doc);
-            if (origText == null) {
-                this.logger.warn(
-                    `${LOG_PREFIX}: Can't get last known neovim content for ${doc.uri.toString()}, skipping`,
-                );
-                continue;
-            }
-
-            const bufId = this.main.bufferManager.getBufferIdForTextDocument(doc);
-            if (!bufId) {
-                this.logger.warn(`${LOG_PREFIX}: No neovim buffer for ${doc.uri.toString()}`);
-                continue;
-            }
-
-            let newText = doc.getText();
-            this.documentContentInNeovim.set(doc, newText);
-
-            const eol = doc.eol === EndOfLine.LF ? "\n" : "\r\n";
-
-            // workaround about problem changing last line when it's empty
-            // todo: it doesn't work if you just add empty line without changing it
-            // if (origText.slice(-1) === "\n" || origText.slice(-1) === "\r\n") {
-            // add few lines to the end otherwise diff may be wrong for a newline characters
-            origText += `${eol}end${eol}end`;
-            newText += `${eol}end${eol}end`;
-            // }
-            const diffPrepare = diffLineToChars(origText, newText);
-            const d = diff(diffPrepare.chars1, diffPrepare.chars2);
-            const ranges = prepareEditRangesFromDiff(d);
-            if (!ranges.length) {
-                this.logger.debug(`${LOG_PREFIX}: No diff ranges for ${doc.uri.toString()}, skipping`);
-                continue;
-            }
-            // dmp.diff_charsToLines_(diff, diffPrepare.lineArray);
-            const bufLinesRequests: [string, unknown[]][] = [];
-            // each subsequent nvim_buf_set_lines uses the result of previous nvim_buf_set_lines so we must shift start/end
-            let lineDiffForNextChange = 0;
-            for (const range of ranges) {
-                let text = doc.getText(new Range(range.newStart, 0, range.newEnd, 999999)).split(eol);
-                const start = range.start + lineDiffForNextChange;
-                let end = range.end + lineDiffForNextChange;
-                if (range.type === "removed") {
-                    text = [];
-                    end++;
-                    lineDiffForNextChange--;
-                } else if (range.type === "changed") {
-                    // workaround for the diff issue when you put newline after the first line
-                    // diff doesn't account this case
-                    if ((newText.slice(-1) === "\n" || newText.slice(-1) === "\r\n") && !origText.includes(eol)) {
-                        text.push("");
-                    }
-                    end++;
-                } else if (range.type === "added") {
-                    // prevent adding newline
-                    if (range.start === 0 && !origText) {
-                        end++;
-                    }
-                    lineDiffForNextChange++;
-                    // if (text.slice(-1)[0] === "") {
-                    //     text.pop();
-                    // }
-                    // text.push("\n");
-                }
-                bufLinesRequests.push(["nvim_buf_set_lines", [bufId, start, end, false, text]]);
-                lineDiffForNextChange += range.newEnd - range.newStart - (range.end - range.start);
-            }
-            const bufTick: number = await this.client.request("nvim_buf_get_changedtick", [bufId]);
-            if (!bufTick) {
-                this.logger.warn(`${LOG_PREFIX}: Can't get changed tick for bufId: ${bufId}, deleted?`);
-                continue;
-            }
-            this.logger.debug(
-                `${LOG_PREFIX}: BufId: ${bufId}, lineChanges: ${bufLinesRequests.length}, tick: ${bufTick}, skipTick: ${
-                    bufTick + bufLinesRequests.length
-                }`,
-            );
-            this.bufferSkipTicks.set(bufId, bufTick + bufLinesRequests.length);
-            requests.push(...bufLinesRequests);
-        }
-        if (window.activeTextEditor) {
-            requests.push(["nvim_win_set_cursor", [0, getNeovimCursorPosFromEditor(window.activeTextEditor)]]);
-        }
-        if (!requests.length) {
-            return;
-        }
-        await callAtomic(this.client, requests, this.logger, LOG_PREFIX);
     }
 
     public async syncDotRepeatWithNeovim(): Promise<void> {
@@ -519,10 +419,7 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
                             // indepent of the diff operation in question.
                             editor.selections = [new Selection(cursorBefore, cursorBefore)];
                         }
-                        this.cursorAfterTextDocumentChange.set(editor.document, {
-                            line: editor.selection.active.line,
-                            character: editor.selection.active.character,
-                        });
+                        this.cursorAfterTextDocumentChange.set(editor.document, editor.selection.active);
                         docPromises.forEach((p) => p.resolve && p.resolve());
                         this.logger.debug(`${LOG_PREFIX}: Changes succesfully applied for ${doc.uri.toString()}`);
                         this.documentContentInNeovim.set(doc, doc.getText());
@@ -556,22 +453,42 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
         this.applyingEdits = false;
     };
 
-    private onChangeTextDocument = (e: TextDocumentChangeEvent): void => {
-        const { document, contentChanges } = e;
+    private onChangeTextDocument = async (e: TextDocumentChangeEvent): Promise<void> => {
+        const { document: doc } = e;
+        const origText = this.documentContentInNeovim.get(doc);
+        if (origText == null) {
+            this.logger.warn(`${LOG_PREFIX}: Can't get last known neovim content for ${doc.uri.toString()}, skipping`);
+            return;
+        }
+        this.documentContentInNeovim.set(doc, doc.getText());
+        await this.documentChangeLock.runExclusive(async () => await this.onChangeTextDocumentLocked(e, origText));
+    };
 
-        this.logger.debug(`${LOG_PREFIX}: Change text document for uri: ${document.uri.toString()}`);
-        if (this.documentSkipVersionOnChange.get(document) === document.version) {
+    private onChangeTextDocumentLocked = async (e: TextDocumentChangeEvent, origText: string): Promise<void> => {
+        const { document: doc, contentChanges } = e;
+
+        this.logger.debug(`${LOG_PREFIX}: Change text document for uri: ${doc.uri.toString()}`);
+        this.logger.debug(
+            `${LOG_PREFIX}: Version: ${doc.version}, skipVersion: ${this.documentSkipVersionOnChange.get(doc)}`,
+        );
+        if ((this.documentSkipVersionOnChange.get(doc) ?? 0) >= doc.version) {
             this.logger.debug(`${LOG_PREFIX}: Skipping a change since versions equals`);
             return;
         }
 
+        const bufId = this.main.bufferManager.getBufferIdForTextDocument(doc);
+        if (!bufId) {
+            this.logger.warn(`${LOG_PREFIX}: No neovim buffer for ${doc.uri.toString()}`);
+            return;
+        }
+
+        const eol = doc.eol === EndOfLine.LF ? "\n" : "\r\n";
         const startModeHint = this.dotRepeatStartModeInsertHint;
         const activeEditor = window.activeTextEditor;
 
         // Store dot repeat
-        if (activeEditor && activeEditor.document === document && this.main.modeManager.isInsertMode) {
+        if (activeEditor && activeEditor.document === doc && this.main.modeManager.isInsertMode) {
             this.dotRepeatStartModeInsertHint = undefined;
-            const eol = document.eol === EndOfLine.LF ? "\n" : "\r\n";
             const cursor = activeEditor.selection.active;
             for (const change of contentChanges) {
                 if (isCursorChange(change, cursor, eol)) {
@@ -583,9 +500,32 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
                 }
             }
         }
-        this.changedDocuments.add(document);
-        if (!this.main.modeManager.isInsertMode) {
-            this.syncDocumentsWithNeovim();
+
+        const requests: [string, unknown[]][] = [];
+
+        for (const c of contentChanges) {
+            const start = c.range.start;
+            const end = c.range.end;
+            const text = c.text;
+            const startBytes = convertCharNumToByteNum(origText.split(eol)[start.line], start.character);
+            const endBytes = convertCharNumToByteNum(origText.split(eol)[end.line], end.character);
+            requests.push(["nvim_buf_set_text", [bufId, start.line, startBytes, end.line, endBytes, text.split(eol)]]);
         }
+
+        const bufTick: number = await this.client.request("nvim_buf_get_changedtick", [bufId]);
+        if (!bufTick) {
+            this.logger.warn(`${LOG_PREFIX}: Can't get changed tick for bufId: ${bufId}, deleted?`);
+            return;
+        }
+        this.logger.debug(
+            `${LOG_PREFIX}: BufId: ${bufId}, lineChanges: ${requests.length}, tick: ${bufTick}, skipTick: ${
+                bufTick + requests.length
+            }`,
+        );
+        this.bufferSkipTicks.set(bufId, bufTick + contentChanges.length);
+
+        this.logger.debug(`${LOG_PREFIX}: Setting wantInsertCursorUpdate to false`);
+        this.main.cursorManager.wantInsertCursorUpdate = false;
+        if (requests.length) await callAtomic(this.client, requests, this.logger, LOG_PREFIX);
     };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,16 +25,6 @@ export interface EditRange {
     type: "changed" | "removed" | "added";
 }
 
-export interface GridConf {
-    winId: number;
-    cursorLine: number;
-    cursorPos: number;
-    screenLine: number;
-    screenPos: number;
-    topScreenLineStr: string;
-    bottomScreenLineStr: string;
-}
-
 export type GridLineEvent = [number, number, number, [string, number, number][]];
 
 /**
@@ -61,43 +51,6 @@ export interface DotRepeatChange {
      * Text eol
      */
     eol: string;
-}
-
-export function processLineNumberStringFromEvent(
-    event: GridLineEvent,
-    lineNumberHlId: number,
-    prevString: string,
-): string {
-    const [, , colStart, cells] = event;
-    if (!cells.length || cells[0][1] !== lineNumberHlId) {
-        return prevString;
-    }
-
-    let lineNumStr = "";
-    for (const [text, hlId, repeat] of cells) {
-        if (hlId != null && hlId !== lineNumberHlId) {
-            break;
-        }
-        for (let i = 0; i < (repeat || 1); i++) {
-            lineNumStr += text;
-        }
-    }
-    const newStr = prevString.slice(0, colStart) + lineNumStr + prevString.slice(colStart + lineNumStr.length);
-    return newStr;
-}
-
-export function getLineFromLineNumberString(lineStr: string): number {
-    const num = parseInt(lineStr.trim(), 10);
-    return isNaN(num) ? 0 : num - 1;
-}
-
-export function convertLineNumberToString(line: number): string {
-    let lineNumStr = line.toString(10);
-    // prepend " " for empty lines
-    for (let i = lineNumStr.length; i < 7; i++) {
-        lineNumStr = " " + lineNumStr;
-    }
-    return lineNumStr + " ";
 }
 
 // Copied from https://github.com/google/diff-match-patch/blob/master/javascript/diff_match_patch_uncompressed.js
@@ -315,24 +268,6 @@ export function calculateEditorColFromVimScreenCol(
         }
     }
     return currentCharIdx;
-}
-
-export function getEditorCursorPos(editor: TextEditor, conf: GridConf): { line: number; col: number } {
-    const topScreenLine = getLineFromLineNumberString(conf.topScreenLineStr);
-    const cursorLine = topScreenLine + conf.screenLine;
-    if (cursorLine >= editor.document.lineCount) {
-        // rarely happens, but could, usually for external help files when text is not available now (due to async edit or so)
-        return {
-            col: conf.screenPos,
-            line: cursorLine,
-        };
-    }
-    const line = editor.document.lineAt(cursorLine).text;
-    const col = calculateEditorColFromVimScreenCol(line, conf.screenPos);
-    return {
-        line: cursorLine,
-        col,
-    };
 }
 
 export function isChangeSubsequentToChange(


### PR DESCRIPTION
I started to work on fixing #543. 
Helps #84

So far it seems to work well, though a couple tests fail.

Unfortunately, it does not seem to fix either dot-repeat or marks. Marks are lost like before, and dot-repeat does not replay any of the changes sent using set_text.

I tried sending the changes to nvim in real-time, which showed promise. With this, when you type, it sends individual characters to nvim asynchronously (so no typing lag). However, this also didn't fix dot-repeat, and had cursor pos syncronization issues.

This does reduce code bloat however, and might improve performance (especially in the case where vscode makes changes in normal mode). 