### PR TITLE
Doc: Fix link to "Plugins" wiki in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Plug 'easymotion/vim-easymotion', Cond(!exists('g:vscode'))
 Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymotion' })
 ```
 
-See [plugins](Plugins) in the wiki for tips on configuring VIM plugins.
+See [[Plugins|plugins]] in the wiki for tips on configuring VIM plugins.
 
 ### VSCode configuration
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Plug 'easymotion/vim-easymotion', Cond(!exists('g:vscode'))
 Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymotion' })
 ```
 
-See [[Plugins|plugins]] in the wiki for tips on configuring VIM plugins.
+See [plugins](https://github.com/vscode-neovim/vscode-neovim/wiki/Plugins) in the wiki for tips on configuring VIM plugins.
 
 ### VSCode configuration
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Plug 'easymotion/vim-easymotion', Cond(!exists('g:vscode'))
 Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymotion' })
 ```
 
-See [plugins](plugins) in the wiki for tips on configuring VIM plugins.
+See [plugins](Plugins) in the wiki for tips on configuring VIM plugins.
 
 ### VSCode configuration
 


### PR DESCRIPTION
Capitalized the "p" in the "Plugins" hyperlink relative reference so it takes the user to the Plugins Wiki page (https://github.com/vscode-neovim/vscode-neovim/wiki/Plugins) instead of "Page Not Found."