### PR TITLE
fix(cursor_manager): Make mouse clicks extend selection in visual mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,11 +115,6 @@
                     "default": true,
                     "description": "Use Ctrl keys in insert mode"
                 },
-                "vscode-neovim.mouseSelectionStartVisualMode": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Mouse selection starts visual mode"
-                },
                 "vscode-neovim.useWSL": {
                     "type": "boolean",
                     "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const highlightConfIgnore = settings.get("highlightGroups.ignoreHighlights");
     const highlightConfHighlights = settings.get("highlightGroups.highlights");
     const highlightConfUnknown = settings.get("highlightGroups.unknownHighlight");
-    const mouseVisualSelection = settings.get("mouseSelectionStartVisualMode", false);
     const useCtrlKeysNormalMode = settings.get("useCtrlKeysForNormalMode", true);
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
     const useWsl = isWindows && settings.get("useWSL", false);
@@ -44,7 +43,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 unknownHighlight: highlightConfUnknown,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any,
-            mouseSelection: mouseVisualSelection,
             neovimPath: neovimPath,
             useWsl: ext.extensionKind === vscode.ExtensionKind.Workspace ? false : useWsl,
             neovimViewportWidth: neovimWidth,

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -36,7 +36,6 @@ export interface ControllerSettings {
     neovimPath: string;
     extensionPath: string;
     highlightsConfiguration: HighlightConfiguration;
-    mouseSelection: boolean;
     useWsl: boolean;
     customInitFile: string;
     clean: boolean;
@@ -209,9 +208,6 @@ export class MainController implements vscode.Disposable {
             this.bufferManager,
             this.changeManager,
             this.viewportManager,
-            {
-                mouseSelectionEnabled: this.settings.mouseSelection,
-            },
         );
         this.disposables.push(this.cursorManager);
 


### PR DESCRIPTION
In the early times of this extension, there were attempts to make mouse clicks start a visual selection, similar to `set mouse=a` in Vim. This behaviour is controlled by the `mouseSelectionStartVisualMode` setting which is off by default. As everybody can probably attest who has given this option a try, it is broken badly.  I don't think anyone is actually using it on a daily basis.

However, it turns out that parts of the code being written can be very useful. This PR enables the fraction of this feature which works smoothly by default and removes the setting `mouseSelectionStartVisualMode`.

Example

* Intention: You want to select a couple of lines using your mouse
* Press `V` where you want your selection to start
* Scroll around and click where you want your selection to end
* Operate on the selection as you please

Personally, I find this very useful to select large chunks of code, especially when I want to rely on the (visual) indent guide.