### PR TITLE
chore: use the default indentation options

### DIFF
--- a/runtime/lua/vscode-neovim/default-options.lua
+++ b/runtime/lua/vscode-neovim/default-options.lua
@@ -3,10 +3,6 @@ local function setup()
   -- customise statusbar
   vim.opt.shortmess = "filnxtToOFI"
 
-  --- Turn on auto-indenting
-  vim.opt.autoindent = true
-  vim.opt.smartindent = true
-
   --- split/nosplit doesn't work currently, see https://github.com/asvetliakov/vscode-neovim/issues/329
   vim.opt.inccommand = ""
 


### PR DESCRIPTION
Let users set these options themselves if they need to.

by default:

 	autoindent: on
 	smartindent: off

- Related: #695