### PR TITLE
fix(highlight): remove flash.nvim lag

### DIFF
--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -215,7 +215,7 @@ export class HighlightProvider {
                     const curChar = lineText.slice(cellIdx, cellIdx + text.length);
                     // text is not same as the cell text on buffer
                     if (text === listCharsTab) text = "\t";
-                    if (curChar !== text && text !== "") {
+                    if (curChar !== "" && text !== "" && curChar !== text) {
                         hlDeco.virtText = text;
                         hlDeco.overlayPos = lineText.length > 0 ? cellIdx : 1;
                     }
@@ -359,17 +359,13 @@ export class HighlightProvider {
             const decoratorRanges = ranges.map((r) => {
                 const lineLength = editor.document.lineAt(Math.min(topLine + r.lineS, editor.document.lineCount - 1))
                     .text.length;
-                const pastEnd = r.colE >= lineLength;
+                const pastEnd = r.colE >= lineLength && r.colS >= lineLength;
                 if (r.hl || pastEnd) {
                     const conf = this.getDecoratorOptions(decorator);
                     let text;
                     // if we are past end, or text is " ", we need to add something to make sure it gets rendered
                     if (r.hl) {
-                        if (r.hl.virtText == " ") {
-                            text = "\u200D";
-                        } else {
-                            text = r.hl.virtText!;
-                        }
+                        text = r.hl.virtText!.replace(" ", "\u200D");
                     } else {
                         text = "\u200D";
                     }

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -212,11 +212,13 @@ export class HighlightProvider {
                     const hlDeco: Highlight = {
                         hlId: cellHlId,
                     };
+                    // check if text is not same as the cell text on buffer
+                    // only render decorations one cell past the end of the line
                     const curChar = lineText.slice(cellIdx, cellIdx + text.length);
-                    // text is not same as the cell text on buffer
                     if (text === listCharsTab) text = "\t";
-                    if (curChar !== "" && text !== "" && curChar !== text) {
-                        hlDeco.virtText = text;
+                    if (cellIdx <= lineText.length && text !== "" && curChar !== text) {
+                        // if we are past end, or text is " ", we need to add something to make sure it gets rendered
+                        hlDeco.virtText = text.replace(" ", "\u200D");
                         hlDeco.overlayPos = lineText.length > 0 ? cellIdx : 1;
                     }
                     gridHl[row][cellIdx] = hlDeco;
@@ -359,18 +361,10 @@ export class HighlightProvider {
             const decoratorRanges = ranges.map((r) => {
                 const lineLength = editor.document.lineAt(Math.min(topLine + r.lineS, editor.document.lineCount - 1))
                     .text.length;
-                const pastEnd = r.colE >= lineLength && r.colS >= lineLength;
-                if (r.hl || pastEnd) {
+                if (r.hl) {
                     const conf = this.getDecoratorOptions(decorator);
-                    let text;
-                    // if we are past end, or text is " ", we need to add something to make sure it gets rendered
-                    if (r.hl) {
-                        text = r.hl.virtText!.replace(" ", "\u200D");
-                    } else {
-                        text = "\u200D";
-                    }
                     return this.createVirtTextDecorationOption(
-                        text,
+                        r.hl.virtText!,
                         { ...conf, backgroundColor: conf.backgroundColor || new ThemeColor("editor.background") }, // overwrite text underneath
                         topLine + r.lineS,
                         r.colS + 1,


### PR DESCRIPTION
The bug was caused due to the new behavior in 0.4.0 that can now render blank highlights, used for eol visual cursor and blank leap.nvim labels. However, flash.nvim adds its grey overlay to every single cell in the buffer, and so thousands of "blank" cells were trying to be rendered using text decoration. This commit makes it so it will only render highlights that are over text.

Fixes https://github.com/vscode-neovim/vscode-neovim/issues/1369, fixes https://github.com/vscode-neovim/vscode-neovim/issues/1349