### PR TITLE
fix(mode): allow escaping from replace mode

### DIFF
--- a/src/mode_manager.ts
+++ b/src/mode_manager.ts
@@ -16,7 +16,7 @@ export class Mode {
         return this.shortname.charAt(0).replace("\x16", "v");
     }
     // mode long name
-    public get name(): "insert" | "visual" | "cmdline" | "normal" {
+    public get name(): "insert" | "visual" | "cmdline" | "normal" | "replace" {
         switch (this.char.toLowerCase()) {
             case "i":
                 return "insert";
@@ -24,6 +24,8 @@ export class Mode {
                 return "visual";
             case "c":
                 return "cmdline";
+            case "r":
+                return "replace";
             case "n":
             default:
                 return "normal";
@@ -41,6 +43,9 @@ export class Mode {
     }
     public get isNormal(): boolean {
         return this.name === "normal";
+    }
+    public get isReplace(): boolean {
+        return this.name === "replace";
     }
 }
 export class ModeManager implements Disposable, NeovimExtensionRequestProcessable {
@@ -87,6 +92,10 @@ export class ModeManager implements Disposable, NeovimExtensionRequestProcessabl
 
     public get isRecordingInInsertMode(): boolean {
         return this.isRecording;
+    }
+
+    public get isReplaceMode(): boolean {
+        return this.mode.isReplace;
     }
 
     public onModeChange(callback: () => void): void {

--- a/src/mode_manager.ts
+++ b/src/mode_manager.ts
@@ -16,7 +16,7 @@ export class Mode {
         return this.shortname.charAt(0).replace("\x16", "v");
     }
     // mode long name
-    public get name(): "insert" | "visual" | "cmdline" | "normal" | "replace" {
+    public get name(): "insert" | "visual" | "cmdline" | "replace" | "normal" {
         switch (this.char.toLowerCase()) {
             case "i":
                 return "insert";
@@ -43,9 +43,6 @@ export class Mode {
     }
     public get isNormal(): boolean {
         return this.name === "normal";
-    }
-    public get isReplace(): boolean {
-        return this.name === "replace";
     }
 }
 export class ModeManager implements Disposable, NeovimExtensionRequestProcessable {
@@ -94,10 +91,6 @@ export class ModeManager implements Disposable, NeovimExtensionRequestProcessabl
         return this.isRecording;
     }
 
-    public get isReplaceMode(): boolean {
-        return this.mode.isReplace;
-    }
-
     public onModeChange(callback: () => void): void {
         this.eventEmitter.on("neovimModeChanged", callback);
     }
@@ -114,6 +107,7 @@ export class ModeManager implements Disposable, NeovimExtensionRequestProcessabl
                     commands.executeCommand("setContext", "neovim.recording", false);
                 }
                 commands.executeCommand("setContext", "neovim.mode", this.mode.name);
+                this.logger.debug(`${LOG_PREFIX}: Setting mode context to ${this.mode.name}`);
                 this.eventEmitter.emit("neovimModeChanged");
                 break;
             }

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -178,7 +178,10 @@ export class TypingManager implements Disposable {
     private onSendCommand = async (key: string): Promise<void> => {
         this.logger.debug(`${LOG_PREFIX}: Send for: ${key}`);
         this.main.cursorManager.wantInsertCursorUpdate = true;
-        if (this.main.modeManager.isInsertMode && !(await this.client.mode).blocking) {
+        if (
+            (this.main.modeManager.isInsertMode || this.main.modeManager.isReplaceMode) &&
+            !(await this.client.mode).blocking
+        ) {
             this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
             await this.main.changeManager.documentChangeLock.waitForUnlock();
             if (window.activeTextEditor)

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -178,10 +178,7 @@ export class TypingManager implements Disposable {
     private onSendCommand = async (key: string): Promise<void> => {
         this.logger.debug(`${LOG_PREFIX}: Send for: ${key}`);
         this.main.cursorManager.wantInsertCursorUpdate = true;
-        if (
-            (this.main.modeManager.isInsertMode || this.main.modeManager.isReplaceMode) &&
-            !(await this.client.mode).blocking
-        ) {
+        if (this.main.modeManager.isInsertMode && !(await this.client.mode).blocking) {
             this.logger.debug(`${LOG_PREFIX}: Syncing buffers with neovim (${key})`);
             await this.main.changeManager.documentChangeLock.waitForUnlock();
             if (window.activeTextEditor)


### PR DESCRIPTION
This should close #1304; I've tried it out locally and everything seems to behave as expected. 🙂

(Force-pushed after linting.)