### PR TITLE
feat(document_change): extract nvim_input from document change

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ mode and editor commands, making the best use of both editors.
     -   [VSCode specific differences](#vscode-specific-differences)
     -   [Troubleshooting](#troubleshooting)
         -   [Performance problems](#performance-problems)
-    -   [Composite escape keys](#composite-escape-keys)
     -   [Jumplist](#jumplist)
     -   [Wildmenu completion](#wildmenu-completion)
     -   [Multiple cursors](#multiple-cursors)
@@ -179,35 +178,6 @@ If you have any performance problems (cursor jitter usually) make sure you're no
 
 If you're not sure, disable all other extensions, **reload VSCode window**, and see if the problem persists before
 reporting it.
-
-### Composite escape keys
-
-Since VSCode is responsible for insert mode, custom insert-mode VIM mappings don't work. To map composite escape keys,
-put into your keybindings.json:
-
-for <kbd>jj</kbd>
-
-```json
-{
-    "command": "vscode-neovim.compositeEscape1",
-    "key": "j",
-    "when": "neovim.mode == insert && editorTextFocus",
-    "args": "j"
-}
-```
-
-to enable <kbd>jk</kbd> add also:
-
-```json
-{
-    "command": "vscode-neovim.compositeEscape2",
-    "key": "k",
-    "when": "neovim.mode == insert && editorTextFocus",
-    "args": "k"
-}
-```
-
-Currently, there is no way to map both `jk` and `kj`, or to map `jk` without also mapping `jj`.
 
 ### Jumplist
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,6 @@ The VSCode keybindings editor provides a good way to delete keybindings.
 -   When you type some commands they may be substituted for the another, like `:write` will be replaced by `:Write`.
 -   Scrolling is done by VSCode. <kbd>C-d</kbd>/<kbd>C-u</kbd>/etc are slightly different.
 -   Editor customization (relative line number, scrolloff, etc) is handled by VSCode.
--   Dot-repeat (<kbd>.</kbd>) is slightly different - moving the cursor within a change range won't break the repeat.
-    sequence. In Neovim, if you type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here
-    the repeat sequence would be `1`. However in VSCode it would be `a1bc`. Another difference is that when you delete
-    some text in insert mode, dot repeat only works from right-to-left, meaning it will treat <kbd>Del</kbd> key as
-    <kbd>BS</kbd> keys when running dot repeat.
 
 ### Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -208,14 +208,6 @@
                 "title": "Neovim send escape key to neovim, or other keys that will exit insert mode"
             },
             {
-                "command": "vscode-neovim.compositeEscape1",
-                "title": "Composite escape key 1"
-            },
-            {
-                "command": "vscode-neovim.compositeEscape2",
-                "title": "Composite escape key 2"
-            },
-            {
                 "command": "vscode-neovim.commit-cmdline",
                 "title": "Neovim: Accept cmdline"
             },

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -58,14 +58,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 this.scrollLine(to);
                 break;
             }
-            case "insert-line": {
-                const [type] = args as ["before" | "after"];
-                await this.client.command("startinsert");
-                await vscode.commands.executeCommand(
-                    type === "before" ? "editor.action.insertLineBefore" : "editor.action.insertLineAfter",
-                );
-                break;
-            }
         }
     }
 

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -267,7 +267,6 @@ export class MainController implements vscode.Disposable {
         ];
         const extensionCommandManagers: NeovimExtensionRequestProcessable[] = [
             this.modeManager,
-            this.changeManager,
             this.commandsController,
             this.bufferManager,
             this.viewportManager,
@@ -327,7 +326,6 @@ export class MainController implements vscode.Disposable {
     ): Promise<void> => {
         const extensionCommandManagers: NeovimExtensionRequestProcessable[] = [
             this.modeManager,
-            this.changeManager,
             this.commandsController,
             this.bufferManager,
             this.cursorManager,

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -191,7 +191,6 @@ export class TypingManager implements Disposable {
                     window.activeTextEditor,
                     window.activeTextEditor.selection.active,
                 );
-            await this.main.changeManager.syncDotRepeatWithNeovim();
             const keys = normalizeInputString(this.pendingKeysAfterExit);
             this.logger.debug(`${LOG_PREFIX}: Pending keys sent with ${key}: ${keys}`);
             this.pendingKeysAfterExit = "";

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -38,10 +38,6 @@ export class TypingManager implements Disposable {
      */
     private pendingKeysAfterEnter = "";
     /**
-     * Timestamp when the first composite escape key was pressed. Using timestamp because timer may be delayed if the extension host is busy
-     */
-    private compositeEscapeFirstPressTimestamp?: number;
-    /**
      * Composing flag
      */
     private isInComposition = false;
@@ -63,16 +59,6 @@ export class TypingManager implements Disposable {
         this.disposables.push(commands.registerCommand("vscode-neovim.enable", () => this.onEnableCommand("enable")));
         this.disposables.push(commands.registerCommand("vscode-neovim.disable", () => this.onEnableCommand("disable")));
         this.disposables.push(commands.registerCommand("vscode-neovim.toggle", () => this.onEnableCommand("toggle")));
-        this.disposables.push(
-            commands.registerCommand("vscode-neovim.compositeEscape1", (key: string) =>
-                this.handleCompositeEscapeFirstKey(key),
-            ),
-        );
-        this.disposables.push(
-            commands.registerCommand("vscode-neovim.compositeEscape2", (key: string) =>
-                this.handleCompositeEscapeSecondKey(key),
-            ),
-        );
         this.disposables.push(commands.registerCommand("compositionStart", this.onCompositionStart));
         this.disposables.push(commands.registerCommand("compositionEnd", this.onCompositionEnd));
         this.main.modeManager.onModeChange(this.onModeChange);
@@ -233,29 +219,6 @@ export class TypingManager implements Disposable {
         if (this.neovimEnable || key !== "<Esc>") {
             this.isExitingInsertMode = true;
             await this.onSendBlockingCommand(key);
-        }
-    };
-
-    private handleCompositeEscapeFirstKey = async (key: string): Promise<void> => {
-        const now = new Date().getTime();
-        if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
-            this.compositeEscapeFirstPressTimestamp = undefined;
-            await commands.executeCommand("deleteLeft");
-            await this.onEscapeKeyCommand();
-        } else {
-            this.compositeEscapeFirstPressTimestamp = now;
-            await commands.executeCommand("type", { text: key });
-        }
-    };
-
-    private handleCompositeEscapeSecondKey = async (key: string): Promise<void> => {
-        const now = new Date().getTime();
-        if (this.compositeEscapeFirstPressTimestamp && now - this.compositeEscapeFirstPressTimestamp <= 200) {
-            this.compositeEscapeFirstPressTimestamp = undefined;
-            await commands.executeCommand("deleteLeft");
-            await this.onEscapeKeyCommand();
-        } else {
-            await commands.executeCommand("type", { text: key });
         }
     };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,4 @@
-import {
-    workspace,
-    TextEditor,
-    TextDocumentContentChangeEvent,
-    Position,
-    TextDocument,
-    EndOfLine,
-    Range,
-    TextEditorEdit,
-} from "vscode";
+import { workspace, TextEditor, Position, TextDocument, EndOfLine, Range, TextEditorEdit } from "vscode";
 import diff, { Diff } from "fast-diff";
 import { NeovimClient } from "neovim";
 import wcwidth from "ts-wcwidth";
@@ -26,32 +17,6 @@ export interface EditRange {
 }
 
 export type GridLineEvent = [number, number, number, [string, number, number][]];
-
-/**
- * Stores last changes information for dot repeat
- */
-export interface DotRepeatChange {
-    /**
-     * Num of deleted characters, 0 when only added
-     */
-    rangeLength: number;
-    /**
-     * Range offset
-     */
-    rangeOffset: number;
-    /**
-     * Change text
-     */
-    text: string;
-    /**
-     * Set if it was the first change and started either through o or O
-     */
-    startMode?: "o" | "O";
-    /**
-     * Text eol
-     */
-    eol: string;
-}
 
 // Copied from https://github.com/google/diff-match-patch/blob/master/javascript/diff_match_patch_uncompressed.js
 export function diffLineToChars(text1: string, text2: string): { chars1: string; chars2: string; lineArray: string[] } {
@@ -277,44 +242,6 @@ export function calculateEditorColFromVimScreenCol(line: string, screenCol: numb
     return currentCharIdx;
 }
 
-export function isChangeSubsequentToChange(
-    change: TextDocumentContentChangeEvent,
-    lastChange: DotRepeatChange,
-): boolean {
-    const lastChangeTextLength = lastChange.text.length;
-    const lastChangeOffsetStart = lastChange.rangeOffset;
-    const lastChangeOffsetEnd = lastChange.rangeOffset + lastChangeTextLength;
-
-    if (change.rangeOffset >= lastChangeOffsetStart && change.rangeOffset <= lastChangeOffsetEnd) {
-        return true;
-    }
-
-    if (
-        change.rangeOffset < lastChangeOffsetStart &&
-        change.rangeOffset + change.rangeLength >= lastChangeOffsetStart
-    ) {
-        return true;
-    }
-
-    return false;
-}
-
-export function isCursorChange(change: TextDocumentContentChangeEvent, cursor: Position, eol: string): boolean {
-    if (change.range.contains(cursor)) {
-        return true;
-    }
-    if (change.range.isSingleLine && change.text) {
-        const lines = change.text.split(eol);
-        const lineLength = lines.length;
-        const newEndLineRange = change.range.start.line + lineLength - 1;
-        const newEndLastLineCharRange = change.range.end.character + lines.slice(-1)[0].length;
-        if (newEndLineRange >= cursor.line && newEndLastLineCharRange >= cursor.character) {
-            return true;
-        }
-    }
-    return false;
-}
-
 type LegacySettingName = "neovimPath" | "neovimInitPath";
 type SettingPrefix = "neovimExecutablePaths" | "neovimInitVimPaths"; //this needs to be aligned with setting names in package.json
 type Platform = "win32" | "darwin" | "linux";
@@ -356,55 +283,6 @@ export function getNeovimInitPath(): string | undefined {
         vscodeSettingName: "neovimInitPath",
     } as const;
     return getSystemSpecificSetting("neovimInitVimPaths", legacySettingInfo);
-}
-
-export function normalizeDotRepeatChange(
-    change: TextDocumentContentChangeEvent,
-    eol: string,
-    startMode?: "o" | "O",
-): DotRepeatChange {
-    return {
-        rangeLength: change.rangeLength,
-        rangeOffset: change.rangeOffset,
-        text: change.text,
-        startMode,
-        eol,
-    };
-}
-
-export function accumulateDotRepeatChange(
-    change: TextDocumentContentChangeEvent,
-    lastChange: DotRepeatChange,
-): DotRepeatChange {
-    const newLastChange: DotRepeatChange = {
-        ...lastChange,
-    };
-
-    const removedLength =
-        change.rangeOffset <= lastChange.rangeOffset
-            ? change.rangeOffset - lastChange.rangeOffset + change.rangeLength
-            : change.rangeLength;
-
-    const sliceBeforeStart = 0;
-    const sliceBeforeEnd =
-        change.rangeOffset <= lastChange.rangeOffset
-            ? // ? sliceBeforeStart + removedLength
-              0
-            : change.rangeOffset - lastChange.rangeOffset;
-
-    const sliceAfterStart = change.rangeOffset - lastChange.rangeOffset + removedLength;
-
-    // adjust text
-    newLastChange.text =
-        lastChange.text.slice(sliceBeforeStart, sliceBeforeEnd) + change.text + lastChange.text.slice(sliceAfterStart);
-
-    // adjust offset & range length
-    // we need to account the case only when text was deleted before the original change
-    if (change.rangeOffset < lastChange.rangeOffset) {
-        newLastChange.rangeOffset = change.rangeOffset;
-        newLastChange.rangeLength += change.rangeLength;
-    }
-    return newLastChange;
 }
 
 export function getDocumentLineArray(doc: TextDocument): string[] {


### PR DESCRIPTION
Ref: https://github.com/vscode-neovim/vscode-neovim/issues/1266

This removes the need for the custom dot repeat hack and composite escape. For composite escape to work it currently needs https://github.com/max397574/better-escape.nvim.

I'm not sure if this is a viable option, just due to edge cases and bugs. However, worth investigating. 

Todo:

- [ ] handle moving cursor (like with auto parens)
- [ ] ignore document changes while in insert mode?
- [ ] consider what happens with pasting a line of code containing a composite escape
- [ ] try to remove need for better-escape (use vscode cursor instead, and ignore large movements)
- [ ] simplify code
- [ ] isolate situations where nvim_input is used 