### PR TITLE
fix: rework `:tabnew`

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -257,8 +257,13 @@ export class BufferManager implements Disposable {
                 doc = await workspace.openTextDocument();
             } else {
                 const normalizedName = fileName.trim();
-                const filePath = this.findPathFromFileName(normalizedName);
-                doc = await workspace.openTextDocument(filePath);
+                let filePath = this.findPathFromFileName(normalizedName);
+                try {
+                    await workspace.fs.stat(Uri.file(filePath));
+                } catch {
+                    filePath = `untitled:${filePath}`
+                }
+                doc = await workspace.openTextDocument(Uri.parse(filePath));
             }
         } catch (error) {
             logger.error(`Error opening file ${fileName}, ${error}`);

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -263,6 +263,12 @@ export class BufferManager implements Disposable {
                     await workspace.fs.stat(uri);
                 } catch {
                     uri = Uri.from({ scheme: "untitled", path: normalizedName });
+                    // Why notebook?
+                    // Limitations with TextDocument, specifically when there is no active
+                    // workspace. openNotebookDocument prompts for a file path when the
+                    // document is saved and while it returns a NotebookDocument it can
+                    // still be used as a TextDocument
+                    // https://github.com/microsoft/vscode/issues/197836
                     doc = await workspace.openNotebookDocument(uri);
                 }
                 doc ??= await workspace.openTextDocument(uri);

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -258,7 +258,7 @@ export class BufferManager implements Disposable {
                 doc = await workspace.openTextDocument();
             } else {
                 const normalizedName = fileName.trim();
-                let uri = Uri.parse(this.findPathFromFileName(normalizedName));
+                let uri = Uri.from({ scheme: "file", path: this.findPathFromFileName(normalizedName) });
                 try {
                     await workspace.fs.stat(uri);
                 } catch {

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -257,13 +257,13 @@ export class BufferManager implements Disposable {
                 doc = await workspace.openTextDocument();
             } else {
                 const normalizedName = fileName.trim();
-                let filePath = this.findPathFromFileName(normalizedName);
+                let uri = Uri.parse(this.findPathFromFileName(normalizedName));
                 try {
-                    await workspace.fs.stat(Uri.file(filePath));
+                    await workspace.fs.stat(uri);
                 } catch {
-                    filePath = `untitled:${filePath}`
+                    uri = Uri.from({ scheme: 'untitled', path: uri.path });
                 }
-                doc = await workspace.openTextDocument(Uri.parse(filePath));
+                doc = await workspace.openTextDocument(uri);
             }
         } catch (error) {
             logger.error(`Error opening file ${fileName}, ${error}`);

--- a/vim/vscode-tab-commands.vim
+++ b/vim/vscode-tab-commands.vim
@@ -12,7 +12,7 @@ function! s:gotoEditor(...) abort
 endfunction
 
 command! -complete=file -nargs=? Tabedit if empty(<q-args>) | call VSCodeNotify('workbench.action.quickOpen') | else | call VSCodeExtensionNotify('open-file', expand(<q-args>), 0) | endif
-command! -complete=file -nargs=? Tabnew call VSCodeExtensionNotify('open-file', '__vscode_new__', 0)
+command! -complete=file -nargs=? Tabnew call VSCodeExtensionNotify('open-file', empty(<q-args>) ? '__vscode_new__' : expand(<q-args>), 0)
 command! Tabfind call VSCodeNotify('workbench.action.quickOpen')
 command! Tab echoerr 'Not supported'
 command! Tabs echoerr 'Not supported'


### PR DESCRIPTION
Fixes #1548

Rework `tabnew` to correctly replicate behaviour. For now an active workspace is required to provide a directory if the file is saved.
