### PR TITLE
feat: collapse all and copy bindings for file explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -651,6 +651,16 @@
                 "when": "filesExplorerFocus && !inputFocus"
             },
             {
+                "key": "c",
+                "command": "filesExplorer.copy",
+                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !inputFocus"
+            },
+            {
+                "key": "shift+w",
+                "command": "workbench.files.action.collapseExplorerFolders",
+                "when": "filesExplorerFocus"
+            },
+            {
                 "key": "tab",
                 "command": "togglePeekWidgetFocus",
                 "when": "inReferenceSearchEditor && neovim.mode == normal || referenceSearchVisible"

--- a/package.json
+++ b/package.json
@@ -651,12 +651,7 @@
                 "when": "filesExplorerFocus && !inputFocus"
             },
             {
-                "key": "c",
-                "command": "filesExplorer.copy",
-                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !inputFocus"
-            },
-            {
-                "key": "shift+w",
+                "key": "z shift+m",
                 "command": "workbench.files.action.collapseExplorerFolders",
                 "when": "filesExplorerFocus"
             },


### PR DESCRIPTION
nvim-tree allows to copy files using `c` as well. Also, you can collapse all folders with `W` which is also a default on nvim-tree.