### PR TITLE
fix(cmdline): handle `wildmenu_hide` event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1221,12 +1221,12 @@
             {
                 "command": "workbench.action.quickOpenSelectNext",
                 "key": "ctrl+n",
-                "when": "inQuickOpen && neovim.mode != cmdline"
+                "when": "inQuickOpen && (neovim.mode != cmdline || neovim.wildMenuVisible)"
             },
             {
                 "command": "workbench.action.quickOpenSelectPrevious",
                 "key": "ctrl+p",
-                "when": "inQuickOpen && neovim.mode != cmdline"
+                "when": "inQuickOpen && (neovim.mode != cmdline || neovim.wildMenuVisible)"
             },
             {
                 "key": "ctrl+n",

--- a/scripts/keybindings/5 widgets.cjs
+++ b/scripts/keybindings/5 widgets.cjs
@@ -187,12 +187,12 @@ const keybinds = [
     {
         command: "workbench.action.quickOpenSelectNext",
         key: "ctrl+n",
-        when: "inQuickOpen && neovim.mode != cmdline",
+        when: "inQuickOpen && (neovim.mode != cmdline || neovim.wildMenuVisible)",
     },
     {
         command: "workbench.action.quickOpenSelectPrevious",
         key: "ctrl+p",
-        when: "inQuickOpen && neovim.mode != cmdline",
+        when: "inQuickOpen && (neovim.mode != cmdline || neovim.wildMenuVisible)",
     },
     {
         key: "ctrl+n",

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -33,6 +33,8 @@ export class CommandLineController implements Disposable {
 
     private updatedFromNvim = false; // whether to replace nvim cmdline with new content
 
+    private wildMenuVisible = false; // indicates if the wildmenu is visible
+
     public constructor(
         private client: NeovimClient,
         private callbacks: CommandLineCallbacks,
@@ -94,6 +96,14 @@ export class CommandLineController implements Disposable {
         this.completionItems = items.map((i) => ({ label: i, alwaysShow: true }));
         if (this.completionAllowed) {
             this.input.items = this.completionItems;
+            // When deleting the input text to empty, the wildmenu displays all the candidate commands.
+            // However, the wildmenu is not actually useful in this situation, so it is forced to be invisible.
+            // This allows Ctrl+n and Ctrl+p to input normally(navigating history) instead of selecting candidates in quickOpen.
+            const wildMenuVisible = this.input.value.length > 0 && this.completionItems.length > 0;
+            if (this.wildMenuVisible !== wildMenuVisible) {
+                this.wildMenuVisible = wildMenuVisible;
+                commands.executeCommand("setContext", "neovim.wildMenuVisible", this.wildMenuVisible);
+            }
         }
     }
 

--- a/src/command_line_manager.ts
+++ b/src/command_line_manager.ts
@@ -62,10 +62,11 @@ export class CommandLineManager implements Disposable {
                     break;
                 }
                 case "wildmenu_show": {
-                    const [items] = args[0];
-                    if (this.commandLine) {
-                        this.commandLine.setCompletionItems(items);
-                    }
+                    this.commandLine?.setCompletionItems(args[0][0]);
+                    break;
+                }
+                case "wildmenu_hide": {
+                    this.commandLine?.setCompletionItems([]);
                     break;
                 }
                 case "cmdline_hide": {

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -98,6 +98,7 @@ type RedrawEventArgs = (
     // ["mouse_off"]
     | IRedrawEventArg<"mouse_off">
     | IRedrawEventArg<"wildmenu_show", [string[]]>
+    | IRedrawEventArg<"wildmenu_hide">
 )[];
 // #endregion
 


### PR DESCRIPTION
fix(cmdline): use Ctrl+n/p to select candidates when candidates exist

New context: `neovim.wildMenuVisible`

Resolve: #991