### PR TITLE
feat(main): set `WSLENV` to pass `NVIM_APPNAME` into WSL

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -142,6 +142,10 @@ export class MainController implements vscode.Disposable {
         if (settings.NVIM_APPNAME) {
             process.env.NVIM_APPNAME = settings.NVIM_APPNAME;
             if (settings.useWsl) {
+                /*
+                 * `/u` flag indicates the value should only be included when invoking WSL from Win32.
+                 * https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/#u
+                 */
                 process.env.WSLENV = "NVIM_APPNAME/u";
             }
         }

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -141,6 +141,9 @@ export class MainController implements vscode.Disposable {
         );
         if (settings.NVIM_APPNAME) {
             process.env.NVIM_APPNAME = settings.NVIM_APPNAME;
+            if (settings.useWsl) {
+                process.env.WSLENV = "NVIM_APPNAME/u";
+            }
         }
         this.nvimProc = spawn(settings.useWsl ? "C:\\Windows\\system32\\wsl.exe" : settings.neovimPath, args, {});
         this.nvimProc.on("close", (code) => {


### PR DESCRIPTION
Set the [`WSLENV`](https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/) environment variable to pass `NVIM_APPNAME` into WSL.

See #1303 for more discussions.

Fixes #1295.