### PR TITLE
fix(buffer): sync layout on doc closed

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -123,6 +123,8 @@ export class BufferManager implements Disposable {
         this.disposables.push(
             window.onDidChangeVisibleTextEditors(this.onEditorLayoutChanged),
             window.onDidChangeActiveTextEditor(this.onEditorLayoutChanged),
+            workspace.onDidCloseTextDocument(this.onEditorLayoutChanged),
+            workspace.onDidCloseNotebookDocument(this.onEditorLayoutChanged),
             window.onDidChangeTextEditorOptions((e) => this.onDidChangeEditorOptions(e.textEditor)),
             workspace.registerTextDocumentContentProvider(BUFFER_SCHEME, this.bufferProvider),
             eventBus.on("redraw", this.handleRedraw, this),


### PR DESCRIPTION
Not sure if this can truly fix a certain problem, but theoretically it will improve a bit by clearing the buffer in time.