### PR TITLE
feat: quick fix navigation via ctrl+n/p

### DIFF
--- a/package.json
+++ b/package.json
@@ -1379,6 +1379,16 @@
                 "key": "ctrl+Escape",
                 "command": "workbench.action.focusActiveEditorGroup",
                 "when": "terminalFocus"
+            },
+            {
+                "key": "ctrl+p",
+                "when": "codeActionMenuVisible && neovim.ctrlKeysNormal && neovim.init && neovim.mode != 'insert'",
+                "command": "selectPrevCodeAction"
+            },
+            {
+                "key": "ctrl+n",
+                "when": "codeActionMenuVisible && neovim.ctrlKeysNormal && neovim.init && neovim.mode != 'insert'",
+                "command": "selectNextCodeAction"
             }
         ]
     },


### PR DESCRIPTION
Suggestions in Vim can be navigated with Ctrl+N/P, so I implemented those for QuickFix in this PR:

![2023-07-21 19 19 52](https://github.com/vscode-neovim/vscode-neovim/assets/24259245/c5ac83ef-89d1-4fdc-948f-4b8b59a10390)

For navigation of the suggestions itself, it's a bit more complicated, see #1331 