### PR TITLE
fix(change): Respect the selections of the editor

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -313,10 +313,7 @@ export class CursorManager implements Disposable {
         return func;
     };
 
-    private applySelectionChanged = async (
-        editor: TextEditor,
-        kind: TextEditorSelectionChangeKind | undefined,
-    ): Promise<void> => {
+    public applySelectionChanged = async (editor: TextEditor, kind?: TextEditorSelectionChangeKind): Promise<void> => {
         // reset cursor style if needed
         this.updateCursorStyle(this.main.modeManager.currentMode.name);
 

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -380,5 +380,7 @@ export class DocumentChangeManager implements Disposable {
         this.main.cursorManager.wantInsertCursorUpdate = false;
 
         await actions.lua("handle_changes", bufId, changeArgs);
+        const editor = window.visibleTextEditors.find((e) => e.document === doc);
+        if (editor) await this.main.cursorManager.applySelectionChanged(editor);
     };
 }


### PR DESCRIPTION
After synchronizing document changes, the current selection should be kept.

Fix #1660