### PR TITLE
docs(readme): fix visual studio marketplace badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center"><strong>VSCode Neovim Integration</strong></p>
 
 <p align=center>
-<a href="https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim"><img src="https://vsmarketplacebadge.apphb.com/version/asvetliakov.vscode-neovim.svg"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim"><img src="https://img.shields.io/visual-studio-marketplace/v/asvetliakov.vscode-neovim?color=%234c1&label=Visual%20Studio%20Marketplace"></a>
 <a href="https://github.com/asvetliakov/vscode-neovim/actions/workflows/build_test.yml"><img src="https://github.com/asvetliakov/vscode-neovim/workflows/Code%20Check%20&%20Test/badge.svg"></a>
 <a href="https://gitter.im/vscode-neovim/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/vscode-neovim/community.svg"></a>
 </p>


### PR DESCRIPTION
It seems that the https://vsmarketplacebadge.apphb.com is down for a while, so I replace the marketplace badge with the one generated by https://shields.io.

Extra color `#4c1` and label `Visual Studio Marketplace` settings were added to make it looks like the original badge.

<img width="1184" alt="vscode-neovim-bagde" src="https://user-images.githubusercontent.com/16042676/211222867-a2336551-c496-4cc0-a5a0-275cc38674f0.png">
Screenshot source: https://web.archive.org/web/20220413024110/https://github.com/vscode-neovim/vscode-neovim