### PR TITLE
feat(statusline): combine status line items

### DIFF
--- a/src/status_line.ts
+++ b/src/status_line.ts
@@ -1,46 +1,49 @@
-import * as vscode from "vscode";
+import { Disposable, StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
 
-export class StatusLineController implements vscode.Disposable {
-    private modeItem: vscode.StatusBarItem;
-    private commandItem: vscode.StatusBarItem;
-    private msgItem: vscode.StatusBarItem;
+// !Maybe we can support &statusline
+
+export class StatusLineController implements Disposable {
+    private _modeText = "";
+    private _statusText = "";
+    private _msgText = "";
+    private _seperator = " - ";
+
+    private statusBar: StatusBarItem;
 
     public constructor() {
-        this.modeItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
-        this.commandItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5);
-        this.msgItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
+        this.statusBar = window.createStatusBarItem(StatusBarAlignment.Left, 10);
+        this._seperator = workspace.getConfiguration("window").get("titleSeparator", this._seperator);
+    }
+
+    private refreshStatusBar() {
+        const items = [];
+        this._modeText.length && items.push(this._modeText);
+        this._statusText.length && items.push(this._statusText);
+        this._msgText.length && items.push(this._msgText);
+        if (items.length) {
+            this.statusBar.text = items.join(this._seperator);
+            this.statusBar.show();
+        } else {
+            this.statusBar.hide();
+        }
     }
 
     public set modeString(str: string) {
-        if (!str) {
-            this.modeItem.hide();
-        } else {
-            this.modeItem.text = str;
-            this.modeItem.show();
-        }
+        this._modeText = str;
+        this.refreshStatusBar();
     }
 
     public set statusString(str: string) {
-        if (!str) {
-            this.commandItem.hide();
-        } else {
-            this.commandItem.text = str;
-            this.commandItem.show();
-        }
+        this._statusText = str;
+        this.refreshStatusBar();
     }
 
     public set msgString(str: string) {
-        if (!str) {
-            this.msgItem.hide();
-        } else {
-            this.msgItem.text = str;
-            this.msgItem.show();
-        }
+        this._msgText = str;
+        this.refreshStatusBar();
     }
 
     public dispose(): void {
-        this.commandItem.dispose();
-        this.modeItem.dispose();
-        this.msgItem.dispose();
+        this.statusBar.dispose();
     }
 }


### PR DESCRIPTION
Currentlly, we use `window.titleSeparator` as the separator. Of course, it is best to provide a separate configuration, whether in vscode or nvim. But the priority is not high.

Resolve: #1251