### PR TITLE
chore(gitignore): Session.vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist
 node_modules
 .vscode-test/
 .DS_Store
+Session.vim
 *.vsix
 *.zip


### PR DESCRIPTION
Adds `Session.vim` to `.gitignore` for those who make use of `mks!` in Neovim while editing this project. 

I think this is a reasonable PR, since we all are Vim users.