### PR TITLE
feat: Add vscode commands "restart" and "stop"

### DIFF
--- a/package.json
+++ b/package.json
@@ -377,16 +377,12 @@
         },
         "commands": [
             {
-                "command": "vscode-neovim.enable",
-                "title": "Neovim: Enable vscode-neovim extension"
+                "command": "vscode-neovim.restart",
+                "title": "Neovim: Restart Extension"
             },
             {
-                "command": "vscode-neovim.disable",
-                "title": "Neovim: Disable vscode-neovim extension"
-            },
-            {
-                "command": "vscode-neovim.toggle",
-                "title": "Neovim: Turn on/off vscode-neovim extension"
+                "command": "vscode-neovim.stop",
+                "title": "Neovim: Stop Extension"
             },
             {
                 "command": "vscode-neovim.send",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,6 +2,8 @@ import { NeovimClient } from "neovim";
 import { VimValue } from "neovim/lib/types/VimValue";
 import { ConfigurationTarget, Disposable, Position, Range, Selection, commands, window, workspace } from "vscode";
 
+import { disposeAll } from "./utils";
+
 function getActionName(action: string) {
     return `neovim:${action}`;
 }
@@ -11,13 +13,14 @@ class ActionManager implements Disposable {
     private actions: string[] = [];
     private client!: NeovimClient;
 
-    constructor() {
+    init() {
         this.initActions();
         this.initHooks();
     }
 
     dispose() {
-        this.disposables.forEach((d) => d.dispose());
+        this.actions = [];
+        disposeAll(this.disposables);
     }
 
     /**

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -28,7 +28,7 @@ import { config } from "./config";
 import { EventBusData, eventBus } from "./eventBus";
 import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
-import { ManualPromise, callAtomic, convertByteNumToCharNum } from "./utils";
+import { ManualPromise, callAtomic, convertByteNumToCharNum, disposeAll } from "./utils";
 
 // !Note: document and editors in vscode events and namespace are reference stable
 // ! Integration notes:
@@ -154,7 +154,7 @@ export class BufferManager implements Disposable {
     }
 
     public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 
     public async forceResync(): Promise<void> {

--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -3,7 +3,7 @@ import { Disposable, QuickPick, QuickPickItem, commands, window } from "vscode";
 
 import { GlyphChars } from "./constants";
 import { createLogger } from "./logger";
-import { VSCodeContext } from "./utils";
+import { VSCodeContext, disposeAll } from "./utils";
 
 const logger = createLogger("CmdLine");
 
@@ -45,6 +45,7 @@ export class CommandLineController implements Disposable {
         this.input = window.createQuickPick();
         this.input.ignoreFocusOut = true;
         this.disposables.push(
+            this.input,
             this.input.onDidAccept(this.onAccept),
             this.input.onDidChangeValue(this.onChange),
             this.input.onDidHide(this.onHide),
@@ -114,10 +115,7 @@ export class CommandLineController implements Disposable {
     }
 
     public dispose(): void {
-        for (const d of this.disposables) {
-            d.dispose();
-        }
-        this.input.dispose();
+        disposeAll(this.disposables);
     }
 
     private onAccept = (): void => {

--- a/src/command_line_manager.ts
+++ b/src/command_line_manager.ts
@@ -4,7 +4,7 @@ import { CommandLineController } from "./command_line";
 import { config } from "./config";
 import { EventBusData, eventBus } from "./eventBus";
 import { MainController } from "./main_controller";
-import { normalizeInputString } from "./utils";
+import { disposeAll, normalizeInputString } from "./utils";
 
 export class CommandLineManager implements Disposable {
     private disposables: Disposable[] = [];
@@ -25,11 +25,9 @@ export class CommandLineManager implements Disposable {
         eventBus.on("redraw", this.handleRedraw, this, this.disposables);
     }
 
-    public dispose(): void {
-        if (this.commandLine) {
-            this.commandLine.dispose();
-        }
-        this.disposables.forEach((d) => d.dispose());
+    public dispose() {
+        this.commandLine?.dispose();
+        disposeAll(this.disposables);
     }
 
     private handleRedraw(data: EventBusData<"redraw">) {

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -3,6 +3,7 @@ import vscode, { Disposable, commands } from "vscode";
 import { config } from "./config";
 import { eventBus } from "./eventBus";
 import { MainController } from "./main_controller";
+import { disposeAll } from "./utils";
 
 export class CommandsController implements Disposable {
     private disposables: Disposable[] = [];
@@ -33,9 +34,7 @@ export class CommandsController implements Disposable {
     }
 
     public dispose(): void {
-        for (const d of this.disposables) {
-            d.dispose();
-        }
+        disposeAll(this.disposables);
     }
 
     /// SCROLL COMMANDS ///

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ import {
 } from "vscode";
 
 import { CTRL_KEYS, EXT_ID, EXT_NAME } from "./constants";
-import { VSCodeContext } from "./utils";
+import { VSCodeContext, disposeAll } from "./utils";
 
 const isWindows = process.platform == "win32";
 
@@ -32,10 +32,10 @@ export class Config implements Disposable {
     ].map((c) => `${this.root}.${c}`);
 
     dispose() {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 
-    constructor() {
+    public init() {
         this.onConfigurationChanged();
         workspace.onDidChangeConfiguration(this.onConfigurationChanged, this, this.disposables);
     }

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -25,6 +25,7 @@ import {
     computeEditorOperationsFromDiff,
     convertCharNumToByteNum,
     diffLineToChars,
+    disposeAll,
     getDocumentLineArray,
     isChangeSubsequentToChange,
     isCursorChange,
@@ -105,7 +106,7 @@ export class DocumentChangeManager implements Disposable {
     }
 
     public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 
     public eatDocumentCursorAfterChange(doc: TextDocument): Position | undefined {

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -145,10 +145,14 @@ class EventBus implements Disposable {
      * All Nvim events are dispatched by this single EventEmitter.
      * Components can subscribe to event broadcasts using `EventBus.on()`.
      */
-    private readonly emitter = new EventEmitter<Event>();
+    private emitter!: EventEmitter<Event>;
 
     dispose() {
         this.emitter.dispose();
+    }
+
+    init() {
+        this.emitter = new EventEmitter<Event>();
     }
 
     /**

--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -3,17 +3,17 @@ import { Disposable } from "vscode";
 import { EventBusData, eventBus } from "./eventBus";
 import { HighlightProvider } from "./highlight_provider";
 import { MainController } from "./main_controller";
+import { disposeAll } from "./utils";
 
 export class HighlightManager implements Disposable {
     private disposables: Disposable[] = [];
 
     private highlightProvider: HighlightProvider;
 
-    private commandsDisposables: Disposable[] = [];
-
     public constructor(private main: MainController) {
         this.highlightProvider = new HighlightProvider();
-        eventBus.on("redraw", this.handleRedraw, this, this.disposables);
+        this.disposables.push(this.highlightProvider);
+        this.disposables.push(eventBus.on("redraw", this.handleRedraw, this));
     }
 
     private handleRedraw(data: EventBusData<"redraw">): void {
@@ -121,7 +121,6 @@ export class HighlightManager implements Disposable {
     };
 
     public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
-        this.commandsDisposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 }

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -4,6 +4,7 @@ import wcswidth from "ts-wcwidth";
 import {
     DecorationOptions,
     DecorationRangeBehavior,
+    Disposable,
     Range,
     TextEditor,
     TextEditorDecorationType,
@@ -130,7 +131,7 @@ class CellIter {
     }
 }
 
-export class HighlightProvider {
+export class HighlightProvider implements Disposable {
     /**
      * key is the grid id and values is a three-dimensional array representing rows and columns.
      * Each column can contain multiple highlights. e.g. double-width character, tab
@@ -158,6 +159,12 @@ export class HighlightProvider {
             highlights[key] = normalizeDecorationConfig(opts);
         }
         this.configuration = { highlights };
+    }
+
+    dispose() {
+        for (const decoration of this.highlighIdToDecorator.values()) {
+            decoration.dispose();
+        }
     }
 
     private createDecoratorForHighlightId(id: number, options: ThemableDecorationRenderOptions): void {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,6 +4,8 @@ import { inspect } from "util";
 
 import { Disposable, window } from "vscode";
 
+import { disposeAll } from "./utils";
+
 export enum LogLevel {
     none = 0,
     error = 1,
@@ -34,6 +36,9 @@ export class Logger implements Disposable {
         if (filePath && level !== LogLevel.none) {
             try {
                 this.fd = fs.openSync(filePath, "w");
+                this.disposables.push({
+                    dispose: () => fs.closeSync(this.fd),
+                });
             } catch {
                 // ignore
             }
@@ -43,10 +48,7 @@ export class Logger implements Disposable {
     }
 
     public dispose(): void {
-        if (this.fd) {
-            fs.closeSync(this.fd);
-        }
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 
     private log(level: LogLevel, scope: string, args: any[]): void {

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -22,7 +22,7 @@ import { ModeManager } from "./mode_manager";
 import { MultilineMessagesManager } from "./multiline_messages_manager";
 import { StatusLineManager } from "./status_line_manager";
 import { TypingManager } from "./typing_manager";
-import { findLastEvent, VSCodeContext } from "./utils";
+import { disposeAll, findLastEvent, VSCodeContext } from "./utils";
 import { ViewportManager } from "./viewport_manager";
 
 interface RequestResponse {
@@ -142,7 +142,7 @@ export class MainController implements vscode.Disposable {
             },
         });
         // This is an exception. Should avoid doing this.
-        Object.defineProperty(actions, "client", { get: () => this.client });
+        Object.defineProperty(actions, "client", { get: () => this.client, configurable: true });
     }
 
     public async init(): Promise<void> {
@@ -399,10 +399,10 @@ export class MainController implements vscode.Disposable {
         }
     }
 
-    public dispose(): void {
-        for (const d of this.disposables) {
-            d.dispose();
-        }
+    dispose() {
+        disposeAll(this.disposables);
+        this.nvimProc.removeAllListeners();
+        this.client.removeAllListeners();
         this.client.quit();
     }
 }

--- a/src/mode_manager.ts
+++ b/src/mode_manager.ts
@@ -2,7 +2,7 @@ import { Disposable, EventEmitter } from "vscode";
 
 import { eventBus, EventBusData } from "./eventBus";
 import { createLogger } from "./logger";
-import { VSCodeContext } from "./utils";
+import { disposeAll, VSCodeContext } from "./utils";
 
 const logger = createLogger("ModeManager");
 
@@ -108,6 +108,6 @@ export class ModeManager implements Disposable {
     }
 
     dispose() {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 }

--- a/src/multiline_messages_manager.ts
+++ b/src/multiline_messages_manager.ts
@@ -2,6 +2,7 @@ import { Disposable, OutputChannel, window } from "vscode";
 
 import { EXT_NAME } from "./constants";
 import { EventBusData, eventBus } from "./eventBus";
+import { disposeAll } from "./utils";
 
 export class MultilineMessagesManager implements Disposable {
     private disposables: Disposable[] = [];
@@ -15,7 +16,7 @@ export class MultilineMessagesManager implements Disposable {
     }
 
     public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 
     private handleRedraw(data: EventBusData<"redraw">): void {

--- a/src/status_line_manager.ts
+++ b/src/status_line_manager.ts
@@ -3,6 +3,7 @@ import { Disposable } from "vscode";
 import { MainController } from "./main_controller";
 import { StatusLineController } from "./status_line";
 import { EventBusData, eventBus } from "./eventBus";
+import { disposeAll } from "./utils";
 
 export class StatusLineManager implements Disposable {
     private disposables: Disposable[] = [];
@@ -22,7 +23,7 @@ export class StatusLineManager implements Disposable {
     }
 
     public dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 
     private handleRedraw(data: EventBusData<"redraw">) {

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -5,6 +5,7 @@ import { config } from "./config";
 import { EventBusData, eventBus } from "./eventBus";
 import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
+import { disposeAll } from "./utils";
 
 const logger = createLogger("ViewportManager");
 
@@ -156,6 +157,6 @@ export class ViewportManager implements Disposable {
     }
 
     dispose() {
-        this.disposables.forEach((d) => d.dispose());
+        disposeAll(this.disposables);
     }
 }


### PR DESCRIPTION
New commands:

- `vscode-neovim.restart` => Restart the extension
- `vscode-neovim.stop` => Stop the extension

Removed the following commands:

- `vscode-neovim.enable`
- `vscode-neovim.disable`
- `vscode-neovim.toggle`

Resolve #250