### PR TITLE
fix: colliding ctrl+w bindings in terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1323,57 +1323,57 @@
             {
                 "key": "ctrl+w ctrl+w",
                 "command": "workbench.action.focusNextGroup",
-                "when": "!editorTextFocus && !(filesExplorerFocus || inSearchEditor || searchViewletFocus || replaceInputBoxFocus)"
+                "when": "!editorTextFocus && !terminalFocus && !(filesExplorerFocus || inSearchEditor || searchViewletFocus || replaceInputBoxFocus)"
             },
             {
                 "key": "ctrl+w ctrl+w",
                 "command": "workbench.action.focusFirstEditorGroup",
-                "when": "!editorTextFocus && !(filesExplorerFocus || inSearchEditor || searchViewletFocus || replaceInputBoxFocus)"
+                "when": "!editorTextFocus && !terminalFocus && !(filesExplorerFocus || inSearchEditor || searchViewletFocus || replaceInputBoxFocus)"
             },
             {
                 "key": "ctrl+w up",
                 "command": "workbench.action.navigateUp",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w k",
                 "command": "workbench.action.navigateUp",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w down",
                 "command": "workbench.action.navigateDown",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w j",
                 "command": "workbench.action.navigateDown",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w left",
                 "command": "workbench.action.navigateLeft",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w h",
                 "command": "workbench.action.navigateLeft",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w right",
                 "command": "workbench.action.navigateRight",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w l",
                 "command": "workbench.action.navigateRight",
-                "when": "!editorTextFocus"
+                "when": "!editorTextFocus && !terminalFocus"
             },
             {
                 "key": "ctrl+w q",
                 "command": "workbench.action.closeActiveEditor",
-                "when": "!editorTextFocus && !filesExplorerFocus && !searchViewletFocus"
+                "when": "!editorTextFocus && !terminalFocus && !filesExplorerFocus && !searchViewletFocus"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -1374,6 +1374,11 @@
                 "key": "ctrl+w q",
                 "command": "workbench.action.closeActiveEditor",
                 "when": "!editorTextFocus && !terminalFocus && !filesExplorerFocus && !searchViewletFocus"
+            },
+            {
+                "key": "ctrl+Escape",
+                "command": "workbench.action.focusActiveEditorGroup",
+                "when": "terminalFocus"
             }
         ]
     },


### PR DESCRIPTION
Fixes #1297

Primary focus is to allow using `ctrl+w` to delete the last word. <s>Will introduce a new issue for now: We cannot escape the terminal (for now).</s>