### PR TITLE
fix(highlight): remove duplicate visual selection highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,9 +339,6 @@
                         "Search": {
                             "backgroundColor": "theme.editor.findMatchHighlightBackground",
                             "borderColor": "theme.editor.findMatchHighlightBorder"
-                        },
-                        "Visual": {
-                            "backgroundColor": "theme.editor.selectionBackground"
                         }
                     }
                 },

--- a/runtime/lua/vscode-neovim/highlight.lua
+++ b/runtime/lua/vscode-neovim/highlight.lua
@@ -52,6 +52,7 @@ local function setup_globals()
     Normal       = {},
     NormalNC     = {},
     NormalFloat  = {},
+    Visual       = {},
     VisualNC     = {},
     VisualNOS    = {},
     Substitute   = {},


### PR DESCRIPTION
With https://github.com/vscode-neovim/vscode-neovim/pull/1597, applying the `Visual` highlight is no longer needed, we can entirely rely on vscode's selection. 