### PR TITLE
docs(readme): clean up the instruction using vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,20 @@ else
 end
 ```
 
-To conditionally activate plugins, `vim-plug` has a
-[few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation). For example, using the `Cond`
-helper, you can conditionally activate installed plugins
-([source](https://github.com/asvetliakov/vscode-neovim/issues/415#issuecomment-715533865)):
-
+Here is how to enable easy-motion using `vim-plug`:
 ```vim
 " inside plug#begin:
-" use normal easymotion when in VIM mode
-Plug 'easymotion/vim-easymotion', Cond(!exists('g:vscode'))
-" use VSCode easymotion when in VSCode mode
-Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymotion' })
+if exists('g:vscode')
+  " use VSCode easymotion when in VSCode mode
+  Plug 'asvetliakov/vim-easymotion', { 'as': 'vsc-easymotion' }
+else
+  " use normal easymotion when in VIM mode
+  Plug 'easymotion/vim-easymotion'
+endif
 ```
+For more information please visit `vim-plug` [wiki page](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation).
 
-See [plugins](https://github.com/vscode-neovim/vscode-neovim/wiki/Plugins) in the wiki for tips on configuring VIM
-plugins.
+See [plugins](https://github.com/vscode-neovim/vscode-neovim/wiki/Plugins) in the wiki for tips on configuring VIM plugins.
 
 ### VSCode configuration
 


### PR DESCRIPTION
I myself first encountered `Cond` function not found error.
So, it might be easier for having one more way to enable easymotion without defining `Cond` function.