### PR TITLE
feat: Add option `afterInitConfig`

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,18 @@
                     "title": "Custom init.vim path on Linux",
                     "markdownDescription": "Full path to custom neovim init.vim file on Linux or default WSL distro, equals to startup option `-u`. If the `useWSL` setting is checked, this path will be used to find `init.vim` in Windows Subsystem for Linux. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
                 },
+                "vscode-neovim.afterInitConfig": {
+                    "type": [
+                        "string",
+                        "array"
+                    ],
+                    "default": "",
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "After init config",
+                    "markdownDescription": "Config to be sourced after init config. e.g. : `[\"echo 'hello'\", \"lua << EOF\", \"require'vscode-neovim'.notify('world')\", \"EOF\"]`"
+                },
                 "vscode-neovim.neovimClean": {
                     "type": "boolean",
                     "default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,12 +31,14 @@ export class Config implements Disposable {
         "logOutputToConsole",
         "neovimWidth",
         "useWSL",
+        "wslDistribution",
         "neovimInitVimPaths.darwin",
         "neovimInitVimPaths.linux",
         "neovimInitVimPaths.win32",
         "neovimExecutablePaths.darwin",
         "neovimExecutablePaths.linux",
         "neovimExecutablePaths.win32",
+        "afterInitConfig",
     ].map((c) => `${this.root}.${c}`);
 
     dispose() {
@@ -157,6 +159,10 @@ export class Config implements Disposable {
     }
     get NVIM_APPNAME() {
         return this.cfg.get("NVIM_APPNAME", "");
+    }
+    get afterInitConfig(): string {
+        const config = this.cfg.get<string | string[]>("afterInitConfig", "");
+        return Array.isArray(config) ? config.join("\n") : config;
     }
     get logPath() {
         return this.cfg.get("logPath", "");

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, execSync, spawn } from "child_process";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import path from "path";
 
 import { attach, NeovimClient } from "neovim";
@@ -118,6 +119,13 @@ export class MainController implements vscode.Disposable {
         // #1162
         if (!config.clean && config.neovimInitPath) {
             args.push("-u", config.neovimInitPath);
+        }
+        if (config.afterInitConfig.length) {
+            const storagePath = this.extContext.globalStorageUri.fsPath;
+            if (!existsSync(storagePath)) mkdirSync(storagePath, { recursive: true });
+            const vim = path.join(storagePath, "afterInitConfig.vim");
+            writeFileSync(vim, config.afterInitConfig, { encoding: "utf8" });
+            args.push("-c", `source ${config.useWsl ? wslpath(vim) : vim}`);
         }
         if (config.NVIM_APPNAME) {
             process.env.NVIM_APPNAME = config.NVIM_APPNAME;


### PR DESCRIPTION
The main idea: Save the config to a temporary file, and then use nvim's startup option -c and command source to load the file.

This configuration is suitable for simple operations such as configuring mappings in a temporary environment, but it can also execute any logic. The reason for using "after" is to avoid conflicting with existing configurations, and at the same time, it can be used to determine whether local configurations have been loaded in this configuration, thus executing different logic.

In addition, this configuration will not be automatically ignored based on neovimClean. Users can use "finish" on the first line to end the logic.

Close #1350
