### PR TITLE
fix(cursor): decrease delay for debounce

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -345,7 +345,7 @@ export class CursorManager implements Disposable, NeovimRedrawProcessable, Neovi
                 await this.updateNeovimVisualSelection(editor, selection);
             }
         },
-        200,
+        20,
         { leading: false, trailing: true },
     );
 


### PR DESCRIPTION
200ms is too long and will cause the cursor to be out of sync when moving quickly and switching modes.

Can reproduced by: `llllv`, `lllla`, `2lv`, `2jv`, `2la`...
![cursor-out-of-sync](https://github.com/vscode-neovim/vscode-neovim/assets/47070852/511ce2ff-df79-47b0-8acc-44d603e8a8ac)
