### PR TITLE
fix(highlights): fix misaligned rendering in visual mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,9 +174,6 @@
                         "Search": {
                             "backgroundColor": "theme.editor.findMatchHighlightBackground",
                             "borderColor": "theme.editor.findMatchHighlightBorder"
-                        },
-                        "Visual": {
-                            "backgroundColor": "theme.editor.selectionBackground"
                         }
                     }
                 }

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -534,9 +534,6 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
         }
 
         const requests: [string, unknown[]][] = [
-            ["nvim_buf_set_option", [bufId, "expandtab", insertSpaces]],
-            ["nvim_buf_set_option", [bufId, "tabstop", tabSize]],
-            ["nvim_buf_set_option", [bufId, "shiftwidth", tabSize]],
             // fill the buffer
             ["nvim_buf_set_lines", [bufId, 0, -1, false, lines]],
             // set vscode controlled flag so we can check it neovim
@@ -552,6 +549,11 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
             ["nvim_buf_set_option", [bufId, "buftype", "nofile"]],
             // list buffer
             ["nvim_buf_set_option", [bufId, "buflisted", true]],
+            // nvim_buf_set_name will do filetype detection
+            // we must override tab options after vim initializes defaults
+            ["nvim_buf_set_option", [bufId, "expandtab", insertSpaces]],
+            ["nvim_buf_set_option", [bufId, "tabstop", tabSize]],
+            ["nvim_buf_set_option", [bufId, "shiftwidth", tabSize]],
         ];
         await callAtomic(this.client, requests, this.logger, LOG_PREFIX);
         // Looks like need to be in separate request


### PR DESCRIPTION
- Avoid duplicate selection highlighting
- Fix misaligned character rendering in visual mode

This is a very hidden bug, always thought it was a highlight-related logic problem, and gradually realized that it was caused by tabstop being out of sync. You guys can check the commit message for details.

fixes #1374, #1144