### PR TITLE
fact(highlight): ignore undesired highlights from vim side instead of vscode side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.79.0"
+                "vscode": "^1.80.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
                         ]
                     },
                     "default": {
-                        "Directory": "vim",
                         "IncSearch": {
                             "backgroundColor": "theme.editor.findMatchBackground",
                             "borderColor": "theme.editor.findMatchBorder"
@@ -178,9 +177,7 @@
                         },
                         "Visual": {
                             "backgroundColor": "theme.editor.selectionBackground"
-                        },
-                        "Conceal": "vim",
-                        "Substitute": "vim"
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -151,70 +151,6 @@
                     "default": false,
                     "description": "When on, print log messages to vscode developer console (not output channel!)"
                 },
-                "vscode-neovim.highlightGroups.ignoreHighlights": {
-                    "type": "array",
-                    "title": "Ignore Highlighs Groups",
-                    "description": "List of vim highlights groups to ignore",
-                    "default": [
-                        "EndOfBuffer",
-                        "ErrorMsg",
-                        "MoreMsg",
-                        "ModeMsg",
-                        "Question",
-                        "VisualNC",
-                        "WarningMsg",
-                        "^Diff",
-                        "Sign",
-                        "SignColumn",
-                        "^Spell",
-                        "^Pmenu",
-                        "^Tab",
-                        "ColorColumn",
-                        "QuickFixLine",
-                        "MsgSeparator",
-                        "MsgArea",
-                        "^RedrawDebug",
-                        "^MatchParen",
-                        "^Nvim",
-                        "Operator",
-                        "Delimiter",
-                        "Identifier",
-                        "SpecialChar",
-                        "Number",
-                        "Type",
-                        "String",
-                        "Error",
-                        "Comment",
-                        "Constant",
-                        "Special",
-                        "Statement",
-                        "PreProc",
-                        "Underlined",
-                        "Ignore",
-                        "Todo",
-                        "Character",
-                        "Boolean",
-                        "Float",
-                        "Function",
-                        "Conditional",
-                        "Repeat",
-                        "Label",
-                        "Keyword",
-                        "Exception",
-                        "Include",
-                        "Define",
-                        "Macro",
-                        "PreCondit",
-                        "StorageClass",
-                        "Structure",
-                        "Typedef",
-                        "Tag",
-                        "SpecialComment",
-                        "Debug",
-                        "Folded",
-                        "FoldColumn"
-                    ]
-                },
                 "vscode-neovim.highlightGroups.highlights": {
                     "type": "object",
                     "title": "Highlight Groups Configuration",
@@ -246,20 +182,6 @@
                         "Conceal": "vim",
                         "Substitute": "vim"
                     }
-                },
-                "vscode-neovim.highlightGroups.unknownHighlight": {
-                    "oneOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "string",
-                            "const": "vim"
-                        }
-                    ],
-                    "title": "Unknown Highlight Groups",
-                    "description": "Highlight Configuration for non defined group. Can accept 'vim' to use colors coming from vim or text decoration properties object",
-                    "default": "vim"
                 }
             }
         },

--- a/runtime/lua/vscode.lua
+++ b/runtime/lua/vscode.lua
@@ -1,4 +1,5 @@
 require("vscode.cursor")
+require("vscode.highlight")
 
 local M = {}
 

--- a/runtime/lua/vscode.lua
+++ b/runtime/lua/vscode.lua
@@ -1,5 +1,5 @@
+require("vscode.defaults")
 require("vscode.cursor")
-require("vscode.highlight")
 
 local M = {}
 

--- a/runtime/lua/vscode/defaults.lua
+++ b/runtime/lua/vscode/defaults.lua
@@ -1,8 +1,18 @@
+-- customise statusbar
+vim.opt.shortmess = "filnxtToOFI"
+
+--- Turn on auto-indenting
+vim.opt.autoindent = true
+vim.opt.smartindent = true
+
+--- split/nosplit doesn't work currently, see https://github.com/asvetliakov/vscode-neovim/issues/329
+vim.opt.inccommand = ""
+
 -- disable matchparen because we don't need it
 vim.g.loaded_matchparen = 1
 
 -- syntax groups that are hidden by default but can be overridden by `vscode-neovim.highlightGroups.highlights` or init.vim config (inside ColorScheme au)
-local function ignore_highlights()
+local function apply_highlights()
     vim.api.nvim_set_hl(0, "Normal", {})
     vim.api.nvim_set_hl(0, "NormalNC", {})
     vim.api.nvim_set_hl(0, "NormalFloat", {})
@@ -11,7 +21,10 @@ local function ignore_highlights()
     vim.api.nvim_set_hl(0, "VisualNOS", {})
     vim.api.nvim_set_hl(0, "Substitute", {})
     vim.api.nvim_set_hl(0, "Whitespace", {})
+
+    -- make cursor visible for plugins that use fake cursor
+    vim.api.nvim_set_hl(0, 'Cursor', { reverse = true })
 end
 
-ignore_highlights()
-vim.api.nvim_create_autocmd({ "FileType", "ColorScheme" }, { callback = ignore_highlights })
+apply_highlights()
+vim.api.nvim_create_autocmd({ "FileType", "ColorScheme" }, { callback = apply_highlights })

--- a/runtime/lua/vscode/force_options.lua
+++ b/runtime/lua/vscode/force_options.lua
@@ -1,6 +1,6 @@
---- This file is used to force set options which may break the extension. Loaded manually after user config by main_controller.
+--- This file is used to force set options which may break the extension. Loaded after user config by main_controller.
 
-vim.opt.shortmess = "filnxtToOFI"
+-- ------------------------- forced global options ------------------------- --
 vim.opt.cmdheight = 1
 vim.opt.wildmode = "list"
 vim.cmd [[set wildchar=<C-e>]]
@@ -10,6 +10,7 @@ vim.opt.backup = false
 vim.opt.wb = false
 vim.opt.swapfile = false
 vim.opt.autoread = false
+vim.opt.autowrite = false
 vim.opt.cursorline = false
 vim.opt.signcolumn = "no"
 
@@ -22,33 +23,22 @@ vim.opt.ruler = false
 vim.opt.modeline = false
 vim.opt.modelines = 0
 
---- Turn on auto-indenting
-vim.opt.autoindent = true
-vim.opt.smartindent = true
-
---- split/nosplit doesn't work currently, see https://github.com/asvetliakov/vscode-neovim/issues/329
-vim.opt.inccommand = ""
-
 --- Allow to use vim HL for external buffers, vscode buffers explicitly disable it
 vim.cmd [[syntax on]]
 
--- make cursor visible for plugins what use fake cursor
-vim.api.nvim_set_hl(0, 'Cursor', { reverse = true })
-
--- these are applied to global options and forced on local options
+-- --------------------- forced global and local critical options -------------------- --
 local function forceoptions(opt)
     opt.wrap = false
     opt.conceallevel = 0
     opt.hidden = true
     opt.bufhidden = "hide"
-    opt.autowrite = false
     opt.number = false
     opt.relativenumber = false
     opt.list = true
     --- Need to know tabs for HL
     opt.listchars = { tab = "❥♥" }
     -- disable syntax hl for vscode buffers
-    if vim.b.vscode_controlled then
+    if vim.b.vscode_controlled and opt == vim.opt_local then
         opt.syntax = "off"
     end
     --- Turn off auto-folding
@@ -59,6 +49,7 @@ local function forceoptions(opt)
     opt.lazyredraw = false
 end
 
+-- force global options on startup
 forceoptions(vim.opt)
 
 -- force local options on buffer load

--- a/runtime/lua/vscode/highlight.lua
+++ b/runtime/lua/vscode/highlight.lua
@@ -1,0 +1,98 @@
+local M = {}
+
+-- remove highlight groups that should never be shown
+vim.api.nvim_create_autocmd({ "BufEnter", "FileType", "ColorScheme" }, {
+    callback = function()
+        vim.api.nvim_set_hl(0, "Normal", {})
+        vim.api.nvim_set_hl(0, "NormalNC", {})
+        vim.api.nvim_set_hl(0, "NormalFloat", {})
+        vim.api.nvim_set_hl(0, "NonText", {})
+        vim.api.nvim_set_hl(0, "SpecialKey", {})
+        vim.api.nvim_set_hl(0, "TermCursor", {})
+        vim.api.nvim_set_hl(0, "TermCursorNC", {})
+        vim.api.nvim_set_hl(0, "Visual", {})
+        vim.api.nvim_set_hl(0, "VisualNOS", {})
+        vim.api.nvim_set_hl(0, "Conceal", {})
+        vim.api.nvim_set_hl(0, "CursorLine", {})
+        vim.api.nvim_set_hl(0, "CursorLineNr", {})
+        vim.api.nvim_set_hl(0, "ColorColumn", {})
+        vim.api.nvim_set_hl(0, "LineNr", {})
+        vim.api.nvim_set_hl(0, "StatusLine", {})
+        vim.api.nvim_set_hl(0, "StatusLineNC", {})
+        vim.api.nvim_set_hl(0, "VertSplit", {})
+        vim.api.nvim_set_hl(0, "Title", {})
+        vim.api.nvim_set_hl(0, "WildMenu", {})
+        vim.api.nvim_set_hl(0, "Whitespace", {})
+    end
+})
+
+-- hide highlight groups when vscode owns the buffer
+-- todo: these seem arbitrary
+local ns = vim.api.nvim_create_namespace("vscode-owned-highlights")
+vim.api.nvim_set_hl(ns, "EndOfBuffer", {})
+vim.api.nvim_set_hl(ns, "ErrorMsg", {})
+vim.api.nvim_set_hl(ns, "MoreMsg", {})
+vim.api.nvim_set_hl(ns, "ModeMsg", {})
+vim.api.nvim_set_hl(ns, "Question", {})
+vim.api.nvim_set_hl(ns, "VisualNC", {})
+vim.api.nvim_set_hl(ns, "WarningMsg", {})
+vim.api.nvim_set_hl(ns, "Sign", {})
+vim.api.nvim_set_hl(ns, "SignColumn", {})
+vim.api.nvim_set_hl(ns, "ColorColumn", {})
+vim.api.nvim_set_hl(ns, "QuickFixLine", {})
+vim.api.nvim_set_hl(ns, "MsgSeparator", {})
+vim.api.nvim_set_hl(ns, "MsgArea", {})
+vim.api.nvim_set_hl(ns, "MatchParen", {})
+vim.api.nvim_set_hl(ns, "MatchIt", {})
+vim.api.nvim_set_hl(ns, "Operator", {})
+vim.api.nvim_set_hl(ns, "Delimiter", {})
+vim.api.nvim_set_hl(ns, "Identifier", {})
+vim.api.nvim_set_hl(ns, "SpecialChar", {})
+vim.api.nvim_set_hl(ns, "Number", {})
+vim.api.nvim_set_hl(ns, "Type", {})
+vim.api.nvim_set_hl(ns, "String", {})
+vim.api.nvim_set_hl(ns, "Error", {})
+vim.api.nvim_set_hl(ns, "Comment", {})
+vim.api.nvim_set_hl(ns, "Constant", {})
+vim.api.nvim_set_hl(ns, "Special", {})
+vim.api.nvim_set_hl(ns, "Statement", {})
+vim.api.nvim_set_hl(ns, "PreProc", {})
+vim.api.nvim_set_hl(ns, "Underlined", {})
+vim.api.nvim_set_hl(ns, "Ignore", {})
+vim.api.nvim_set_hl(ns, "Todo", {})
+vim.api.nvim_set_hl(ns, "Character", {})
+vim.api.nvim_set_hl(ns, "Boolean", {})
+vim.api.nvim_set_hl(ns, "Float", {})
+vim.api.nvim_set_hl(ns, "Function", {})
+vim.api.nvim_set_hl(ns, "Conditional", {})
+vim.api.nvim_set_hl(ns, "Repeat", {})
+vim.api.nvim_set_hl(ns, "Label", {})
+vim.api.nvim_set_hl(ns, "Keyword", {})
+vim.api.nvim_set_hl(ns, "Exception", {})
+vim.api.nvim_set_hl(ns, "Include", {})
+vim.api.nvim_set_hl(ns, "Define", {})
+vim.api.nvim_set_hl(ns, "Macro", {})
+vim.api.nvim_set_hl(ns, "PreCondit", {})
+vim.api.nvim_set_hl(ns, "StorageClass", {})
+vim.api.nvim_set_hl(ns, "Structure", {})
+vim.api.nvim_set_hl(ns, "Typedef", {})
+vim.api.nvim_set_hl(ns, "Tag", {})
+vim.api.nvim_set_hl(ns, "SpecialComment", {})
+vim.api.nvim_set_hl(ns, "Debug", {})
+vim.api.nvim_set_hl(ns, "Folded", {})
+vim.api.nvim_set_hl(ns, "FoldColumn", {})
+
+vim.api.nvim_create_autocmd({ "BufEnter", "FileType", "ColorScheme" }, {
+    callback = function()
+        if vim.b.vscode_controlled then
+            vim.api.nvim_set_hl_ns(ns)
+        else
+            vim.api.nvim_set_hl_ns(0)
+        end
+    end
+})
+
+-- if users want to ignore their own highlights in vscode owned buffers, they can use this namespace
+M.vscode_owned_ns = ns
+
+return M

--- a/runtime/lua/vscode/highlight.lua
+++ b/runtime/lua/vscode/highlight.lua
@@ -13,6 +13,5 @@ local function ignore_highlights()
     vim.api.nvim_set_hl(0, "Whitespace", {})
 end
 
--- remove highlight groups that should never be shown
 ignore_highlights()
 vim.api.nvim_create_autocmd({ "FileType", "ColorScheme" }, { callback = ignore_highlights })

--- a/runtime/lua/vscode/highlight.lua
+++ b/runtime/lua/vscode/highlight.lua
@@ -1,98 +1,18 @@
-local M = {}
+-- disable matchparen because we don't need it
+vim.g.loaded_matchparen = 1
+
+-- syntax groups that are hidden by default but can be overridden by `vscode-neovim.highlightGroups.highlights` or init.vim config (inside ColorScheme au)
+local function ignore_highlights()
+    vim.api.nvim_set_hl(0, "Normal", {})
+    vim.api.nvim_set_hl(0, "NormalNC", {})
+    vim.api.nvim_set_hl(0, "NormalFloat", {})
+    vim.api.nvim_set_hl(0, "NonText", {})
+    vim.api.nvim_set_hl(0, "Visual", {})
+    vim.api.nvim_set_hl(0, "VisualNOS", {})
+    vim.api.nvim_set_hl(0, "Substitute", {})
+    vim.api.nvim_set_hl(0, "Whitespace", {})
+end
 
 -- remove highlight groups that should never be shown
-vim.api.nvim_create_autocmd({ "BufEnter", "FileType", "ColorScheme" }, {
-    callback = function()
-        vim.api.nvim_set_hl(0, "Normal", {})
-        vim.api.nvim_set_hl(0, "NormalNC", {})
-        vim.api.nvim_set_hl(0, "NormalFloat", {})
-        vim.api.nvim_set_hl(0, "NonText", {})
-        vim.api.nvim_set_hl(0, "SpecialKey", {})
-        vim.api.nvim_set_hl(0, "TermCursor", {})
-        vim.api.nvim_set_hl(0, "TermCursorNC", {})
-        vim.api.nvim_set_hl(0, "Visual", {})
-        vim.api.nvim_set_hl(0, "VisualNOS", {})
-        vim.api.nvim_set_hl(0, "Conceal", {})
-        vim.api.nvim_set_hl(0, "CursorLine", {})
-        vim.api.nvim_set_hl(0, "CursorLineNr", {})
-        vim.api.nvim_set_hl(0, "ColorColumn", {})
-        vim.api.nvim_set_hl(0, "LineNr", {})
-        vim.api.nvim_set_hl(0, "StatusLine", {})
-        vim.api.nvim_set_hl(0, "StatusLineNC", {})
-        vim.api.nvim_set_hl(0, "VertSplit", {})
-        vim.api.nvim_set_hl(0, "Title", {})
-        vim.api.nvim_set_hl(0, "WildMenu", {})
-        vim.api.nvim_set_hl(0, "Whitespace", {})
-    end
-})
-
--- hide highlight groups when vscode owns the buffer
--- todo: these seem arbitrary
-local ns = vim.api.nvim_create_namespace("vscode-owned-highlights")
-vim.api.nvim_set_hl(ns, "EndOfBuffer", {})
-vim.api.nvim_set_hl(ns, "ErrorMsg", {})
-vim.api.nvim_set_hl(ns, "MoreMsg", {})
-vim.api.nvim_set_hl(ns, "ModeMsg", {})
-vim.api.nvim_set_hl(ns, "Question", {})
-vim.api.nvim_set_hl(ns, "VisualNC", {})
-vim.api.nvim_set_hl(ns, "WarningMsg", {})
-vim.api.nvim_set_hl(ns, "Sign", {})
-vim.api.nvim_set_hl(ns, "SignColumn", {})
-vim.api.nvim_set_hl(ns, "ColorColumn", {})
-vim.api.nvim_set_hl(ns, "QuickFixLine", {})
-vim.api.nvim_set_hl(ns, "MsgSeparator", {})
-vim.api.nvim_set_hl(ns, "MsgArea", {})
-vim.api.nvim_set_hl(ns, "MatchParen", {})
-vim.api.nvim_set_hl(ns, "MatchIt", {})
-vim.api.nvim_set_hl(ns, "Operator", {})
-vim.api.nvim_set_hl(ns, "Delimiter", {})
-vim.api.nvim_set_hl(ns, "Identifier", {})
-vim.api.nvim_set_hl(ns, "SpecialChar", {})
-vim.api.nvim_set_hl(ns, "Number", {})
-vim.api.nvim_set_hl(ns, "Type", {})
-vim.api.nvim_set_hl(ns, "String", {})
-vim.api.nvim_set_hl(ns, "Error", {})
-vim.api.nvim_set_hl(ns, "Comment", {})
-vim.api.nvim_set_hl(ns, "Constant", {})
-vim.api.nvim_set_hl(ns, "Special", {})
-vim.api.nvim_set_hl(ns, "Statement", {})
-vim.api.nvim_set_hl(ns, "PreProc", {})
-vim.api.nvim_set_hl(ns, "Underlined", {})
-vim.api.nvim_set_hl(ns, "Ignore", {})
-vim.api.nvim_set_hl(ns, "Todo", {})
-vim.api.nvim_set_hl(ns, "Character", {})
-vim.api.nvim_set_hl(ns, "Boolean", {})
-vim.api.nvim_set_hl(ns, "Float", {})
-vim.api.nvim_set_hl(ns, "Function", {})
-vim.api.nvim_set_hl(ns, "Conditional", {})
-vim.api.nvim_set_hl(ns, "Repeat", {})
-vim.api.nvim_set_hl(ns, "Label", {})
-vim.api.nvim_set_hl(ns, "Keyword", {})
-vim.api.nvim_set_hl(ns, "Exception", {})
-vim.api.nvim_set_hl(ns, "Include", {})
-vim.api.nvim_set_hl(ns, "Define", {})
-vim.api.nvim_set_hl(ns, "Macro", {})
-vim.api.nvim_set_hl(ns, "PreCondit", {})
-vim.api.nvim_set_hl(ns, "StorageClass", {})
-vim.api.nvim_set_hl(ns, "Structure", {})
-vim.api.nvim_set_hl(ns, "Typedef", {})
-vim.api.nvim_set_hl(ns, "Tag", {})
-vim.api.nvim_set_hl(ns, "SpecialComment", {})
-vim.api.nvim_set_hl(ns, "Debug", {})
-vim.api.nvim_set_hl(ns, "Folded", {})
-vim.api.nvim_set_hl(ns, "FoldColumn", {})
-
-vim.api.nvim_create_autocmd({ "BufEnter", "FileType", "ColorScheme" }, {
-    callback = function()
-        if vim.b.vscode_controlled then
-            vim.api.nvim_set_hl_ns(ns)
-        else
-            vim.api.nvim_set_hl_ns(0)
-        end
-    end
-})
-
--- if users want to ignore their own highlights in vscode owned buffers, they can use this namespace
-M.vscode_owned_ns = ns
-
-return M
+ignore_highlights()
+vim.api.nvim_create_autocmd({ "FileType", "ColorScheme" }, { callback = ignore_highlights })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const neovimPath = getNeovimPath();
     const isWindows = process.platform == "win32";
 
-    const highlightConfIgnore = settings.get("highlightGroups.ignoreHighlights");
     const highlightConfHighlights = settings.get("highlightGroups.highlights");
-    const highlightConfUnknown = settings.get("highlightGroups.unknownHighlight");
     const useCtrlKeysNormalMode = settings.get("useCtrlKeysForNormalMode", true);
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
     const useWsl = isWindows && settings.get("useWSL", false);
@@ -38,8 +36,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             extensionPath: context.extensionPath.replace(/\\/g, "\\\\"),
             highlightsConfiguration: {
                 highlights: highlightConfHighlights,
-                ignoreHighlights: highlightConfIgnore,
-                unknownHighlight: highlightConfUnknown,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any,
             neovimPath: neovimPath,

--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -38,9 +38,11 @@ export class HighlightManager implements Disposable, NeovimRedrawProcessable {
                         never,
                         [{ kind: "ui" | "syntax" | "terminal"; ui_name: string; hi_name: string }],
                     ][]) {
-                        // if this hl consists of only one group, apply a custom decoration if applicable
-                        const name = info && info.length === 1 ? info[0].hi_name : undefined;
-                        this.highlightProvider.addHighlightGroup(id, uiAttrs, name);
+                        this.highlightProvider.addHighlightGroup(
+                            id,
+                            uiAttrs,
+                            info.map((i) => i.hi_name),
+                        );
                     }
                     break;
                 }

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -404,23 +404,6 @@ export class HighlightProvider {
         return result;
     }
 
-    public clearHighlights(grid: number): [TextEditorDecorationType, Range[]][] {
-        const prevHighlights = this.prevGridHighlightsIds.get(grid);
-        this.highlights.delete(grid);
-        this.prevGridHighlightsIds.delete(grid);
-        if (!prevHighlights) {
-            return [];
-        }
-        const result: [TextEditorDecorationType, Range[]][] = [];
-        for (const id of prevHighlights) {
-            const decorator = this.getDecoratorForHighlightId(id);
-            if (decorator) {
-                result.push([decorator, []]);
-            }
-        }
-        return result;
-    }
-
     private createDecoratorForHighlightId(id: number, options: ThemableDecorationRenderOptions): void {
         const decorator = window.createTextEditorDecorationType(options);
         this.decoratorConfigurations.set(decorator, options);

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -135,8 +135,9 @@ export class HighlightProvider {
     }
 
     public addHighlightGroup(id: number, attrs: VimHighlightUIAttributes, groups: string[]): void {
-        // if this hl consists of only one group, apply a custom decoration if applicable
-        const customHl = groups.length === 1 && this.configuration.highlights[groups[0]];
+        // if the highlight consists of any custom groups, use that instead
+        const customName = groups.reverse().find((g) => this.configuration.highlights[g] !== undefined);
+        const customHl = customName && this.configuration.highlights[customName];
         if (customHl && customHl !== "vim") {
             // no need to create custom decorator if already exists
             if (!this.highlighIdToDecorator.has(id)) {

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -118,7 +118,6 @@ export class HighlightProvider {
      * HL group id to text decorator
      */
     private highlighIdToDecorator: Map<number, TextEditorDecorationType> = new Map();
-    private highlighIdToGroup: Map<number, string> = new Map();
     /**
      * Store configuration per decorator
      */
@@ -135,9 +134,9 @@ export class HighlightProvider {
         }
     }
 
-    public addHighlightGroup(id: number, attrs: VimHighlightUIAttributes, name: string | undefined): void {
-        this.highlighIdToGroup.set(id, name || "");
-        const customHl = name && this.configuration.highlights[name];
+    public addHighlightGroup(id: number, attrs: VimHighlightUIAttributes, groups: string[]): void {
+        // if this hl consists of only one group, apply a custom decoration if applicable
+        const customHl = groups.length === 1 && this.configuration.highlights[groups[0]];
         if (customHl && customHl !== "vim") {
             // no need to create custom decorator if already exists
             if (!this.highlighIdToDecorator.has(id)) {
@@ -146,9 +145,11 @@ export class HighlightProvider {
         } else {
             // remove if exists
             if (this.highlighIdToDecorator.has(id)) this.highlighIdToDecorator.get(id)?.dispose();
-            const options = customHl || "vim";
-            const conf = options === "vim" ? vimHighlightToVSCodeOptions(attrs) : options;
-            this.createDecoratorForHighlightId(id, conf);
+            // don't create decoration for empty attrs
+            if (Object.keys(attrs).length) {
+                const conf = vimHighlightToVSCodeOptions(attrs);
+                this.createDecoratorForHighlightId(id, conf);
+            }
         }
     }
 

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -25,14 +25,6 @@ export interface VimHighlightUIAttributes {
 
 export interface HighlightConfiguration {
     /**
-     * Ignore highlights
-     */
-    ignoreHighlights: string[];
-    /**
-     * What to do on unknown highlights. Either accept vim or use vscode decorator configuration
-     */
-    unknownHighlight: "vim" | ThemableDecorationRenderOptions;
-    /**
      * Map specific highlight to use either vim configuration or use vscode decorator configuration
      */
     highlights: {
@@ -40,14 +32,8 @@ export interface HighlightConfiguration {
     };
 }
 
-export interface HightlightExtMark {
+export interface Highlight {
     hlId: number;
-    /**
-     * :h nvim_buf_set_extmark()
-     * mapping with virt_text_pos on ext_mark in neovim
-     * currently support overylay option
-     */
-    virtTextPos?: "overlay" | "right_align" | "eol";
     virtText?: string;
     overlayPos?: number;
     line?: string;
@@ -126,21 +112,13 @@ export class HighlightProvider {
     /**
      * Current HL. key is the grid id and values is two dimension array representing rows and cols. Array may contain empty values
      */
-    private highlights: Map<number, HightlightExtMark[][]> = new Map();
-    private prevGridHighlightsIds: Map<number, Set<string>> = new Map();
+    private highlights: Map<number, Highlight[][]> = new Map();
+    private prevGridHighlightsIds: Map<number, Set<number>> = new Map();
     /**
-     * Maps highlight id to highlight group name
+     * HL group id to text decorator
      */
-    private highlightIdToGroupName: Map<number, string> = new Map();
-    /**
-     * Maps highlight id can be overlay with extmark
-     */
-    private highlightIdToOverlay: Map<number, boolean> = new Map();
-    /**
-     * HL group name to text decorator
-     * Not all HL groups are supported now
-     */
-    private highlighGroupToDecorator: Map<string, TextEditorDecorationType> = new Map();
+    private highlighIdToDecorator: Map<number, TextEditorDecorationType> = new Map();
+    private highlighIdToGroup: Map<number, string> = new Map();
     /**
      * Store configuration per decorator
      */
@@ -148,98 +126,34 @@ export class HighlightProvider {
 
     private configuration: HighlightConfiguration;
 
-    /**
-     * Set of ignored HL group ids. They can still be used with force flag (mainly for statusbar color decorations)
-     */
-    private ignoredGroupIds: Set<number> = new Set();
-    /**
-     * List of always ignored groups
-     */
-    private alwaysIgnoreGroups = [
-        "Normal",
-        "NormalNC",
-        "NormalFloat",
-        "NonText",
-        "SpecialKey",
-        "TermCursor",
-        "TermCursorNC",
-        // "Visual",
-        "Conceal",
-        "CursorLine",
-        "CursorLineNr",
-        "ColorColumn",
-        "LineNr",
-        "StatusLine",
-        "StatusLineNC",
-        "VertSplit",
-        "Title",
-        "WildMenu",
-        "Whitespace",
-    ];
-
     public constructor(conf: HighlightConfiguration) {
         this.configuration = conf;
-        if (this.configuration.unknownHighlight !== "vim") {
-            this.configuration.unknownHighlight = normalizeDecorationConfig(this.configuration.unknownHighlight);
-        }
         for (const [key, config] of Object.entries(this.configuration.highlights)) {
             if (config !== "vim") {
-                const options = normalizeDecorationConfig(config);
-                this.configuration.highlights[key] = options;
-                // precreate groups if configuration was defined
-                this.createDecoratorForHighlightGroup(key, options);
+                this.configuration.highlights[key] = normalizeDecorationConfig(config);
             }
         }
     }
 
-    public addHighlightGroup(id: number, name: string, vimUiAttrs: VimHighlightUIAttributes): void {
-        if (
-            this.configuration.ignoreHighlights.includes(name) ||
-            this.configuration.ignoreHighlights.find((i) =>
-                i.startsWith("^") || i.endsWith("$") ? new RegExp(i).test(name) : false,
-            )
-        ) {
-            this.ignoredGroupIds.add(id);
-        }
-        if (this.highlighGroupToDecorator.has(name)) this.highlighGroupToDecorator.get(name)?.dispose();
-        this.highlightIdToGroupName.set(id, name);
-        const options = this.configuration.highlights[name] || this.configuration.unknownHighlight;
-        const conf = options === "vim" ? vimHighlightToVSCodeOptions(vimUiAttrs) : options;
-
-        if (!this.ignoredGroupIds.has(id) && !this.configuration.highlights[name]) {
-            this.highlightIdToOverlay.set(id, true);
-        }
-        this.createDecoratorForHighlightGroup(name, conf);
-    }
-
-    public getHighlightGroupName(id: number, force = false): string | undefined {
-        if (this.ignoredGroupIds.has(id) && !force) {
-            return;
-        }
-        const name = this.highlightIdToGroupName.get(id);
-        if (name && this.alwaysIgnoreGroups.includes(name)) {
-            return;
-        }
-        return name;
-    }
-
-    public getDecoratorForHighlightGroup(name: string): TextEditorDecorationType | undefined {
-        let dec = this.highlighGroupToDecorator.get(name);
-        // replace MatchParenVisual with Visual, for example
-        for (const ignore of this.configuration.ignoreHighlights) {
-            if (ignore.startsWith("^") || ignore.endsWith("$")) {
-                name = name.replace(ignore.startsWith("^") ? ignore.slice(1) : ignore.slice(0, -1), "");
-            } else {
-                name = name.replace(ignore, "");
+    public addHighlightGroup(id: number, attrs: VimHighlightUIAttributes, name: string | undefined): void {
+        this.highlighIdToGroup.set(id, name || "");
+        const customHl = name && this.configuration.highlights[name];
+        if (customHl && customHl !== "vim") {
+            // no need to create custom decorator if already exists
+            if (!this.highlighIdToDecorator.has(id)) {
+                this.createDecoratorForHighlightId(id, customHl);
             }
+        } else {
+            // remove if exists
+            if (this.highlighIdToDecorator.has(id)) this.highlighIdToDecorator.get(id)?.dispose();
+            const options = customHl || "vim";
+            const conf = options === "vim" ? vimHighlightToVSCodeOptions(attrs) : options;
+            this.createDecoratorForHighlightId(id, conf);
         }
-        if (!dec && name.endsWith("Default")) {
-            dec = this.highlighGroupToDecorator.get(name.slice(0, -7));
-        }
-        if (!dec) {
-            dec = this.highlighGroupToDecorator.get(name + "Default");
-        }
-        return dec;
+    }
+
+    public getDecoratorForHighlightId(id: number): TextEditorDecorationType | undefined {
+        return this.highlighIdToDecorator.get(id);
     }
 
     public getDecoratorOptions(decorator: TextEditorDecorationType): ThemableDecorationRenderOptions {
@@ -259,7 +173,6 @@ export class HighlightProvider {
         row: number,
         start: number,
         lineText: string,
-        external: boolean,
         cells: [string, number?, number?][],
     ): boolean {
         let cellHlId = 0;
@@ -270,7 +183,9 @@ export class HighlightProvider {
         const gridHl = this.highlights.get(grid)!;
         let hasUpdates = false;
 
-        for (const [text, hlId, repeat] of cells) {
+        for (const [ctext, hlId, repeat] of cells) {
+            let text = ctext;
+
             // 2+bytes chars (such as chinese characters) have "" as second cell
             if (text === "") {
                 continue;
@@ -282,31 +197,25 @@ export class HighlightProvider {
             if (hlId != null) {
                 cellHlId = hlId;
             }
-            const groupName = this.getHighlightGroupName(cellHlId, external);
-            const canOverLay = this.highlightIdToOverlay.get(cellHlId);
 
             const listCharsTab = "❥";
 
             const repeatTo = text === "\t" || text === listCharsTab ? 1 : repeat || 1;
-            // const repeatTo =
-            //     text === "\t" || line[cellIdx] === "\t" ? Math.ceil((repeat || tabSize) / tabSize) : repeat || 1;
             for (let i = 0; i < repeatTo; i++) {
                 if (!gridHl[row]) {
                     gridHl[row] = [];
                 }
-                if (groupName) {
+                if (cellHlId != 0) {
                     hasUpdates = true;
-                    const hlDeco: HightlightExtMark = {
+                    const hlDeco: Highlight = {
                         hlId: cellHlId,
                     };
-                    if (canOverLay) {
-                        const curChar = lineText.slice(cellIdx, cellIdx + text.length);
-                        // text is not same as the cell text on buffer
-                        if (curChar != text && text != "" && text != listCharsTab) {
-                            hlDeco.virtText = text;
-                            hlDeco.virtTextPos = "overlay";
-                            hlDeco.overlayPos = lineText.length > 0 ? cellIdx : 1;
-                        }
+                    const curChar = lineText.slice(cellIdx, cellIdx + text.length);
+                    // text is not same as the cell text on buffer
+                    if (text === listCharsTab) text = "\t";
+                    if (curChar !== text && text !== "") {
+                        hlDeco.virtText = text;
+                        hlDeco.overlayPos = lineText.length > 0 ? cellIdx : 1;
                     }
                     gridHl[row][cellIdx] = hlDeco;
                 } else if (gridHl[row][cellIdx]) {
@@ -368,14 +277,13 @@ export class HighlightProvider {
     ): [TextEditorDecorationType, DecorationOptions[]][] {
         const result: [TextEditorDecorationType, DecorationOptions[]][] = [];
         const hlRanges: Map<
-            string,
-            Array<{ lineS: number; lineE: number; colS: number; colE: number; hl?: HightlightExtMark }>
+            number,
+            Array<{ lineS: number; lineE: number; colS: number; colE: number; hl?: Highlight }>
         > = new Map();
         const gridHl = this.highlights.get(grid);
 
         if (gridHl) {
-            // let currHlId = 0;
-            let currHlName = "";
+            let currHlId = 0;
             let currHlStartRow = 0;
             let currHlEndRow = 0;
             let currHlStartCol = 0;
@@ -383,13 +291,12 @@ export class HighlightProvider {
             // forEach faster than for in/of for arrays while iterating on array with empty values
             gridHl.forEach((rowHighlights, rowIdx) => {
                 rowHighlights.forEach((hlDeco, cellIdx) => {
-                    const cellHlName = this.highlightIdToGroupName.get(hlDeco.hlId);
-                    if (cellHlName && hlDeco.virtTextPos === "overlay") {
-                        if (!hlRanges.has(cellHlName)) {
-                            hlRanges.set(cellHlName, []);
+                    if (hlDeco.virtText) {
+                        if (!hlRanges.has(hlDeco.hlId)) {
+                            hlRanges.set(hlDeco.hlId, []);
                         }
                         // it only has one character we don't need group like normal highlight
-                        hlRanges.get(cellHlName)!.push({
+                        hlRanges.get(hlDeco.hlId)!.push({
                             lineS: rowIdx,
                             lineE: rowIdx,
                             colS: hlDeco.overlayPos || cellIdx,
@@ -399,45 +306,42 @@ export class HighlightProvider {
                         return;
                     }
                     if (
-                        cellHlName &&
-                        currHlName === cellHlName &&
+                        currHlId === hlDeco.hlId &&
                         // allow to extend prev HL if on same row and next cell OR previous row and end of range is end col
                         currHlEndRow === rowIdx &&
                         currHlEndCol === cellIdx - 1
                     ) {
                         currHlEndCol = cellIdx;
                     } else {
-                        if (currHlName) {
-                            if (!hlRanges.has(currHlName)) {
-                                hlRanges.set(currHlName, []);
+                        if (currHlId) {
+                            if (!hlRanges.has(currHlId)) {
+                                hlRanges.set(currHlId, []);
                             }
-                            hlRanges.get(currHlName)!.push({
+                            hlRanges.get(currHlId)!.push({
                                 lineS: currHlStartRow,
                                 lineE: currHlEndRow,
                                 colS: currHlStartCol,
                                 colE: currHlEndCol,
                             });
-                            currHlName = "";
+                            currHlId = 0;
                             currHlStartCol = 0;
                             currHlEndCol = 0;
                             currHlStartRow = 0;
                             currHlEndRow = 0;
                         }
-                        if (cellHlName) {
-                            currHlName = cellHlName;
-                            currHlStartRow = rowIdx;
-                            currHlEndRow = rowIdx;
-                            currHlStartCol = cellIdx;
-                            currHlEndCol = cellIdx;
-                        }
+                        currHlId = hlDeco.hlId;
+                        currHlStartRow = rowIdx;
+                        currHlEndRow = rowIdx;
+                        currHlStartCol = cellIdx;
+                        currHlEndCol = cellIdx;
                     }
                 });
             });
-            if (currHlName) {
-                if (!hlRanges.has(currHlName)) {
-                    hlRanges.set(currHlName, []);
+            if (currHlId) {
+                if (!hlRanges.has(currHlId)) {
+                    hlRanges.set(currHlId, []);
                 }
-                hlRanges.get(currHlName)!.push({
+                hlRanges.get(currHlId)!.push({
                     lineS: currHlStartRow,
                     lineE: currHlEndRow,
                     colS: currHlStartCol,
@@ -445,8 +349,8 @@ export class HighlightProvider {
                 });
             }
         }
-        for (const [groupName, ranges] of hlRanges) {
-            const decorator = this.getDecoratorForHighlightGroup(groupName);
+        for (const [id, ranges] of hlRanges) {
+            const decorator = this.getDecoratorForHighlightId(id);
             if (!decorator) {
                 continue;
             }
@@ -484,9 +388,9 @@ export class HighlightProvider {
 
         const prevHighlights = this.prevGridHighlightsIds.get(grid);
         if (prevHighlights) {
-            for (const groupName of prevHighlights) {
-                if (!hlRanges.has(groupName)) {
-                    const decorator = this.getDecoratorForHighlightGroup(groupName);
+            for (const id of prevHighlights) {
+                if (!hlRanges.has(id)) {
+                    const decorator = this.getDecoratorForHighlightId(id);
                     if (!decorator) {
                         continue;
                     }
@@ -506,8 +410,8 @@ export class HighlightProvider {
             return [];
         }
         const result: [TextEditorDecorationType, Range[]][] = [];
-        for (const groupName of prevHighlights) {
-            const decorator = this.getDecoratorForHighlightGroup(groupName);
+        for (const id of prevHighlights) {
+            const decorator = this.getDecoratorForHighlightId(id);
             if (decorator) {
                 result.push([decorator, []]);
             }
@@ -515,10 +419,10 @@ export class HighlightProvider {
         return result;
     }
 
-    private createDecoratorForHighlightGroup(groupName: string, options: ThemableDecorationRenderOptions): void {
+    private createDecoratorForHighlightId(id: number, options: ThemableDecorationRenderOptions): void {
         const decorator = window.createTextEditorDecorationType(options);
         this.decoratorConfigurations.set(decorator, options);
-        this.highlighGroupToDecorator.set(groupName, decorator);
+        this.highlighIdToDecorator.set(id, decorator);
     }
 
     public createVirtTextDecorationOption(

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -96,7 +96,7 @@ export class MainController implements vscode.Disposable {
 
         // These paths get called inside WSL, they must be POSIX paths (forward slashes)
         const neovimPreScriptPath = path.posix.join(extensionPath, "vim", "vscode-neovim.vim");
-        const neovimPostScriptPath = path.posix.join(extensionPath, "runtime/lua", "vscode/options.lua");
+        const neovimPostScriptPath = path.posix.join(extensionPath, "runtime/lua", "vscode/force_options.lua");
 
         const args = [
             "-N",

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -200,9 +200,7 @@ export class MainController implements vscode.Disposable {
         );
         this.disposables.push(this.viewportManager);
 
-        this.highlightManager = new HighlightManager(this.logger, this, {
-            highlight: this.settings.highlightsConfiguration,
-        });
+        this.highlightManager = new HighlightManager(this, this.settings.highlightsConfiguration);
         this.disposables.push(this.highlightManager);
 
         this.changeManager = new DocumentChangeManager(this.logger, this.client, this);
@@ -273,7 +271,6 @@ export class MainController implements vscode.Disposable {
             this.commandsController,
             this.bufferManager,
             this.viewportManager,
-            this.highlightManager,
             this.cursorManager,
         ];
         const vscodeComandManagers: NeovimCommandProcessable[] = [this.customCommandsManager];
@@ -333,7 +330,6 @@ export class MainController implements vscode.Disposable {
             this.changeManager,
             this.commandsController,
             this.bufferManager,
-            this.highlightManager,
             this.cursorManager,
         ];
         const vscodeCommandManagers: NeovimCommandProcessable[] = [this.customCommandsManager];

--- a/src/test/suite/dot-repeat.test.ts
+++ b/src/test/suite/dot-repeat.test.ts
@@ -429,7 +429,8 @@ describe("Dot-repeat", () => {
     it("With o and undo", async () => {
         await openTextDocument({ content: ["test1", "test2", "test3"].join("\n") });
 
-        await sendVSCodeKeys("o\n\n\n");
+        await sendInsertKey("o");
+        await sendVSCodeKeys("\n\n\n");
         await sendEscapeKey();
 
         await sendVSCodeKeys("j.");


### PR DESCRIPTION
This attempts to simplify the highlight manager and improve the mechanism for ignoring syntax groups.

Instead of providing vscode options to do this, it instead relies on neovim configuration to effectively erase the syntax groups. 

Ref: https://github.com/vscode-neovim/vscode-neovim/issues/1264
