### PR TITLE
feat(main): Add option to pass startup command

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
                     "default": false,
                     "markdownDescription": "Equivalent to the startup option `--clean`."
                 },
+                "vscode-neovim.neovimCmd": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Command passed to startup option `--cmd`, see `:h --cmd`"
+                },
                 "vscode-neovim.NVIM_APPNAME": {
                     "type": "string",
                     "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const neovimViewportHeightExtend = settings.get("neovimViewportHeightExtend", 1);
     const customInit = getNeovimInitPath() ?? "";
     const clean = settings.get("neovimClean", false);
+    const neovimCmd = settings.get("neovimCmd", "");
     const NVIM_APPNAME = settings.get("NVIM_APPNAME", "");
     const logPath = settings.get("logPath", "");
     const logLevel = settings.get("logLevel", "none");
@@ -32,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         const plugin = new MainController({
             customInitFile: customInit,
             clean: clean,
+            neovimCmd: neovimCmd,
             NVIM_APPNAME: NVIM_APPNAME,
             extensionPath: context.extensionPath.replace(/\\/g, "\\\\"),
             highlightsConfiguration: {

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -38,6 +38,7 @@ export interface ControllerSettings {
     useWsl: boolean;
     customInitFile: string;
     clean: boolean;
+    neovimCmd: string;
     NVIM_APPNAME: string;
     neovimViewportWidth: number;
     neovimViewportHeightExtend: number;
@@ -128,6 +129,9 @@ export class MainController implements vscode.Disposable {
         }
         if (settings.clean) {
             args.push("--clean");
+        }
+        if (settings.neovimCmd) {
+            args.push("--cmd", settings.neovimCmd);
         }
         if (settings.customInitFile) {
             args.push("-u", settings.customInitFile);


### PR DESCRIPTION
This adds `vscode-neovim.neovimCmd`  to pass startup command using `--cmd`.
