### PR TITLE
fix: VSCodeNotifyVisual and VSCodeCallVisual produce incorrect VSCode selections in visual and visual block modes if the cursor is placed at the beginning of the visual selection

### DIFF
--- a/src/test/suite/vscode-integartion-specific.test.ts
+++ b/src/test/suite/vscode-integartion-specific.test.ts
@@ -402,7 +402,7 @@ describe("VSCode integration specific stuff", () => {
         );
     });
 
-    it("Spawning command line from visual mode produces vscode selection", async () => {
+    it("Spawning command line from visual line mode produces vscode selection", async () => {
         const doc = await vscode.workspace.openTextDocument({
             content: ["a1", "b1", "c1"].join("\n"),
         });
@@ -426,6 +426,37 @@ describe("VSCode integration specific stuff", () => {
         await assertContent(
             {
                 vsCodeSelections: [new vscode.Selection(2, 2, 1, 0)],
+            },
+            client,
+        );
+        await vscode.commands.executeCommand("workbench.action.closeQuickOpen");
+    });
+
+    it(`Spawning command line from visual mode produces vscode selection`, async () => {
+        const documentContent = "Hello World!";
+        const doc = await vscode.workspace.openTextDocument({
+            content: documentContent,
+        });
+        await vscode.window.showTextDocument(doc);
+        await wait(1000);
+        await sendVSCodeKeys("v$");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-P>");
+        await wait();
+        await assertContent(
+            {
+                vsCodeSelections: [new vscode.Selection(0, 0, 0, documentContent.length)],
+            },
+            client,
+        );
+        await vscode.commands.executeCommand("workbench.action.closeQuickOpen");
+        await sendEscapeKey();
+
+        await sendVSCodeKeys("gvo");
+        await vscode.commands.executeCommand("vscode-neovim.send", "<C-P>");
+        await wait();
+        await assertContent(
+            {
+                vsCodeSelections: [new vscode.Selection(0, documentContent.length, 0, 0)],
             },
             client,
         );

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -58,7 +58,13 @@ function! VSCodeCallVisual(cmd, leaveSelection, ...) abort
     elseif mode ==# 'v' || mode ==# "\<C-v>"
         let startPos = getpos('v')
         let endPos = getpos('.')
-        call VSCodeCallRangePos(a:cmd, startPos[1], endPos[1], startPos[2], endPos[2] + 1, a:leaveSelection, a:000)
+        "  Check if the cursor is at the beginning of the visual selection
+        if (startPos[1] == endPos[1] && startPos[2] > endPos[2]) || startPos[1] > endPos[1]
+            let startPos[2] = startPos[2] + 1
+        else
+            let endPos[2] = endPos[2] + 1
+        endif
+        call VSCodeCallRangePos(a:cmd, startPos[1], endPos[1], startPos[2], endPos[2], a:leaveSelection, a:000)
     else
         call VSCodeCall(a:cmd, a:000)
     endif
@@ -73,7 +79,13 @@ function! VSCodeNotifyVisual(cmd, leaveSelection, ...)
     elseif mode ==# 'v' || mode ==# "\<C-v>"
         let startPos = getpos('v')
         let endPos = getpos('.')
-        call VSCodeNotifyRangePos(a:cmd, startPos[1], endPos[1], startPos[2], endPos[2] + 1, a:leaveSelection, a:000)
+        "  Check if the cursor is at the beginning of the visual selection
+        if (startPos[1] == endPos[1] && startPos[2] > endPos[2]) || startPos[1] > endPos[1]
+            let startPos[2] = startPos[2] + 1
+        else
+            let endPos[2] = endPos[2] + 1
+        endif
+        call VSCodeNotifyRangePos(a:cmd, startPos[1], endPos[1], startPos[2], endPos[2], a:leaveSelection, a:000)
     else
         call VSCodeNotify(a:cmd, a:000)
     endif

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -49,6 +49,15 @@ function! VSCodeExtensionNotify(cmd, ...)
     call rpcnotify(g:vscode_channel, s:vscodePluginEventName, a:cmd, a:000)
 endfunction
 
+function! s:fixVisualPos(startPos, endPos)
+    if (a:startPos[1] == a:endPos[1] && a:startPos[2] > a:endPos[2]) || a:startPos[1] > a:endPos[1]
+        let a:startPos[2] = a:startPos[2] + 1
+    else
+        let a:endPos[2] = a:endPos[2] + 1
+    endif
+    return [a:startPos, a:endPos]
+endfunction
+
 function! VSCodeCallVisual(cmd, leaveSelection, ...) abort
     let mode = mode()
     if mode ==# 'V'
@@ -58,12 +67,7 @@ function! VSCodeCallVisual(cmd, leaveSelection, ...) abort
     elseif mode ==# 'v' || mode ==# "\<C-v>"
         let startPos = getpos('v')
         let endPos = getpos('.')
-        "  Check if the cursor is at the beginning of the visual selection
-        if (startPos[1] == endPos[1] && startPos[2] > endPos[2]) || startPos[1] > endPos[1]
-            let startPos[2] = startPos[2] + 1
-        else
-            let endPos[2] = endPos[2] + 1
-        endif
+        let [startPos, endPos] = s:fixVisualPos(startPos, endPos)
         call VSCodeCallRangePos(a:cmd, startPos[1], endPos[1], startPos[2], endPos[2], a:leaveSelection, a:000)
     else
         call VSCodeCall(a:cmd, a:000)
@@ -79,12 +83,7 @@ function! VSCodeNotifyVisual(cmd, leaveSelection, ...)
     elseif mode ==# 'v' || mode ==# "\<C-v>"
         let startPos = getpos('v')
         let endPos = getpos('.')
-        "  Check if the cursor is at the beginning of the visual selection
-        if (startPos[1] == endPos[1] && startPos[2] > endPos[2]) || startPos[1] > endPos[1]
-            let startPos[2] = startPos[2] + 1
-        else
-            let endPos[2] = endPos[2] + 1
-        endif
+        let [startPos, endPos] = s:fixVisualPos(startPos, endPos)
         call VSCodeNotifyRangePos(a:cmd, startPos[1], endPos[1], startPos[2], endPos[2], a:leaveSelection, a:000)
     else
         call VSCodeNotify(a:cmd, a:000)


### PR DESCRIPTION
Fixes VSCodeNotifyVisual and VSCodeCallVisual producing incorrect VSCode selections in visual and visual block modes when the cursor is placed at the beginning of the visual selection.

`vim.keymap.set("x", "<D-d>, "<Cmd>call VSCodeNotifyVisual('editor.action.addSelectionToNextFindMatch', 1)<CR><Esc>i", opts)` mapping was used in the examples below.
But the problem exists for all mappings that call either `VSCodeNotifyVisual` or `VSCodeCallVisual`.

#### Before
https://user-images.githubusercontent.com/16840190/226107500-f0731da4-2b6e-4236-b273-251ed4c10b78.mp4

#### After
https://user-images.githubusercontent.com/16840190/226107801-37d475cb-1661-4933-97c3-c93cccf54503.mp4

