### PR TITLE
Remove invalid vscode config setting from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ See [plugins](https://github.com/vscode-neovim/vscode-neovim/wiki/Plugins) in th
 
 ### VSCode configuration
 
--   To have the explorer keybindings work, you will need to set `"workbench.list.automaticKeyboardNavigation": false`.
-    Note that this will disable the filtering in the explorer that occurs when you usually start typing.
 -   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to
     fix this open Terminal and execute the following command:
     `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`.

--- a/README.md
+++ b/README.md
@@ -369,9 +369,6 @@ These are the default commands and bindings available for file/scroll/window/tab
 | <kbd>C-u</kbd> / <kbd>C-d</kbd>    | `list.focusPageUp/Down`         |
 | <kbd> / </kbd> / <kbd>Escape</kbd> | `list.toggleKeyboardNavigation` |
 
-> 💡 To enable explorer list navigation, add `"workbench.list.automaticKeyboardNavigation": false` to your
-> `settings.json`.
-
 #### Explorer file manipulation
 
 | Key          | VSCode Command        |


### PR DESCRIPTION
`workbench.list.automaticKeyboardNavigation` no longer a valid setting in settings.json

<img width="417" alt="Screen Shot 2022-08-23 at 15 42 10" src="https://user-images.githubusercontent.com/26180499/186113665-4f185faa-bd87-4a7f-8d12-e12c5e54949e.png">

