### PR TITLE
fix: position statusBarItem in the middle

### DIFF
--- a/src/status_line.ts
+++ b/src/status_line.ts
@@ -12,7 +12,7 @@ export class StatusLineController implements Disposable {
     private statusBar: StatusBarItem;
 
     public constructor() {
-        this.statusBar = window.createStatusBarItem(StatusBarAlignment.Left, 10);
+        this.statusBar = window.createStatusBarItem(StatusBarAlignment.Left, -1);
         this.statusBar.show();
     }
 


### PR DESCRIPTION
If you don’t like this change, how about adding a new configuration option? :(