### PR TITLE
chore: use "onStartupFinished" for activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "Keymaps"
     ],
     "activationEvents": [
-        "*"
+        "onStartupFinished"
     ],
     "main": "./dist/extension.js",
     "contributes": {


### PR DESCRIPTION
I think we should use "onStartupFinished" instead of "*"

1. Better user experience.
2. vscode-neovim needs to perform some synchronization work during initialization, which may cause issues when VSCode is restoring the workspace state(not sure, but it seems possible).