### PR TITLE
Implement external buffer document provider

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -737,7 +737,9 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
     }
 
     private buildExternalBufferUri(name: string, id: number): Uri {
-        return Uri.from({ scheme: BUFFER_SCHEME, authority: id.toString(), path: name });
+        // These might not *always* be file names, but they often are (e.g. for :help) so
+        // make sure we properly convert slashes for the path component, especially on Windows
+        return Uri.file(name).with({ scheme: BUFFER_SCHEME, authority: id.toString() });
     }
 
     private async attachNeovimExternalBuffer(

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -805,7 +805,10 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
                     } catch (e) {
                         this.logger.warn(`${LOG_PREFIX}: Unable to get cursor pos for external buffer: ${id}`);
                     }
-                    editor.selections = [new Selection(finalLine, finalCol, finalLine, finalCol)];
+
+                    const selection = new Selection(finalLine, finalCol, finalLine, finalCol);
+                    editor.selections = [selection];
+                    editor.revealRange(selection, TextEditorRevealType.AtTop);
                 }
             }, 1000);
 

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -757,7 +757,14 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
     ): Promise<void> {
         const uri = this.buildExternalBufferUri(name, id);
         this.logger.debug(`${LOG_PREFIX}: opening external buffer ${uri}`);
-        const doc = await workspace.openTextDocument(uri);
+
+        let doc: TextDocument;
+        try {
+            doc = await workspace.openTextDocument(uri);
+        } catch (error) {
+            this.logger.debug(`${LOG_PREFIX}: unable to open external buffer: ${error}`);
+            return;
+        }
 
         this.externalTextDocuments.add(doc);
         this.textDocumentToBufferId.set(doc, id);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,12 @@ async function main(): Promise<void> {
         const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
         // Download VS Code, unzip it and run the integration test
-        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+        await runTests({
+            extensionDevelopmentPath,
+            extensionTestsPath,
+            // Tell vscode-neovim to create a debug connection
+            extensionTestsEnv: { NEOVIM_DEBUG: "1" },
+        });
     } catch (err) {
         console.error(err);
         console.error("Failed to run tests");

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -5,8 +5,6 @@ import glob from "glob";
 import "source-map-support/register";
 
 export async function run(): Promise<void> {
-    // Tell vscode-neovim to create a debug connection
-    process.env.NEOVIM_DEBUG = "1";
     // Create the mocha test
     const mocha = new Mocha({
         ui: "bdd",

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -57,9 +57,14 @@ export async function attachTestNvimClient(): Promise<NeovimClient> {
 export async function closeNvimClient(client: NeovimClient): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const conn: net.Socket = (client as any).testConn;
-    conn.destroy();
-    // client.quit();
+
+    // Try to gracefully close the socket first, this prevents noisy errors if it works.
+    // The Neovim server seems well-behaved normally and will close the connection.
+    conn.end();
+    // After giving the server some time to respond for graceful shutdown,
     await wait(500);
+    // destroy the connection forcefully if it hasn't already been closed.
+    conn.resetAndDestroy();
 }
 
 export async function getCurrentBufferName(client: NeovimClient): Promise<string> {


### PR DESCRIPTION
Closes #1432 

This opens a document, with a proper buffer name and matches it to the appropriate neovim external buffer.

The document is "readonly" as far as VSCode is concerned, but it can still be edited by setting `modifiable`, so we still need to sync buffer changes whenever it updates. This can break highlighting, however. I'm not sure if there's a way to force `nomodifiable` permanently, but it is already set for all external documents by default

Some things I haven't tested yet (would be grateful if others who use these features could test for their use cases), as mentioned in #1432 :
- I think `:marks` shows up in the output panel so is unaffected by this change
- `q:`, `q/` etc I couldn't get to work even without my changes. Are these expected to be functional?
- lazy.nvim; I didn't get around to trying since I don't use it normally. I can try to test this though

----

Also ensure the buffer scrolls so the selection is visible. This makes `:help` scroll to the help topic immediately, much like neovim does natively.