### PR TITLE
feat(api): support passing a map-like table as args

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,11 @@ Parameters:
 
 -   `name` (string): The name of the action, generally a vscode command.
 -   `opts` (table): Map of optional parameters:
-    -   `args` (table): List of arguments passed to the vscode command.
-        -   Example: `action('foo', { args = { 'foo', 'bar', … } })`
+    -   `args` (table): List of arguments passed to the vscode command. If the command only requires a single object
+        parameter, you can directly pass in a map-like table.
+        -   Examples:
+            -   `action('foo', { args = { 'foo', 'bar', … } })`
+            -   `action('foo', { args = { foo = bar, … } })`
     -   `range` (table): Specific range for the action. Implicitly passed in visual mode. Has three possible forms (all
         values are 0-indexed):
         -   `[start_line, end_line]`
@@ -303,7 +306,7 @@ Returns: the result of the action
     [vscode command definition](https://github.com/microsoft/vscode/blob/43b0558cc1eec2528a9a1b9ee1c7a559823bda31/src/vs/workbench/contrib/search/browser/searchActionsFind.ts#L177-L197)
     for the expected parameter format):
     ```vim
-    nnoremap ? <Cmd>lua require('vscode-neovim').action('workbench.action.findInFiles', { args = { { query = vim.fn.expand('<cword>') } } })<CR>
+    nnoremap ? <Cmd>lua require('vscode-neovim').action('workbench.action.findInFiles', { args = { query = vim.fn.expand('<cword>') } })<CR>
     ```
 
 Currently, two built-in actions are provided for testing purposes:
@@ -343,8 +346,9 @@ do -- Comment the previous line
 end
 
 do -- Find in files for word under cursor
-  local arg = { query = vim.fn.expand('<cword>') }
-  vscode.action("workbench.action.findInFiles", { args = { arg } })
+  vscode.action("workbench.action.findInFiles", {
+    args = { query = vim.fn.expand('<cword>') }
+  })
 end
 
 -- Execute _ping synchronously and print the result

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -59,13 +59,7 @@ function M.action(name, opts)
   })
   vim.validate({
     ["opts.callback"] = { opts.callback, "f", true },
-    ["opts.args"] = {
-      opts.args,
-      function(args)
-        return args == nil or (type(args) == "table" and vim.tbl_islist(args))
-      end,
-      "array-like table",
-    },
+    ["opts.args"] = { opts.args, "t", true },
     ["opts.range"] = {
       opts.range,
       function(range)
@@ -88,6 +82,9 @@ function M.action(name, opts)
     },
     ["opts.restore_selection"] = { opts.restore_selection, "b", true },
   })
+  if opts.args and not vim.tbl_islist(opts.args) then
+    opts.args = { opts.args }
+  end
   if opts.callback then
     opts.callback = add_callback(opts.callback)
   end
@@ -120,13 +117,7 @@ function M.call(name, opts, timeout)
   })
   vim.validate({
     ["opts.callback"] = { opts.callback, "nil" },
-    ["opts.args"] = {
-      opts.args,
-      function(args)
-        return args == nil or (type(args) == "table" and vim.tbl_islist(args))
-      end,
-      "array-like table",
-    },
+    ["opts.args"] = { opts.args, "t", true },
     ["opts.range"] = {
       opts.range,
       function(range)
@@ -149,6 +140,10 @@ function M.call(name, opts, timeout)
     },
     ["opts.restore_selection"] = { opts.restore_selection, "b", true },
   })
+
+  if opts.args and not vim.tbl_islist(opts.args) then
+    opts.args = { opts.args }
+  end
 
   if timeout <= 0 then
     return vim.rpcrequest(vim.g.vscode_channel, "vscode-action", name, opts)


### PR DESCRIPTION
Most commands either require multiple arguments or only require one object parameter. So when args is a map-like table, it is automatically treated as the first argument, which is more convenient and easier to understand.