### PR TITLE
fix(blockwise-visual): handle double-width chars and tabs

### DIFF
--- a/runtime/lua/vscode-neovim/internal.lua
+++ b/runtime/lua/vscode-neovim/internal.lua
@@ -115,4 +115,51 @@ do
   end
 end
 
+---display-col to col
+---@param line string
+---@param discol number
+local function discol_to_col(line, discol)
+  if discol == 0 then
+    return 0
+  end
+
+  local col = 0
+  local max_col = vim.fn.strcharlen(line)
+
+  local min_distance = math.huge
+  local nearest_col = 0
+
+  while col <= max_col do
+    local curr_col = math.floor((col + max_col) / 2)
+    local curr_discol = fn.strdisplaywidth(fn.strcharpart(line, 0, curr_col))
+    if curr_discol == discol then
+      return curr_col
+    elseif curr_discol > discol then
+      max_col = curr_col - 1
+    else
+      col = curr_col + 1
+    end
+
+    local curr_distance = math.abs(curr_discol - discol)
+    if curr_distance < min_distance then
+      min_distance = curr_distance
+      nearest_col = curr_col
+    elseif curr_distance == min_distance and curr_col < nearest_col then
+      nearest_col = curr_col
+    end
+  end
+  return nearest_col
+end
+
+function M.handle_blockwise_selection(lines, start_discol, end_discol)
+  local result = {}
+  for _, line in ipairs(lines) do
+    table.insert(result, {
+      discol_to_col(line, start_discol),
+      discol_to_col(line, end_discol),
+    })
+  end
+  return result
+end
+
 return M

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -489,7 +489,7 @@ export class CursorManager implements Disposable {
                 ret.forEach(([startChar, endChar], idx) => {
                     const line = idx + startLine;
                     const lineRange = doc.lineAt(line).range;
-                    const range = new Range(line, startChar, line, endChar).intersection(lineRange);
+                    const range = lineRange.intersection(new Range(line, startChar, line, endChar));
                     if (range && (range.start.isBefore(lineRange.end) || line === active.line)) ranges.push(range);
                 });
 

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -437,23 +437,23 @@ export class CursorManager implements Disposable {
         // we hide the real cursor and use a highlight decorator for the fake cursor
         switch (mode.visual) {
             case "char":
-                if (anchor.isBeforeOrEqual(active))
-                    return [
-                        new Selection(
-                            anchor,
-                            new Position(active.line, Math.min(active.character + 1, activeLineLength)),
-                        ),
-                    ];
-                else
-                    return [
-                        new Selection(
-                            new Position(anchor.line, Math.min(anchor.character + 1, anchorLineLength)),
-                            active,
-                        ),
-                    ];
+                return [
+                    anchor.isBeforeOrEqual(active)
+                        ? new Selection(
+                              anchor,
+                              new Position(active.line, Math.min(active.character + 1, activeLineLength)),
+                          )
+                        : new Selection(
+                              new Position(anchor.line, Math.min(anchor.character + 1, anchorLineLength)),
+                              active,
+                          ),
+                ];
             case "line":
-                if (anchor.line <= active.line) return [new Selection(anchor.line, 0, active.line, activeLineLength)];
-                else return [new Selection(anchor.line, anchorLineLength, active.line, 0)];
+                return [
+                    anchor.line <= active.line
+                        ? new Selection(anchor.line, 0, active.line, activeLineLength)
+                        : new Selection(anchor.line, anchorLineLength, active.line, 0),
+                ];
             case "block": {
                 const tabSize = editor.options.tabSize as number;
                 const getTabCount = (pos: Position) => {

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -490,7 +490,7 @@ export class CursorManager implements Disposable {
                     const line = idx + startLine;
                     const lineRange = doc.lineAt(line).range;
                     const range = new Range(line, startChar, line, endChar).intersection(lineRange);
-                    if (range) ranges.push(range);
+                    if (range && (range.start.isBefore(lineRange.end) || line === active.line)) ranges.push(range);
                 });
 
                 // correct the orientation

--- a/src/test/suite/visual-modes.test.ts
+++ b/src/test/suite/visual-modes.test.ts
@@ -238,7 +238,7 @@ describe("Visual modes test", () => {
         await sendVSCodeKeys("0");
         await assertContent(
             {
-                vsCodeSelections: [new vscode.Selection(0, 0, 0, 7), new vscode.Selection(1, 0, 1, 7)],
+                vsCodeSelections: [new vscode.Selection(0, 7, 0, 0), new vscode.Selection(1, 7, 1, 0)],
             },
             client,
         );
@@ -272,7 +272,7 @@ describe("Visual modes test", () => {
         await sendVSCodeKeys("j");
         await assertContent(
             {
-                vsCodeSelections: [new vscode.Selection(1, 1, 1, 1), new vscode.Selection(0, 1, 0, 3)],
+                vsCodeSelections: [new vscode.Selection(1, 1, 1, 1), new vscode.Selection(0, 3, 0, 1)],
             },
             client,
         );


### PR DESCRIPTION
improvement: the selection direction is consistent with nvim

Issue - Fixed

<img src="https://github.com/vscode-neovim/vscode-neovim/assets/47070852/718222f1-d7ce-4e47-a793-3aa98b6831e0" height=300 />
<img src="https://github.com/vscode-neovim/vscode-neovim/assets/47070852/741be990-4727-4f2b-98e5-baa4f187c8e9" height=300 />


