### PR TITLE
fix(cursor): re-add new VSCodeNotifyRange impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,29 @@ See gif in action:
 
 ### Invoking VSCode actions from neovim
 
-To invoke VSCode actions from Neovim, use `VSCodeNotify(command, args, ...)` or `VSCodeCall(command, args, ...)`
-functions. From lua, use `require("vscode-neovim").notify(command, args, ...)` or
-`require("vscode-neovim").call(command, args, ...)`. `Notify` is non-blocking, `Call` is blocking. Generally use Notify
-unless you really need a blocking call, such as wanting VSCode to process a visual selection before leaving it with
-<kbd>Esc</kbd>.
+There are a
+[few helper functions](https://github.com/vscode-neovim/vscode-neovim/blob/master/vim/vscode-neovim.vim#L17-L39) that
+are used to invoke VSCode commands from Neovim:
+
+| Command                                                                                                                                                                                                                             | Description                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <ul><li>`VSCodeNotify(command, ...)`</li><li>`VSCodeCall`</li><li>`require("vscode-neovim").notify`</li> <li>`require("vscode-neovim").call`</li></ul>                                                                              | Invoke VSCode command with optional arguments.                                                                                                                                                |
+| <ul><li>`VSCodeNotifyRange(command, line1, line2, leaveSelection, ...)` </li><li>`VSCodeCallRange`</li><li>`require("vscode-neovim").notify_range`</li><li>`require("vscode-neovim").call_range`</li></ul>                          | Produce linewise VSCode selection from `line1` to `line2` and invoke VSCode command. Setting `leaveSelection` to 1 keeps VSCode selection active after invoking the command. Line is 1-based. |
+| <ul><li>`VSCodeNotifyRangePos(command, line1, line2, pos1, pos2, leaveSelection ,...)`</li><li>`VSCodeCallRangePos`</li><li>`require("vscode-neovim").notify_range_pos`</li><li>`require("vscode-neovim").call_range_pos`</li></ul> | Produce characterwise VSCode selection from `line1.pos1` to `line2.pos2` and invoke VSCode command. Pos is \[1,1\]-based.                                                                     |
+
+> 💡 Functions with `Notify` in their name are non-blocking, the ones with `Call` are blocking. Generally **use Notify**
+> unless you really need a blocking call. One example of a blocking call is wanting VSCode to process a visual selection
+> when running a command before exiting visual mode.
 
 #### Examples
+
+Format selection (default binding):
+
+```vim
+xnoremap = <Cmd>call VSCodeCall('editor.action.formatSelection')<CR>
+nnoremap = <Cmd>call VSCodeCall('editor.action.formatSelection')<CR><Esc>
+nnoremap == <Cmd>call VSCodeCall('editor.action.formatSelection')<CR>
+```
 
 Open definition aside (default binding):
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ See gif in action:
 
 There are a
 [few helper functions](https://github.com/vscode-neovim/vscode-neovim/blob/master/vim/vscode-neovim.vim#L17-L39) that
-are used to invoke VSCode commands from Neovim:
+are used to invoke VSCode commands from Neovim. Note that the commands that start with `require("vscode-neovim")` are
+lua variants.
 
 | Command                                                                                                                                                                                                                             | Description                                                                                                                                                                                   |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/runtime/lua/vscode-neovim.lua
+++ b/runtime/lua/vscode-neovim.lua
@@ -6,6 +6,10 @@ local M = {}
 
 M.notify = api.notify
 M.call = api.call
+M.call_range = api.call_range
+M.notify_range = api.notify_range
+M.call_range_pos = api.call_range_pos
+M.notify_range_pos = api.notify_range_pos
 
 M.setup = function()
     defaults.setup()

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -23,6 +23,23 @@ function M.call_extension(command, ...)
     return vim.rpcrequest(vim.g.vscode_channel, plugin_event_name, command, { ... })
 end
 
+-- send command to vscode with range (line or char). [1, 1]-based.
+function M.call_range(command, line1, line2, leaveSelection, ...)
+    return M.call_extension('range-command', command, 'V', line1, line2, 1, 1, leaveSelection, { ... })
+end
+
+function M.notify_range(command, line1, line2, leaveSelection, ...)
+    return M.notify_extension('range-command', command, 'V', line1, line2, 1, 1, leaveSelection, { ... })
+end
+
+function M.call_range_pos(command, line1, line2, pos1, pos2, leaveSelection, ...)
+    return M.call_extension('range-command', command, 'v', line1, line2, pos1, pos2, leaveSelection, { ... })
+end
+
+function M.notify_range_pos(command, line1, line2, pos1, pos2, leaveSelection, ...)
+    return M.notify_extension('range-command', command, 'v', line1, line2, pos1, pos2, leaveSelection, { ... })
+end
+
 ---call from vscode to sync viewport with neovim
 ---@param vscode_topline number the top line of vscode visible range
 ---@param vscode_endline number the end line of vscode visible range

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -515,7 +515,7 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
         this.logger.debug(
             `${LOG_PREFIX}: Range command: ${command}, range: [${startLine}, ${startPos}] - [${endLine}, ${endPos}], leaveSelection: ${leaveSelection}`,
         );
-        const prevSelections = [...e.selections];
+        const prevSelections = e.selections;
         const selection = await this.createVisualSelection(
             e,
             new Mode(mode),

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -87,6 +87,29 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
                 }
                 break;
             }
+            case "range-command": {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const [vscodeCommand, mode, line1, line2, pos1, pos2, leaveSelection, inargs] = args as any;
+                try {
+                    this.handleRangeCommand(
+                        vscodeCommand,
+                        mode,
+                        line1,
+                        line2,
+                        pos1,
+                        pos2,
+                        !!leaveSelection,
+                        Array.isArray(inargs) ? inargs : [inargs],
+                    );
+                } catch (e) {
+                    this.logger.error(
+                        `${vscodeCommand} failed, range: [${line1}, ${line2}, ${pos1}, ${pos2}] args: ${JSON.stringify(
+                            inargs,
+                        )} error: ${(e as Error).message}`,
+                    );
+                }
+                break;
+            }
             case "visual-edit": {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const [append, visualMode, startLine, endLine, startCol, endCol, skipEmpty] = args as any;
@@ -248,7 +271,7 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
 
         const mode = this.main.modeManager.currentMode;
         if (mode.isVisual) {
-            selections = await this.createVisualSelection(editor, mode, active);
+            selections = await this.createVisualSelection(editor, mode, active, undefined);
         } else {
             this.logger.debug(`${LOG_PREFIX}: Updating cursor in editor pos: [${active.line}, ${active.character}]`);
             selections = [new Selection(active, active)];
@@ -375,11 +398,18 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
     }
 
     // given a neovim visual selection range (and the current mode), create a vscode selection
-    private createVisualSelection = async (editor: TextEditor, mode: Mode, active: Position): Promise<Selection[]> => {
+    private createVisualSelection = async (
+        editor: TextEditor,
+        mode: Mode,
+        active: Position,
+        anchor: Position | undefined,
+    ): Promise<Selection[]> => {
         const doc = editor.document;
 
-        const anchorNvim = await this.client.callFunction("getpos", ["v"]);
-        const anchor = convertVimPositionToEditorPosition(editor, new Position(anchorNvim[1] - 1, anchorNvim[2] - 1));
+        if (!anchor) {
+            const anchorNvim = await this.client.callFunction("getpos", ["v"]);
+            anchor = convertVimPositionToEditorPosition(editor, new Position(anchorNvim[1] - 1, anchorNvim[2] - 1));
+        }
 
         this.logger.debug(
             `${LOG_PREFIX}: Creating visual selection, mode: ${mode.visual}, anchor: [${anchor.line}, ${anchor.character}], active: [${active.line}, ${active.character}]`,
@@ -459,6 +489,49 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
         editor.revealRange(new Selection(pos, pos), type);
         this.main.viewportManager.scrollNeovim(editor);
     };
+
+    /**
+     * Produce vscode selection and execute command
+     * @param command VSCode command to execute
+     * @param startLine Start line to select. 1based
+     * @param endLine End line to select. 1based
+     * @param startPos Start pos to select. 1based. If 0 then whole line will be selected
+     * @param endPos End pos to select, 1based. If you then whole line will be selected
+     * @param leaveSelection When true won't clear vscode selection after running the command
+     * @param args Additional args
+     */
+    public async handleRangeCommand(
+        command: string,
+        mode: string,
+        startLine: number,
+        endLine: number,
+        startPos: number,
+        endPos: number,
+        leaveSelection: boolean,
+        args: unknown[],
+    ): Promise<unknown> {
+        const e = window.activeTextEditor;
+        if (!e) return;
+        this.logger.debug(
+            `${LOG_PREFIX}: Range command: ${command}, range: [${startLine}, ${startPos}] - [${endLine}, ${endPos}], leaveSelection: ${leaveSelection}`,
+        );
+        const prevSelections = [...e.selections];
+        const selection = await this.createVisualSelection(
+            e,
+            new Mode(mode),
+            new Position(endLine - 1, endPos - 1),
+            new Position(startLine - 1, startPos - 1),
+        );
+        this.neovimCursorPosition.set(e, selection[0]);
+        e.selections = selection;
+        const res = await commands.executeCommand(command, ...args);
+        this.logger.debug(`${LOG_PREFIX}: Range command completed`);
+        if (!leaveSelection) {
+            this.neovimCursorPosition.set(e, prevSelections[0]);
+            e.selections = prevSelections;
+        }
+        return res;
+    }
 
     private async multipleCursorFromVisualMode(
         append: boolean,

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -91,7 +91,7 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const [vscodeCommand, mode, line1, line2, pos1, pos2, leaveSelection, inargs] = args as any;
                 try {
-                    this.handleRangeCommand(
+                    await this.handleRangeCommand(
                         vscodeCommand,
                         mode,
                         line1,

--- a/src/custom_commands_manager.ts
+++ b/src/custom_commands_manager.ts
@@ -1,18 +1,25 @@
-import { commands, Disposable } from "vscode";
+import { commands, Disposable, window } from "vscode";
 
 import { Logger } from "./logger";
 import { NeovimCommandProcessable } from "./neovim_events_processable";
+import { MainController } from "./main_controller";
 
 export class CustomCommandsManager implements Disposable, NeovimCommandProcessable {
     private disposables: Disposable[] = [];
 
-    public constructor(private logger: Logger) {}
+    public constructor(
+        private logger: Logger,
+        private main: MainController,
+    ) {}
 
     public dispose(): void {
         this.disposables.forEach((d) => d.dispose());
     }
 
     public async handleVSCodeCommand(command: string, args: unknown[]): Promise<unknown> {
+        const editor = window.activeTextEditor;
+        if (!editor) return;
+        await this.main.cursorManager.waitForCursorUpdate(editor);
         const res = await commands.executeCommand(command, ...args);
         return res;
     }

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -218,7 +218,7 @@ export class MainController implements vscode.Disposable {
         this.statusLineManager = new StatusLineManager(this.logger, this.client);
         this.disposables.push(this.statusLineManager);
 
-        this.customCommandsManager = new CustomCommandsManager(this.logger);
+        this.customCommandsManager = new CustomCommandsManager(this.logger, this);
         this.disposables.push(this.customCommandsManager);
 
         this.multilineMessagesManager = new MutlilineMessagesManager(this.logger);

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -13,7 +13,7 @@ function! s:vscodeCommentary(...) abort
         let [line1, line2] = [line("'["), line("']")]
     endif
 
-    call VSCodeCallRange('editor.action.commentLine', line1, line2, 1)
+    call VSCodeCallRange('editor.action.commentLine', line1, line2, 0)
 endfunction
 
 

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -2,8 +2,30 @@
 xnoremap = <Cmd>call VSCodeCall('editor.action.formatSelection')<CR>
 nnoremap = <Cmd>call VSCodeCall('editor.action.formatSelection')<CR><Esc>
 nnoremap == <Cmd>call VSCodeCall('editor.action.formatSelection')<CR>
-xnoremap <C-/> <Cmd>call VSCodeCall('editor.action.commentLine')<CR><Esc>
-nnoremap <C-/> <Cmd>call VSCodeCall('editor.action.commentLine')<CR>
+
+function! s:vscodeCommentary(...) abort
+    if !a:0
+        let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
+        return 'g@'
+    elseif a:0 > 1
+        let [line1, line2] = [a:1, a:2]
+    else
+        let [line1, line2] = [line("'["), line("']")]
+    endif
+
+    call VSCodeCallRange('editor.action.commentLine', line1, line2, 1)
+endfunction
+
+
+command! -range -bar VSCodeCommentary call s:vscodeCommentary(<line1>, <line2>)
+
+xnoremap <expr> <Plug>VSCodeCommentary <SID>vscodeCommentary()
+nnoremap <expr> <Plug>VSCodeCommentary <SID>vscodeCommentary()
+nnoremap <expr> <Plug>VSCodeCommentaryLine <SID>vscodeCommentary() . '_'
+
+" Bind C-/ to vscode commentary to add dot-repeat and auto-deselection
+xnoremap <expr> <C-/> <SID>vscodeCommentary()
+nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
 function! s:vscodeGoToDefinition(str)
     if exists('b:vscode_controlled') && b:vscode_controlled

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -31,6 +31,22 @@ function! VSCodeExtensionNotify(cmd, ...)
     call rpcnotify(g:vscode_channel, s:vscodePluginEventName, a:cmd, a:000)
 endfunction
 
+function! VSCodeCallRange(cmd, line1, line2, leaveSelection, ...) abort
+    call VSCodeExtensionCall('range-command', a:cmd, 'V', a:line1, a:line2, 1, 1, a:leaveSelection, a:000)
+endfunction
+
+function! VSCodeNotifyRange(cmd, line1, line2, leaveSelection, ...)
+    call VSCodeExtensionNotify('range-command', a:cmd, 'V', a:line1, a:line2, 1, 1, a:leaveSelection, a:000)
+endfunction
+
+function! VSCodeCallRangePos(cmd, line1, line2, pos1, pos2, leaveSelection, ...) abort
+    call VSCodeExtensionCall('range-command', a:cmd, 'v', a:line1, a:line2, a:pos1, a:pos2, a:leaveSelection, a:000)
+endfunction
+
+function! VSCodeNotifyRangePos(cmd, line1, line2, pos1, pos2, leaveSelection, ...)
+    call VSCodeExtensionNotify('range-command', a:cmd, 'v', a:line1, a:line2, a:pos1, a:pos2, a:leaveSelection, a:000)
+endfunction
+
 " Called from extension when opening/creating new file in vscode to reset undo tree
 function! VSCodeClearUndo(bufId)
     let oldlevels = &undolevels


### PR DESCRIPTION
Adds `VSCodeNotifyRange` but with a more concise and accurate impl. Fixes https://github.com/vscode-neovim/vscode-neovim/issues/1355, fixes https://github.com/vscode-neovim/vscode-neovim/issues/1351, fixes https://github.com/vscode-neovim/vscode-neovim/issues/1345.

Also re-adds `VSCodeCommentary` and fixes a bug with `VSCodeNotify`.