### PR TITLE
fix(highlight): check overlay from config

### DIFF
--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -204,8 +204,8 @@ export class HighlightProvider {
         this.highlightIdToGroupName.set(id, name);
         const options = this.configuration.highlights[name] || this.configuration.unknownHighlight;
         const conf = options === "vim" ? vimHighlightToVSCodeOptions(vimUiAttrs) : options;
-        // Search highlight creates https://github.com/vscode-neovim/vscode-neovim/issues/968
-        if (!this.ignoredGroupIds.has(id) && !name.endsWith("Search")) {
+
+        if (!this.ignoredGroupIds.has(id) && !this.configuration.highlights[name]) {
             this.highlightIdToOverlay.set(id, true);
         }
         this.createDecoratorForHighlightGroup(name, conf);


### PR DESCRIPTION
@theol0403  sorry I just realize It is not only search and incsearch group.
 highlight group of that config can make the ext_mark overlay broken
https://github.com/vscode-neovim/vscode-neovim/blob/master/package.json#L234