### PR TITLE
feat(keybindings): Add keybindings for the hover widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,14 +596,14 @@ If you find that these options are not working, you can manually modify the keyb
 
 > 💡 See [Keybindings help](#keybindings-help) to see all defined shortcuts and their documentation.
 
-You can add this to your keybindings.json: When hover is invisible, K is sent to nvim(show hover); when hover is
+The following keybinding is set by default: When hover is invisible, K is sent to nvim(show hover); when hover is
 visible, press K again to focus the hover widget.
 
 ```json
 {
     "command": "editor.action.showHover",
     "key": "shift+k",
-    "when": "editorTextFocus && editorHoverVisible && neovim.mode == normal"
+    "when": "neovim.init && neovim.mode == normal && editorTextFocus && editorHoverVisible"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -592,6 +592,32 @@ If you find that these options are not working, you can manually modify the keyb
 | <kbd>a</kbd> | `explorer.newFile`    |
 | <kbd>A</kbd> | `explorer.newFolder`  |
 
+### Hover widget manipulation
+
+> 💡 See [Keybindings help](#keybindings-help) to see all defined shortcuts and their documentation.
+
+You can add this to your keybindings.json: When hover is invisible, K is sent to nvim(show hover); when hover is
+visible, press K again to focus the hover widget.
+
+```json
+{
+    "command": "editor.action.showHover",
+    "key": "shift+k",
+    "when": "editorTextFocus && editorHoverVisible && neovim.mode == normal"
+}
+```
+
+| Key            | VSCode Command                   |
+| -------------- | -------------------------------- |
+| <kbd>h</kbd>   | `editor.action.scrollLeftHover`  |
+| <kbd>j</kbd>   | `editor.action.scrollDownHover`  |
+| <kbd>k</kbd>   | `editor.action.scrollUpHover`    |
+| <kbd>l</kbd>   | `editor.action.scrollRightHover` |
+| <kbd>gg</kbd>  | `editor.action.goToTopHover`     |
+| <kbd>G</kbd>   | `editor.action.goToBottomHover`  |
+| <kbd>C-f</kbd> | `editor.action.pageDownHover`    |
+| <kbd>C-b</kbd> | `editor.action.pageUpHover`      |
+
 ### File management
 
 The extension aliases various Nvim commands (`:edit`, `:enew`, `:find`, `:write`, `:saveas`, `:wall`, `:quit`, etc.) to

--- a/package.json
+++ b/package.json
@@ -1633,6 +1633,11 @@
                 "when": "terminalFocus"
             },
             {
+                "command": "editor.action.showHover",
+                "key": "shift+k",
+                "when": "neovim.init && neovim.mode == normal && editorTextFocus && editorHoverVisible"
+            },
+            {
                 "command": "editor.action.pageDownHover",
                 "key": "ctrl+f",
                 "when": "editorHoverFocused"

--- a/package.json
+++ b/package.json
@@ -1633,6 +1633,46 @@
                 "when": "terminalFocus"
             },
             {
+                "command": "editor.action.pageDownHover",
+                "key": "ctrl+f",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.pageUpHover",
+                "key": "ctrl+b",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.scrollDownHover",
+                "key": "j",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.scrollUpHover",
+                "key": "k",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.scrollLeftHover",
+                "key": "h",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.scrollRightHover",
+                "key": "l",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.goToTopHover",
+                "key": "g g",
+                "when": "editorHoverFocused"
+            },
+            {
+                "command": "editor.action.goToBottomHover",
+                "key": "shift+g",
+                "when": "editorHoverFocused"
+            },
+            {
                 "command": "-workbench.action.switchWindow",
                 "key": "ctrl+w"
             },

--- a/scripts/keybindings/5_widgets.cjs
+++ b/scripts/keybindings/5_widgets.cjs
@@ -217,6 +217,11 @@ const keybinds = [
 
     // #region Hover Widget
     {
+        command: "editor.action.showHover",
+        key: "shift+k",
+        when: "neovim.init && neovim.mode == normal && editorTextFocus && editorHoverVisible",
+    },
+    {
         command: "editor.action.pageDownHover",
         key: "ctrl+f",
         when: "editorHoverFocused",

--- a/scripts/keybindings/5_widgets.cjs
+++ b/scripts/keybindings/5_widgets.cjs
@@ -214,6 +214,49 @@ const keybinds = [
         command: "workbench.action.focusActiveEditorGroup",
         when: "terminalFocus",
     },
+
+    // #region Hover Widget
+    {
+        command: "editor.action.pageDownHover",
+        key: "ctrl+f",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.pageUpHover",
+        key: "ctrl+b",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.scrollDownHover",
+        key: "j",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.scrollUpHover",
+        key: "k",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.scrollLeftHover",
+        key: "h",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.scrollRightHover",
+        key: "l",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.goToTopHover",
+        key: "g g",
+        when: "editorHoverFocused",
+    },
+    {
+        command: "editor.action.goToBottomHover",
+        key: "shift+g",
+        when: "editorHoverFocused",
+    },
+    // #endregion
 ];
 
 module.exports = keybinds;


### PR DESCRIPTION
- h/j/k/l
- gg/G
- C-f/C-b
- When hover is invisible, K is sent to nvim(show hover); when hover is visible, press K again to focus the hover widget.

Resolve #1681