### PR TITLE
feat(options): synchronize editor line number style

### DIFF
--- a/runtime/lua/vscode/force_options.lua
+++ b/runtime/lua/vscode/force_options.lua
@@ -56,3 +56,18 @@ forceoptions(vim.opt)
 vim.api.nvim_create_autocmd({ "BufEnter", "FileType" }, {
     callback = function() forceoptions(vim.opt_local) end,
 })
+
+-- send option changes to vscode, and then reset
+vim.api.nvim_create_autocmd({ "OptionSet" }, {
+    callback = function(ev)
+        vim.fn.VSCodeExtensionNotify("option-set", vim.fn.win_getid(), ev.match,
+            {
+                option_type = vim.v.option_type,
+                option_new = vim.v.option_new,
+                option_oldlocal = vim.v.option_oldlocal,
+                option_oldglobal = vim.v.option_oldglobal,
+                option_old = vim.v.option_old
+            })
+        forceoptions(vim.opt)
+    end
+})

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -218,7 +218,7 @@ export class MainController implements vscode.Disposable {
         this.statusLineManager = new StatusLineManager(this.logger, this.client);
         this.disposables.push(this.statusLineManager);
 
-        this.customCommandsManager = new CustomCommandsManager(this.logger);
+        this.customCommandsManager = new CustomCommandsManager(this.logger, this);
         this.disposables.push(this.customCommandsManager);
 
         this.multilineMessagesManager = new MutlilineMessagesManager(this.logger);
@@ -269,6 +269,7 @@ export class MainController implements vscode.Disposable {
             this.modeManager,
             this.changeManager,
             this.commandsController,
+            this.customCommandsManager,
             this.bufferManager,
             this.viewportManager,
             this.cursorManager,
@@ -329,6 +330,7 @@ export class MainController implements vscode.Disposable {
             this.modeManager,
             this.changeManager,
             this.commandsController,
+            this.customCommandsManager,
             this.bufferManager,
             this.cursorManager,
         ];


### PR DESCRIPTION
Fixes https://github.com/vscode-neovim/vscode-neovim/issues/1263, fixes https://github.com/vscode-neovim/vscode-neovim/issues/175, supersedes https://github.com/vscode-neovim/vscode-neovim/pull/656.

For now, this PR just syncs number/relative number, but lays the groundwork for syncing more options. This allows for smart relative numbers (https://github.com/jeffkreeftmeijer/vim-numbertoggle).

However, that specific plugin does not work, because it first checks if `nu` is set, but we force it to be off. 

A working snippet is 

```vim
augroup numbertoggle
  autocmd!
  autocmd BufEnter,FocusGained,InsertLeave,WinEnter * if mode() != "i" | set rnu   | endif
  autocmd BufLeave,FocusLost,InsertEnter,WinLeave   * if &nu           | set nornu | endif
augroup END
```