### PR TITLE
feat: add $NVIM_APPNAME option

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
                     "default": false,
                     "markdownDescription": "Equivalent to the startup option `--clean`."
                 },
+                "vscode-neovim.NVIM_APPNAME": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "See `:h NVIM_APPNAME`."
+                },
                 "vscode-neovim.neovimWidth": {
                     "type": "number",
                     "default": 1000,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const neovimViewportHeightExtend = settings.get("neovimViewportHeightExtend", 1);
     const customInit = getNeovimInitPath() ?? "";
     const clean = settings.get("neovimClean", false);
+    const NVIM_APPNAME = settings.get("NVIM_APPNAME", "");
     const logPath = settings.get("logPath", "");
     const logLevel = settings.get("logLevel", "none");
     const outputToConsole = settings.get("logOutputToConsole", false);
@@ -34,6 +35,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         const plugin = new MainController({
             customInitFile: customInit,
             clean: clean,
+            NVIM_APPNAME: NVIM_APPNAME,
             extensionPath: context.extensionPath.replace(/\\/g, "\\\\"),
             highlightsConfiguration: {
                 highlights: highlightConfHighlights,

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -40,6 +40,7 @@ export interface ControllerSettings {
     useWsl: boolean;
     customInitFile: string;
     clean: boolean;
+    NVIM_APPNAME: string;
     neovimViewportWidth: number;
     neovimViewportHeightExtend: number;
     revealCursorScrollLine: boolean;
@@ -138,6 +139,9 @@ export class MainController implements vscode.Disposable {
                 settings.useWsl
             }, args: ${JSON.stringify(args)}`,
         );
+        if (settings.NVIM_APPNAME) {
+            process.env.NVIM_APPNAME = settings.NVIM_APPNAME;
+        }
         this.nvimProc = spawn(settings.useWsl ? "C:\\Windows\\system32\\wsl.exe" : settings.neovimPath, args, {});
         this.nvimProc.on("close", (code) => {
             this.logger.error(`${LOG_PREFIX}: Neovim exited with code: ${code}`);


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/22128

Personally I want a separate neovim config just for vscode, which can be achieved by setting `$NVIM_APPNAME`

![image](https://user-images.githubusercontent.com/56817415/227526254-b4e75842-6b52-4c8d-bafd-1784a32d18a4.png)
