### PR TITLE
update substr (deprecated) to substring

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -239,7 +239,7 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
                     }
                     await this.attachNeovimExternalBuffer(name, id, !!expandTab, tabStop);
                 } else if (name) {
-                    const normalizedName = name.startsWith(BUFFER_NAME_PREFIX) ? name.substr(18) : name;
+                    const normalizedName = name.startsWith(BUFFER_NAME_PREFIX) ? name.substring(18) : name;
                     this.logger.debug(`${LOG_PREFIX}: Buffer request for ${normalizedName}, bufId: ${idStr}`);
                     try {
                         let doc = this.findDocFromUri(normalizedName);

--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -196,7 +196,7 @@ export class HighlightManager implements Disposable, NeovimRedrawProcessable, Ne
                         // use a single text decoration but modify it when a
                         // new decoration would be pushed on top of it.
                         const ogText = drawnAt.get(mapKey).renderOptions.after.contentText;
-                        drawnAt.get(mapKey).renderOptions.after.contentText = (text[0] + ogText).substr(
+                        drawnAt.get(mapKey).renderOptions.after.contentText = (text[0] + ogText).substring(
                             0,
                             ogText.length,
                         );


### PR DESCRIPTION
`substr` is deprecated (was used for compatibility with Internet Explorer).

Replaces the two occurrences of `substr` with `substring`