### PR TITLE
chore: rename extension description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-neovim",
     "displayName": "VSCode Neovim",
-    "description": "VSCode Neovim Integration",
+    "description": "Vim mode for VSCode, powered by Neovim",
     "icon": "images/icon.png",
     "publisher": "asvetliakov",
     "extensionKind": [


### PR DESCRIPTION
This should improve discoverability by ranking higher in the vscode search, because of the "vim" keyword.