### PR TITLE
fix(highlight): Do not clear custom highlight groups directly

### DIFF
--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -29,6 +29,7 @@ export interface VimHighlightUIAttributes {
     // has special color
     undercurl?: boolean;
     blend?: number;
+    altfont?: boolean;
 }
 
 export interface HighlightConfiguration {
@@ -180,6 +181,7 @@ export class HighlightProvider implements Disposable {
     }
 
     public addHighlightGroup(id: number, attrs: VimHighlightUIAttributes, groups: string[]): void {
+        delete attrs.altfont;
         if (groups.includes("Visual")) {
             if (groups.length === 1) this.visualHighlightId = id;
             else this.visualHighlightIds.push(id);


### PR DESCRIPTION
Fixes #1631

The most ideal solution is to set all highlights in nvim, but it is difficult to do without the vscode API, unless we give up using the VSCode's ThemeColor. Please vote for https://github.com/microsoft/vscode/issues/32813