### PR TITLE
fix: cleanup temporary buffers for dotrepeat

### DIFF
--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -79,6 +79,20 @@ function M.delete_buffers(bufs)
   end
 end
 
+---Delete the temporary buffers used for replaying dotrepeat
+function M.delete_dotrepeat_buffers()
+  local bufs = {}
+  for _, buf in ipairs(api.nvim_list_bufs()) do
+    local ok, dotrepeat = pcall(api.nvim_buf_get_var, buf, "_vscode_dotrepeat_buffer")
+    if ok and dotrepeat then
+      table.insert(bufs, buf)
+    end
+  end
+  if #bufs > 0 then
+    M.delete_buffers(bufs)
+  end
+end
+
 ---Handle document changes
 ---@param bufnr number
 ---@param changes (string | integer)[][]

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -145,6 +145,8 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
         if (typeof buf === "number") {
             return;
         }
+        // The buffer will be cleaned by checking this variable
+        await buf.setVar("_vscode_dotrepeat_buffer", true);
         // create temporary win
         await this.client.setOption("eventignore", "BufWinEnter,BufEnter,BufLeave");
         const win = await this.client.openWindow(buf, true, {
@@ -189,6 +191,7 @@ export class DocumentChangeManager implements Disposable, NeovimExtensionRequest
         cleanEdits.push(["nvim_set_current_win", [currWin.id]]);
         cleanEdits.push(["nvim_win_close", [win.id, true]]);
         await callAtomic(this.client, cleanEdits, logger);
+        await this.client.executeLua("require'vscode-neovim.api'.delete_dotrepeat_buffers(...)");
     }
 
     private onBufferInit: BufferManager["onBufferInit"] = (id, doc) => {


### PR DESCRIPTION
For dotrepeat, sometimes the buffer is not cleared properly.

Reproduction steps:
1. Open multiple files.
2. Select a file and start editing, making sure not to exit the insert mode. Instead, switch directly to another file for editing and then exit the insert mode.
3. Repeat step 2.