### PR TITLE
fix(config): ignore init path when nvim running in clean mode

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -99,7 +99,8 @@ export class MainController implements vscode.Disposable {
         if (config.clean) {
             args.push("--clean");
         }
-        if (config.neovimInitPath) {
+        // #1162
+        if (!config.clean && config.neovimInitPath) {
             args.push("-u", config.neovimInitPath);
         }
         logger.debug(


### PR DESCRIPTION
Resolve: #1162