### PR TITLE
refactor: use event bus for vscode-neovim events

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -113,7 +113,7 @@ export class BufferManager implements Disposable {
             eventBus.on("redraw", this.handleRedraw, this),
             eventBus.on("open-file", this.handleOpenFile, this),
             eventBus.on("external-buffer", this.handleExternalBuffer, this),
-            eventBus.on("window-changed", (data) => this.onWindowChangedDebounced(data[0])),
+            eventBus.on("window-changed", ([winId]) => this.handleWindowChangedDebounced(winId)),
         );
     }
 
@@ -297,7 +297,7 @@ export class BufferManager implements Disposable {
         }
     }
 
-    private onWindowChanged = async (winId: number): Promise<void> => {
+    private handleWindowChanged = async (winId: number): Promise<void> => {
         logger.debug(`onWindowChanged, target window id: ${winId}`);
 
         const returnToActiveEditor = async () => {
@@ -367,7 +367,7 @@ export class BufferManager implements Disposable {
         await returnToActiveEditor();
     };
 
-    private onWindowChangedDebounced = debounce(this.onWindowChanged, 100, { leading: false, trailing: true });
+    private handleWindowChangedDebounced = debounce(this.handleWindowChanged, 100, { leading: false, trailing: true });
 
     /**
      * !Note when closing text editor with document, vscode sends onDidCloseTextDocument first

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -41,15 +41,15 @@ export class CommandLineController implements Disposable {
         this.callbacks = callbacks;
         this.input = window.createQuickPick();
         this.input.ignoreFocusOut = true;
-        this.disposables.push(this.input.onDidAccept(this.onAccept));
-        this.disposables.push(this.input.onDidChangeValue(this.onChange));
-        this.disposables.push(this.input.onDidHide(this.onHide));
-        this.disposables.push(commands.registerCommand("vscode-neovim.commit-cmdline", this.onAccept));
         this.disposables.push(
+            this.input.onDidAccept(this.onAccept),
+            this.input.onDidChangeValue(this.onChange),
+            this.input.onDidHide(this.onHide),
+            commands.registerCommand("vscode-neovim.commit-cmdline", this.onAccept),
             commands.registerCommand("vscode-neovim.complete-selection-cmdline", this.acceptSelection),
+            commands.registerCommand("vscode-neovim.send-cmdline", this.sendRedraw),
+            commands.registerCommand("vscode-neovim.test-cmdline", this.testCmdline),
         );
-        this.disposables.push(commands.registerCommand("vscode-neovim.send-cmdline", this.sendRedraw));
-        this.disposables.push(commands.registerCommand("vscode-neovim.test-cmdline", this.testCmdline));
     }
 
     public show(content = "", mode: string, prompt = ""): void {

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -1,10 +1,10 @@
-import vscode, { Disposable } from "vscode";
+import vscode, { Disposable, commands } from "vscode";
 
 import { config } from "./config";
+import { eventBus } from "./eventBus";
 import { MainController } from "./main_controller";
-import { NeovimExtensionRequestProcessable } from "./neovim_events_processable";
 
-export class CommandsController implements Disposable, NeovimExtensionRequestProcessable {
+export class CommandsController implements Disposable {
     private disposables: Disposable[] = [];
 
     private get client() {
@@ -13,58 +13,28 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
 
     public constructor(private main: MainController) {
         this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-f", () => this.scrollPage("page", "down")),
+            commands.registerCommand("vscode-neovim.ctrl-f", () => this.scrollPage("page", "down")),
+            commands.registerCommand("vscode-neovim.ctrl-b", () => this.scrollPage("page", "up")),
+            commands.registerCommand("vscode-neovim.ctrl-d", () => this.scrollPage("halfPage", "down")),
+            commands.registerCommand("vscode-neovim.ctrl-u", () => this.scrollPage("halfPage", "up")),
+            commands.registerCommand("vscode-neovim.ctrl-e", () => this.scrollLine("down")),
+            commands.registerCommand("vscode-neovim.ctrl-y", () => this.scrollLine("up")),
+            eventBus.on("reveal", ([at, updateCursor]) => this.revealLine(at, !!updateCursor)),
+            eventBus.on("move-cursor", ([to]) => this.goToLine(to)),
+            eventBus.on("scroll", ([by, to]) => this.scrollPage(by, to)),
+            eventBus.on("scroll-line", ([to]) => this.scrollLine(to)),
+            eventBus.on("insert-line", async ([type]) => {
+                await this.client.command("startinsert");
+                await commands.executeCommand(
+                    type === "before" ? "editor.action.insertLineBefore" : "editor.action.insertLineAfter",
+                );
+            }),
         );
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-b", () => this.scrollPage("page", "up")),
-        );
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-d", () => this.scrollPage("halfPage", "down")),
-        );
-        this.disposables.push(
-            vscode.commands.registerCommand("vscode-neovim.ctrl-u", () => this.scrollPage("halfPage", "up")),
-        );
-        this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-e", () => this.scrollLine("down")));
-        this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-y", () => this.scrollLine("up")));
     }
 
     public dispose(): void {
         for (const d of this.disposables) {
             d.dispose();
-        }
-    }
-
-    public async handleExtensionRequest(name: string, args: unknown[]): Promise<void> {
-        switch (name) {
-            case "reveal": {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const [at, updateCursor] = args as any;
-                this.revealLine(at, !!updateCursor);
-                break;
-            }
-            case "move-cursor": {
-                const [to] = args as ["top" | "middle" | "bottom"];
-                this.goToLine(to);
-                break;
-            }
-            case "scroll": {
-                const [by, to] = args as ["page" | "halfPage", "up" | "down"];
-                this.scrollPage(by, to);
-                break;
-            }
-            case "scroll-line": {
-                const [to] = args as ["up" | "down"];
-                this.scrollLine(to);
-                break;
-            }
-            case "insert-line": {
-                const [type] = args as ["before" | "after"];
-                await this.client.command("startinsert");
-                await vscode.commands.executeCommand(
-                    type === "before" ? "editor.action.insertLineBefore" : "editor.action.insertLineAfter",
-                );
-                break;
-            }
         }
     }
 

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -84,40 +84,8 @@ export class CursorManager implements Disposable {
                 const gridId = this.main.bufferManager.getGridIdForWinId(winId);
                 if (gridId) this.gridCursorUpdates.add(gridId);
             }),
-            eventBus.on(
-                "range-command",
-                async ([vscodeCommand, mode, line1, line2, pos1, pos2, leaveSelection, inargs]) => {
-                    try {
-                        await this.handleRangeCommand(
-                            vscodeCommand,
-                            mode,
-                            line1,
-                            line2,
-                            pos1,
-                            pos2,
-                            !!leaveSelection,
-                            Array.isArray(inargs) ? inargs : [inargs],
-                        );
-                    } catch (e) {
-                        logger.error(
-                            `${vscodeCommand} failed, range: [${line1}, ${line2}, ${pos1}, ${pos2}] args: ${JSON.stringify(
-                                inargs,
-                            )} error: ${(e as Error).message}`,
-                        );
-                    }
-                },
-            ),
-            eventBus.on("visual-edit", ([append, visualMode, startLine, endLine, startCol, endCol, skipEmpty]) => {
-                this.multipleCursorFromVisualMode(
-                    !!append,
-                    new Mode(visualMode),
-                    startLine - 1,
-                    endLine - 1,
-                    startCol,
-                    endCol,
-                    !!skipEmpty,
-                );
-            }),
+            eventBus.on("range-command", this.handleRangeCommand, this),
+            eventBus.on("visual-edit", this.handleMultipleCursors, this),
         );
     }
 
@@ -495,58 +463,46 @@ export class CursorManager implements Disposable {
         this.main.viewportManager.scrollNeovim(editor);
     };
 
-    /**
-     * Produce vscode selection and execute command
-     * @param command VSCode command to execute
-     * @param startLine Start line to select. 1based
-     * @param endLine End line to select. 1based
-     * @param startPos Start pos to select. 1based. If 0 then whole line will be selected
-     * @param endPos End pos to select, 1based. If you then whole line will be selected
-     * @param leaveSelection When true won't clear vscode selection after running the command
-     * @param args Additional args
-     */
-    public async handleRangeCommand(
-        command: string,
-        mode: string,
-        startLine: number,
-        endLine: number,
-        startPos: number,
-        endPos: number,
-        leaveSelection: boolean,
-        args: unknown[],
-    ): Promise<unknown> {
-        const e = window.activeTextEditor;
-        if (!e) return;
-        logger.debug(
-            `Range command: ${command}, range: [${startLine}, ${startPos}] - [${endLine}, ${endPos}], leaveSelection: ${leaveSelection}`,
-        );
-        const prevSelections = e.selections;
-        const selection = await this.createVisualSelection(
-            e,
-            new Mode(mode),
-            new Position(endLine - 1, endPos - 1),
-            new Position(startLine - 1, startPos - 1),
-        );
-        this.neovimCursorPosition.set(e, selection[0]);
-        e.selections = selection;
-        const res = await commands.executeCommand(command, ...args);
-        logger.debug(`Range command completed`);
-        if (!leaveSelection) {
-            this.neovimCursorPosition.set(e, prevSelections[0]);
-            e.selections = prevSelections;
+    private async handleRangeCommand(data: EventBusData<"range-command">): Promise<unknown> {
+        const [command, mode, startLine, endLine, startPos, endPos, leaveSelection, inargs] = data;
+        const args = Array.isArray(inargs) ? inargs : [inargs];
+        try {
+            const e = window.activeTextEditor;
+            if (!e) return;
+            logger.debug(
+                `Range command: ${command}, range: [${startLine}, ${startPos}] - [${endLine}, ${endPos}], leaveSelection: ${leaveSelection}`,
+            );
+            const prevSelections = e.selections;
+            const selection = await this.createVisualSelection(
+                e,
+                new Mode(mode),
+                new Position(endLine - 1, endPos - 1),
+                new Position(startLine - 1, startPos - 1),
+            );
+            this.neovimCursorPosition.set(e, selection[0]);
+            e.selections = selection;
+            const res = await commands.executeCommand(command, ...args);
+            if (!leaveSelection) {
+                this.neovimCursorPosition.set(e, prevSelections[0]);
+                e.selections = prevSelections;
+            }
+            return res;
+        } catch (e) {
+            logger.error(
+                `${command} failed, range: [${startLine}, ${endLine}, ${startPos}, ${endPos}] args: ${JSON.stringify(
+                    inargs,
+                )} error: ${(e as Error).message}`,
+            );
         }
-        return res;
     }
 
-    private async multipleCursorFromVisualMode(
-        append: boolean,
-        mode: Mode,
-        startLine: number,
-        endLine: number,
-        startCol: number,
-        endCol: number,
-        skipEmpty: boolean,
-    ): Promise<void> {
+    private async handleMultipleCursors(data: EventBusData<"visual-edit">): Promise<void> {
+        // eslint-disable-next-line prefer-const
+        let [append, visualMode, startLine, endLine, startCol, endCol, skipEmpty] = data;
+        const mode = new Mode(visualMode);
+        startLine--;
+        endLine--;
+
         if (!window.activeTextEditor) return;
         await this.waitForCursorUpdate(window.activeTextEditor);
         this.wantInsertCursorUpdate = false;

--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -15,10 +15,6 @@ export class HighlightManager implements Disposable {
         this.highlightProvider = new HighlightProvider();
         eventBus.on("redraw", this.handleRedraw, this, this.disposables);
     }
-    public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
-        this.commandsDisposables.forEach((d) => d.dispose());
-    }
 
     private handleRedraw(data: EventBusData<"redraw">): void {
         const gridHLUpdates: Set<number> = new Set();
@@ -123,4 +119,9 @@ export class HighlightManager implements Disposable {
             });
         }
     };
+
+    public dispose(): void {
+        this.disposables.forEach((d) => d.dispose());
+        this.commandsDisposables.forEach((d) => d.dispose());
+    }
 }

--- a/src/neovim_events_processable.ts
+++ b/src/neovim_events_processable.ts
@@ -1,7 +1,3 @@
-export interface NeovimExtensionRequestProcessable {
-    handleExtensionRequest(name: string, args: unknown[]): Promise<void>;
-}
-
 export interface NeovimCommandProcessable {
     handleVSCodeCommand(command: string, args: unknown[]): Promise<unknown>;
 }

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -43,7 +43,6 @@ export class ViewportManager implements Disposable {
                 const view = this.getViewport(gridId);
                 view.leftcol = saveView.leftcol;
                 view.skipcol = saveView.skipcol;
-                return;
             }),
         );
     }

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -5,7 +5,6 @@ import { config } from "./config";
 import { EventBusData, eventBus } from "./eventBus";
 import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
-import { NeovimExtensionRequestProcessable } from "./neovim_events_processable";
 
 const logger = createLogger("ViewportManager");
 
@@ -19,7 +18,7 @@ export class Viewport {
     skipcol = 0; // skip col (maybe left col)
 }
 
-export class ViewportManager implements Disposable, NeovimExtensionRequestProcessable {
+export class ViewportManager implements Disposable {
     private disposables: Disposable[] = [];
 
     /**
@@ -32,12 +31,21 @@ export class ViewportManager implements Disposable, NeovimExtensionRequestProces
     }
 
     public constructor(private main: MainController) {
-        this.disposables.push(window.onDidChangeTextEditorVisibleRanges(this.onDidChangeVisibleRange));
-        eventBus.on("redraw", this.handleRedraw, this, this.disposables);
-    }
-
-    public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
+        this.disposables.push(
+            window.onDidChangeTextEditorVisibleRanges(this.onDidChangeVisibleRange),
+            eventBus.on("redraw", this.handleRedraw, this),
+            eventBus.on("window-scroll", ([winId, saveView]) => {
+                const gridId = this.main.bufferManager.getGridIdForWinId(winId);
+                if (!gridId) {
+                    logger.warn(`Unable to update scrolled view. No grid for winId: ${winId}`);
+                    return;
+                }
+                const view = this.getViewport(gridId);
+                view.leftcol = saveView.leftcol;
+                view.skipcol = saveView.skipcol;
+                return;
+            }),
+        );
     }
 
     /**
@@ -66,36 +74,6 @@ export class ViewportManager implements Disposable, NeovimExtensionRequestProces
     public getGridOffset(gridId: number): Position {
         const view = this.getViewport(gridId);
         return new Position(view.topline, view.leftcol);
-    }
-
-    public async handleExtensionRequest(name: string, args: unknown[]): Promise<void> {
-        switch (name) {
-            case "window-scroll": {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const [winId, saveView] = args as [
-                    number,
-                    {
-                        lnum: number;
-                        col: number;
-                        coladd: number;
-                        curswant: number;
-                        topline: number;
-                        topfill: number;
-                        leftcol: number;
-                        skipcol: number;
-                    },
-                ];
-                const gridId = this.main.bufferManager.getGridIdForWinId(winId);
-                if (!gridId) {
-                    logger.warn(`Unable to update scrolled view. No grid for winId: ${winId}`);
-                    break;
-                }
-                const view = this.getViewport(gridId);
-                view.leftcol = saveView.leftcol;
-                view.skipcol = saveView.skipcol;
-                break;
-            }
-        }
     }
 
     private handleRedraw(data: EventBusData<"redraw">) {
@@ -173,5 +151,9 @@ export class ViewportManager implements Disposable, NeovimExtensionRequestProces
         if (viewport && startLine != viewport?.topline && currentLine == viewport?.line) {
             this.client.lua("require('vscode-neovim.api').scroll_viewport(...)", [Math.max(startLine, 0), endLine]);
         }
+    }
+
+    dispose() {
+        this.disposables.forEach((d) => d.dispose());
     }
 }

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -23,16 +23,13 @@ function! VSCodeNotify(cmd, ...)
     call rpcnotify(g:vscode_channel, s:vscodeCommandEventName, a:cmd, a:000)
 endfunction
 
-function! VSCodeExtensionCall(cmd, ...) abort
-    call rpcrequest(g:vscode_channel, s:vscodePluginEventName, a:cmd, a:000)
-endfunction
-
 function! VSCodeExtensionNotify(cmd, ...)
     call rpcnotify(g:vscode_channel, s:vscodePluginEventName, a:cmd, a:000)
 endfunction
 
 function! VSCodeCallRange(cmd, line1, line2, leaveSelection, ...) abort
-    call VSCodeExtensionCall('range-command', a:cmd, 'V', a:line1, a:line2, 1, 1, a:leaveSelection, a:000)
+    " FIXME: breaking
+    call VSCodeExtensionNotify('range-command', a:cmd, 'V', a:line1, a:line2, 1, 1, a:leaveSelection, a:000)
 endfunction
 
 function! VSCodeNotifyRange(cmd, line1, line2, leaveSelection, ...)
@@ -40,7 +37,8 @@ function! VSCodeNotifyRange(cmd, line1, line2, leaveSelection, ...)
 endfunction
 
 function! VSCodeCallRangePos(cmd, line1, line2, pos1, pos2, leaveSelection, ...) abort
-    call VSCodeExtensionCall('range-command', a:cmd, 'v', a:line1, a:line2, a:pos1, a:pos2, a:leaveSelection, a:000)
+    " FIXME: breaking
+    call VSCodeExtensionNotify('range-command', a:cmd, 'v', a:line1, a:line2, a:pos1, a:pos2, a:leaveSelection, a:000)
 endfunction
 
 function! VSCodeNotifyRangePos(cmd, line1, line2, pos1, pos2, leaveSelection, ...)
@@ -68,7 +66,7 @@ function! s:onBufEnter(name, id)
     if exists('g:isJumping')
         let isJumping = g:isJumping
     endif
-    call VSCodeExtensionCall('external-buffer', a:name, a:id, 1, tabstop, isJumping)
+    call VSCodeExtensionNotify('external-buffer', a:name, a:id, 1, tabstop, isJumping)
 endfunction
 
 function! s:runFileTypeDetection()
@@ -78,7 +76,7 @@ endfunction
 function! s:onInsertEnter()
     let reg = reg_recording()
     if !empty(reg)
-        call VSCodeExtensionCall('notify-recording', reg)
+        call VSCodeExtensionNotify('notify-recording', reg)
     endif
 endfunction
 

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -30,15 +30,15 @@ nnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
 xnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
 
 " Disabled due to scroll problems (the ext binds them directly)
-" nnoremap <silent> <expr> <C-d> VSCodeExtensionCall('scroll', 'halfPage', 'down')
-" xnoremap <silent> <expr> <C-d> VSCodeExtensionCall('scroll', 'halfPage', 'down')
-" nnoremap <silent> <expr> <C-u> VSCodeExtensionCall('scroll', 'halfPage', 'up')
-" xnoremap <silent> <expr> <C-u> VSCodeExtensionCall('scroll', 'halfPage', 'up')
+" nnoremap <silent> <expr> <C-d> VSCodeExtensionNotify('scroll', 'halfPage', 'down')
+" xnoremap <silent> <expr> <C-d> VSCodeExtensionNotify('scroll', 'halfPage', 'down')
+" nnoremap <silent> <expr> <C-u> VSCodeExtensionNotify('scroll', 'halfPage', 'up')
+" xnoremap <silent> <expr> <C-u> VSCodeExtensionNotify('scroll', 'halfPage', 'up')
 
-" nnoremap <silent> <expr> <C-f> VSCodeExtensionCall('scroll', 'page', 'down')
-" xnoremap <silent> <expr> <C-f> VSCodeExtensionCall('scroll', 'page', 'down')
-" nnoremap <silent> <expr> <C-b> VSCodeExtensionCall('scroll', 'page', 'up')
-" xnoremap <silent> <expr> <C-b> VSCodeExtensionCall('scroll', 'page', 'up')
+" nnoremap <silent> <expr> <C-f> VSCodeExtensionNotify('scroll', 'page', 'down')
+" xnoremap <silent> <expr> <C-f> VSCodeExtensionNotify('scroll', 'page', 'down')
+" nnoremap <silent> <expr> <C-b> VSCodeExtensionNotify('scroll', 'page', 'up')
+" xnoremap <silent> <expr> <C-b> VSCodeExtensionNotify('scroll', 'page', 'up')
 
 " nnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')
 " xnoremap <silent> <expr> <C-e> VSCodeExtensionNotify('scroll-line', 'down')


### PR DESCRIPTION
Remove `NeovimExtensionRequestProcessable` in favor of `eventBus.on`

~~Not sure if it's better than before.~~