### PR TITLE
feat: Add clipboard provider `g:vscode_clipboard`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ local vscode = require('vscode-neovim')
    usage
 9. `vscode.get_status_item`: Gets a vscode statusbar item. Properties can be assigned, which magically updates the
    statusbar item.
+10. `g:vscode_clipboard`: Clipboard provider using VSCode's clipboard API. Used by default when in WSL. See
+    `:h g:clipboard` for more details. Usage: `let g:clipboard = g:vscode_clipboard`
 
 ### vscode.action(name, opts)
 

--- a/runtime/modules/clipboard.lua
+++ b/runtime/modules/clipboard.lua
@@ -33,6 +33,7 @@ vim.g.vscode_clipboard = {
     ["+"] = paste,
     ["*"] = paste,
   },
+  cache_enabled = 0,
 }
 
 -- The user also can override g:clipboard in the init config

--- a/runtime/modules/clipboard.lua
+++ b/runtime/modules/clipboard.lua
@@ -1,0 +1,41 @@
+local code = require("vscode-neovim")
+
+local last_item = nil
+
+local function paste()
+  local curr_text = code.call("clipboard_read"):gsub("\r\n", "\n")
+  local curr_item = { vim.split(curr_text, "\n"), "v" }
+
+  if not last_item then
+    return curr_item
+  end
+
+  if not vim.deep_equal(last_item[1], curr_item[1]) then
+    return curr_item
+  end
+
+  return last_item
+end
+
+local function copy(lines, regtype)
+  last_item = { lines, regtype }
+  local text = table.concat(lines, "\n")
+  code.call("clipboard_write", { args = { text } })
+end
+
+vim.g.vscode_clipboard = {
+  name = "VSCodeClipboard",
+  copy = {
+    ["+"] = copy,
+    ["*"] = copy,
+  },
+  paste = {
+    ["+"] = paste,
+    ["*"] = paste,
+  },
+}
+
+-- The user also can override g:clipboard in the init config
+if vim.fn.has("wsl") == 1 then
+  vim.g.clipboard = vim.g.vscode_clipboard
+end

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,6 @@
 import { NeovimClient } from "neovim";
 import { VimValue } from "neovim/lib/types/VimValue";
-import { ConfigurationTarget, Disposable, Range, commands, window, workspace } from "vscode";
+import vscode, { ConfigurationTarget, Disposable, Range, commands, window, workspace } from "vscode";
 
 import { disposeAll, rangesToSelections } from "./utils";
 
@@ -127,6 +127,8 @@ class ActionManager implements Disposable {
                 editor.selections = rangesToSelections(ranges, editor.document);
             }
         });
+        this.add("clipboard_read", () => vscode.env.clipboard.readText());
+        this.add("clipboard_write", (text: string) => vscode.env.clipboard.writeText(text));
     }
 
     private initHooks() {


### PR DESCRIPTION
Use the VSCode clipboard by default in WSL

Close #103