### PR TITLE
fix(cursor): ignore cursor position errors in the output

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -373,7 +373,13 @@ export class CursorManager implements Disposable {
         try {
             await this.client.request("nvim_win_set_cursor", [winId, vimPos]); // a little faster
         } catch (e) {
-            logger.error(`${(e as Error).message}`);
+            // 1. The output content may be out of sync due to the rapid changes in content.
+            //    When initializing the buffer, the output may be constantly updating.
+            // 2. The output is a textEditor, but it cannot accept input, it's meaningless to use the extension.
+            // In the output, going out-of-sync and cursor position errors are not significant.
+            if (editor.document.uri.scheme !== "output") {
+                logger.error(`${(e as Error).message}`);
+            }
         }
     }
 


### PR DESCRIPTION
As there are no screenshots provided in #901, I'm not sure if the issue is caused by the output, but it is highly probable. Because when I encountered the "Cursor position outside buffer" error, I mostly opened the output.

- Related #1416
- Close #901