### PR TITLE
feat(buffer_manager): don't exit insert mode when switching tabs

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -22,6 +22,7 @@ import {
 import { Logger } from "./logger";
 import { NeovimExtensionRequestProcessable, NeovimRedrawProcessable } from "./neovim_events_processable";
 import { calculateEditorColFromVimScreenCol, callAtomic, getNeovimCursorPosFromEditor } from "./utils";
+import { MainController } from "./main_controller";
 
 // !Note: document and editors in vscode events and namespace are reference stable
 // ! Integration notes:
@@ -92,7 +93,12 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
 
     public onBufferInit?: (bufferId: number, textDocument: TextDocument) => void;
 
-    public constructor(private logger: Logger, private client: NeovimClient, private settings: BufferManagerSettings) {
+    public constructor(
+        private logger: Logger,
+        private client: NeovimClient,
+        private main: MainController,
+        private settings: BufferManagerSettings,
+    ) {
         this.disposables.push(window.onDidChangeVisibleTextEditors(this.onDidChangeVisibleTextEditors));
         this.disposables.push(window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor));
         this.disposables.push(workspace.onDidCloseTextDocument(this.onDidCloseTextDocument));
@@ -469,6 +475,7 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
         this.logger.debug(
             `${LOG_PREFIX}: Setting active editor - viewColumn: ${activeEditor.viewColumn}, winId: ${winId}`,
         );
+        await this.main.cursorManager.updateNeovimCursorPosition(activeEditor, undefined);
         await this.client.request("nvim_set_current_win", [winId]);
     };
 

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -189,7 +189,7 @@ export class MainController implements vscode.Disposable {
         this.modeManager = new ModeManager(this.logger);
         this.disposables.push(this.modeManager);
 
-        this.bufferManager = new BufferManager(this.logger, this.client, {
+        this.bufferManager = new BufferManager(this.logger, this.client, this, {
             neovimViewportHeight: 201,
             neovimViewportWidth: 1000,
         });

--- a/src/mode_manager.ts
+++ b/src/mode_manager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 
-import { commands, Disposable, window } from "vscode";
+import { commands, Disposable } from "vscode";
 
 import { Logger } from "./logger";
 import { NeovimExtensionRequestProcessable, NeovimRedrawProcessable } from "./neovim_events_processable";
@@ -21,9 +21,7 @@ export class ModeManager implements Disposable, NeovimRedrawProcessable, NeovimE
 
     private eventEmitter = new EventEmitter();
 
-    public constructor(private logger: Logger) {
-        this.disposables.push(window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor));
-    }
+    public constructor(private logger: Logger) {}
 
     public dispose(): void {
         this.disposables.forEach((d) => d.dispose());
@@ -78,10 +76,4 @@ export class ModeManager implements Disposable, NeovimRedrawProcessable, NeovimE
             commands.executeCommand("setContext", "neovim.recording", true);
         }
     }
-
-    private onDidChangeActiveTextEditor = (): void => {
-        if (!this.isNormalMode) {
-            commands.executeCommand("vscode-neovim.escape");
-        }
-    };
 }

--- a/src/test/suite/vscode-integartion-specific.test.ts
+++ b/src/test/suite/vscode-integartion-specific.test.ts
@@ -184,10 +184,13 @@ describe("VSCode integration specific stuff", () => {
         await vscode.window.showTextDocument(doc2, vscode.ViewColumn.Two);
         await wait();
 
+        await client.command("au BufEnter * stopinsert");
+        await wait();
+
         await vscode.commands.executeCommand("workbench.action.focusSecondEditorGroup");
         await wait();
 
-        await sendVSCodeKeys("i");
+        await sendVSCodeKeys("I");
         await assertContent(
             {
                 content: ["blah2"],
@@ -227,7 +230,7 @@ describe("VSCode integration specific stuff", () => {
             {
                 content: ["testblah2"],
                 cursorStyle: "block",
-                mode: "n",
+                mode: "V",
             },
             client,
         );
@@ -245,7 +248,10 @@ describe("VSCode integration specific stuff", () => {
         await vscode.window.showTextDocument(doc2, vscode.ViewColumn.One);
         await wait();
 
-        await sendVSCodeKeys("i");
+        await client.command("au BufEnter * stopinsert");
+        await wait();
+
+        await sendVSCodeKeys("I");
         await assertContent(
             {
                 content: ["blah2"],


### PR DESCRIPTION
This mirrors nvim functionality. This also fixes the issue where the cursor is not updated to the click position when switching tabs. 

Depends on https://github.com/vscode-neovim/vscode-neovim/pull/992. 

Closes #716, fixes https://github.com/vscode-neovim/vscode-neovim/issues/613, fixes #776.

If you want to keep existing behaviour, use `au BufEnter * stopinsert`.

Note: this only consists of the last commit.