### PR TITLE
chore: change the action command prefix to `neovim:`

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,7 +3,7 @@ import { VimValue } from "neovim/lib/types/VimValue";
 import { ConfigurationTarget, Disposable, commands, window, workspace } from "vscode";
 
 function getActionName(action: string) {
-    return `neovim-action.${action}`;
+    return `neovim:${action}`;
 }
 
 class ActionManager implements Disposable {


### PR DESCRIPTION
`neovim:addSelectionToNextFindMatch`
`neovim:editor.action.addSelectionToNextFindMatch`

vs

`neovim-action.addSelectionToNextFindMatch`
`neovim-action.editor.action.addSelectionToNextFindMatch`