### PR TITLE
fix: Fix forcing sync editor selections

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -323,6 +323,7 @@ export class CursorManager implements Disposable {
         // wait for possible change document events
         logger.debug(`Waiting for possible document change completion operation`);
         await this.main.changeManager.getDocumentChangeCompletionLock(editor.document);
+        await this.main.changeManager.documentChangeLock.waitForUnlock();
         logger.debug(`Waiting done`);
 
         // ignore selection change caused by buffer edit


### PR DESCRIPTION
Fix #1673

---

document_change_manager also needs to be refactored, and locks should be simplified...