### PR TITLE
chore: register internal command `_getNeovimClient`

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -150,6 +150,8 @@ export class MainController implements vscode.Disposable {
         const channel = await this.client.channelId;
         await this.client.setVar("vscode_channel", channel);
 
+        this.disposables.push(vscode.commands.registerCommand("_getNeovimClient", () => this.client));
+
         this.commandsController = new CommandsController(this);
         this.disposables.push(this.commandsController);
 


### PR DESCRIPTION
Allow users in need to extend existing functionality by creating their own vscode extensions.