### PR TITLE
fix(map): move wrapped lines in visual mode with gk/gj

### DIFF
--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -13,4 +13,6 @@ nnoremap g$ <Cmd>call <SID>toLastCharOfScreenLine()<CR>
 
 " Note: Using these in macro will break it
 nnoremap gk <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count1 })<CR>
+xnoremap gk <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count1 })<CR>
 nnoremap gj <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count1 })<CR>
+xnoremap gj <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count1 })<CR>


### PR DESCRIPTION
Add mapping to move up/down virtual lines (i.e. wrapped lines), in visual modes.

Complements the current mapping for moving up/down virtual lines in normal mode.