### PR TITLE
feat: override the default vim.ui interfaces

### DIFF
--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -1,0 +1,141 @@
+local vscode = require("vscode-neovim")
+
+--- Prompts the user to pick from a list of items, allowing arbitrary (potentially asynchronous)
+--- work until `on_choice`.
+---
+--- Example:
+---
+--- ```lua
+--- vim.ui.select({ 'tabs', 'spaces' }, {
+---     prompt = 'Select tabs or spaces:',
+---     format_item = function(item)
+---         return "I'd like to choose " .. item
+---     end,
+--- }, function(choice)
+---     if choice == 'spaces' then
+---         vim.o.expandtab = true
+---     else
+---         vim.o.expandtab = false
+---     end
+--- end)
+--- ```
+---
+---@param items table Arbitrary items
+---@param opts table Additional options
+---     - prompt (string|nil)
+---               Text of the prompt. Defaults to `Select one of:`
+---     - format_item (function item -> text)
+---               Function to format an
+---               individual item from `items`. Defaults to `tostring`.
+---     - kind (string|nil)
+---               Arbitrary hint string indicating the item shape.
+---               Plugins reimplementing `vim.ui.select` may wish to
+---               use this to infer the structure or semantics of
+---               `items`, or the context in which select() was called.
+---@param on_choice function ((item|nil, idx|nil) -> ())
+---               Called once the user made a choice.
+---               `idx` is the 1-based index of `item` within `items`.
+---               `nil` if the user aborted the dialog.
+local function vscode_ui_select(items, opts, on_choice)
+  -- validate parameters
+  vim.validate({
+    items = { items, "table", false },
+    on_choice = { on_choice, "function", false },
+  })
+  opts = opts or {}
+
+  -- set sane defaults
+  opts.prompt = vim.F.if_nil(opts.prompt, "Select one of")
+  opts.format_item = vim.F.if_nil(opts.format_item, tostring)
+  opts.kind = vim.F.if_nil(opts.prompt, "string")
+
+  -- fill the vscode datastructures
+  local vscode_items = {}
+  for idx, item in ipairs(items) do
+    table.insert(vscode_items, {
+      idx = idx,
+      label = opts.format_item(item),
+      detail = item.detail or nil,
+    })
+  end
+  local vscode_opts = {
+    title = opts.prompt,
+    placeHolder = opts.prompt,
+    matchOnDetail = true,
+  }
+
+  -- open the select dialog
+  vscode.action("ui_select", {
+    args = {
+      items = vscode_items,
+      opts = vscode_opts,
+    },
+    callback = function(err, res)
+      -- distinguish between success and cancelled
+      if not err and type(res) == "table" and res.idx then
+        on_choice(res.label, res.idx)
+      else
+        on_choice(nil, nil)
+      end
+    end,
+  })
+end
+
+--- Prompts the user for input, allowing arbitrary (potentially asynchronous) work until
+--- `on_confirm`.
+---
+--- Example:
+---
+--- ```lua
+--- vim.ui.input({ prompt = 'Enter value for shiftwidth: ' }, function(input)
+---     vim.o.shiftwidth = tonumber(input)
+--- end)
+--- ```
+---
+---@param opts table Additional options. See |input()|
+---     - prompt (string|nil)
+---               Text of the prompt
+---     - default (string|nil)
+---               Default reply to the input
+---@param on_confirm function ((input|nil) -> ())
+---               Called once the user confirms or abort the input.
+---               `input` is what the user typed (it might be
+---               an empty string if nothing was entered), or
+---               `nil` if the user aborted the dialog.
+local function vscode_ui_input(opts, on_confirm)
+  -- validate parameters
+  vim.validate({
+    on_confirm = { on_confirm, 'function', false },
+  })
+  opts = opts or {}
+
+  -- set sane defaults
+  opts.prompt = vim.F.if_nil(opts.prompt, "Enter a value")
+  opts.default = vim.F.if_nil(opts.default, "")
+
+  -- fill the vscode datastructures
+  local vscode_opts = {
+    title = opts.prompt,
+    placeHolder = opts.prompt,
+    value = opts.default,
+  }
+
+  -- open the input dialog
+  vscode.action("ui_input", {
+    args = {
+      opts = vscode_opts,
+    },
+    callback = function(err, res)
+      -- distinguish between empty and cancelled
+      if not err and res ~= nil then
+        on_confirm(res)
+      else
+        on_confirm(nil)
+      end
+    end,
+  })
+end
+
+-- remap the neovim ui function to use the vscode equivalents
+vim.ui.select = vscode_ui_select
+vim.ui.input = vscode_ui_input

--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -45,9 +45,9 @@ local function vscode_ui_select(items, opts, on_choice)
   opts = opts or {}
 
   -- set sane defaults
-  opts.prompt = vim.F.if_nil(opts.prompt, "Select one of")
-  opts.format_item = vim.F.if_nil(opts.format_item, tostring)
-  opts.kind = vim.F.if_nil(opts.prompt, "string")
+  opts.prompt = opts.prompt or "Select one of"
+  opts.format_item = opts.format_item or tostring
+  opts.kind = opts.prompt or "string"
 
   -- fill the vscode datastructures
   local vscode_items = {}
@@ -110,8 +110,8 @@ local function vscode_ui_input(opts, on_confirm)
   opts = opts or {}
 
   -- set sane defaults
-  opts.prompt = vim.F.if_nil(opts.prompt, "Enter a value")
-  opts.default = vim.F.if_nil(opts.default, "")
+  opts.prompt = opts.prompt or "Enter a value"
+  opts.default = opts.default or ""
 
   -- fill the vscode datastructures
   local vscode_opts = {

--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -73,7 +73,7 @@ local function vscode_ui_select(items, opts, on_choice)
     callback = function(err, res)
       -- distinguish between success and cancelled
       if not err and type(res) == "table" and res.idx then
-        on_choice(res.label, res.idx)
+        on_choice(items[res.idx], res.idx)
       else
         on_choice(nil, nil)
       end
@@ -105,7 +105,7 @@ end
 local function vscode_ui_input(opts, on_confirm)
   -- validate parameters
   vim.validate({
-    on_confirm = { on_confirm, 'function', false },
+    on_confirm = { on_confirm, "function", false },
   })
   opts = opts or {}
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -129,6 +129,12 @@ class ActionManager implements Disposable {
         });
         this.add("clipboard_read", () => vscode.env.clipboard.readText());
         this.add("clipboard_write", (text: string) => vscode.env.clipboard.writeText(text));
+        this.add("ui_select", (args: { items: vscode.QuickPickItem[]; opts: vscode.QuickPickOptions }) => {
+            return vscode.window.showQuickPick(args.items, args.opts);
+        });
+        this.add("ui_input", (args: { opts: vscode.InputBoxOptions }) => {
+            return vscode.window.showInputBox(args.opts);
+        });
     }
 
     private initHooks() {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,16 @@
 import { NeovimClient } from "neovim";
 import { VimValue } from "neovim/lib/types/VimValue";
-import vscode, { ConfigurationTarget, Disposable, Range, commands, window, workspace } from "vscode";
+import vscode, {
+    ConfigurationTarget,
+    Disposable,
+    InputBoxOptions,
+    QuickPickItem,
+    QuickPickOptions,
+    Range,
+    commands,
+    window,
+    workspace,
+} from "vscode";
 
 import { disposeAll, rangesToSelections } from "./utils";
 
@@ -129,12 +139,10 @@ class ActionManager implements Disposable {
         });
         this.add("clipboard_read", () => vscode.env.clipboard.readText());
         this.add("clipboard_write", (text: string) => vscode.env.clipboard.writeText(text));
-        this.add("ui_select", (args: { items: vscode.QuickPickItem[]; opts: vscode.QuickPickOptions }) => {
-            return vscode.window.showQuickPick(args.items, args.opts);
-        });
-        this.add("ui_input", (args: { opts: vscode.InputBoxOptions }) => {
-            return vscode.window.showInputBox(args.opts);
-        });
+        this.add("ui_select", (args: { items: QuickPickItem[]; opts: QuickPickOptions }) =>
+            window.showQuickPick(args.items, args.opts),
+        );
+        this.add("ui_input", (args: { opts: InputBoxOptions }) => window.showInputBox(args.opts));
     }
 
     private initHooks() {

--- a/src/test/suite/vscode-integration-specific.test.ts
+++ b/src/test/suite/vscode-integration-specific.test.ts
@@ -533,26 +533,18 @@ describe("VSCode integration specific stuff", () => {
     });
 
     it("vim.ui.select works", async () => {
-        await openTextDocument({ content: "" });
-
-        // trigger vim.ui.select - don't wait on it, otherwise we cannot issue subsequent commands
-        const p1 = client.lua(`
+        await client.lua(`
             vim.ui.select({ 'red', 'green', 'blue' }, {}, function(item, idx)
                 vim.g._ret_item = item
                 vim.g._ret_idx = idx
             end)
         `);
         // wait enough time for it to open
-        await wait(200);
-
+        await wait(100);
         // select the last item
         await vscode.commands.executeCommand("workbench.action.quickOpenNavigateNext");
         await vscode.commands.executeCommand("workbench.action.quickOpenNavigateNext");
         await vscode.commands.executeCommand("workbench.action.acceptSelectedQuickOpenItem");
-
-        // wait for the dialog to close
-        await p1;
-
         // check the results
         const actual_item = await client.getVar("_ret_item");
         const actual_idx = await client.getVar("_ret_idx");
@@ -561,10 +553,7 @@ describe("VSCode integration specific stuff", () => {
     });
 
     it("vim.ui.select with format_item works", async () => {
-        await openTextDocument({ content: "" });
-
-        // trigger vim.ui.select - don't wait on it, otherwise we cannot issue subsequent commands
-        const p1 = client.lua(`
+        await client.lua(`
             vim.ui.select({{ label = 'apple', detail = 'red' }, { label = 'avocado', detail = 'green' }}, {
                 format_item = function(item)
                     return item.label
@@ -575,14 +564,9 @@ describe("VSCode integration specific stuff", () => {
             end)
         `);
         // wait enough time for it to open
-        await wait(200);
-
+        await wait(100);
         // select the first item
         await vscode.commands.executeCommand("workbench.action.acceptSelectedQuickOpenItem");
-
-        // wait for the dialog to close
-        await p1;
-
         // check the results
         const actual_item = await client.getVar("_ret_item");
         const actual_idx = await client.getVar("_ret_idx");
@@ -591,24 +575,16 @@ describe("VSCode integration specific stuff", () => {
     });
 
     it("vim.ui.select cancel returns nil", async () => {
-        await openTextDocument({ content: "" });
-
-        // trigger vim.ui.select - don't wait on it, otherwise we cannot issue subsequent commands
-        const p1 = client.lua(`
+        await client.lua(`
             vim.ui.select({ 'red', 'green', 'blue' }, {}, function(item, idx)
                 vim.g._ret_item = item
                 vim.g._ret_idx = idx
             end)
         `);
         // wait enough time for it to open
-        await wait(200);
-
+        await wait(100);
         // cancel the dialog
         await vscode.commands.executeCommand("workbench.action.closeQuickOpen");
-
-        // wait for the dialog to close
-        await p1;
-
         // check the results
         const actual_item = await client.getVar("_ret_item");
         const actual_idx = await client.getVar("_ret_idx");
@@ -617,69 +593,45 @@ describe("VSCode integration specific stuff", () => {
     });
 
     it("vim.ui.input works", async () => {
-        await openTextDocument({ content: "" });
-
-        // trigger vim.ui.input - don't wait on it, otherwise we cannot issue subsequent commands
-        const p1 = client.lua(`
+        await client.lua(`
             vim.ui.input({ prompt = 'Enter a value: ', default = 'test' }, function(input)
                 vim.g._res = input
             end)
         `);
         // wait enough time for it to open
-        await wait(200);
-
+        await wait(100);
         // confirm the value
         await vscode.commands.executeCommand("workbench.action.acceptSelectedQuickOpenItem");
-
-        // wait for the dialog to close
-        await p1;
-
         // check the results
         const actual_input = await client.getVar("_res");
         assert.strictEqual(actual_input, "test");
     });
 
     it("vim.ui.input empty not nil", async () => {
-        await openTextDocument({ content: "" });
-
-        // trigger vim.ui.input - don't wait on it, otherwise we cannot issue subsequent commands
-        const p1 = client.lua(`
+        await client.lua(`
             vim.ui.input({ prompt = 'Enter a value: ' }, function(input)
                 vim.g._res = input
             end)
         `);
         // wait enough time for it to open
-        await wait(200);
-
+        await wait(100);
         // confirm the value
         await vscode.commands.executeCommand("workbench.action.acceptSelectedQuickOpenItem");
-
-        // wait for the dialog to close
-        await p1;
-
         // check the results
         const actual_input = await client.getVar("_res");
         assert.strictEqual(actual_input, "");
     });
 
     it("vim.ui.input cancel returns nil", async () => {
-        await openTextDocument({ content: "" });
-
-        // trigger vim.ui.select - don't wait on it, otherwise we cannot issue subsequent commands
-        const p1 = client.lua(`
+        await client.lua(`
             vim.ui.input({ prompt = 'Enter a value: ' }, function(input)
                 vim.g._res = input
             end)
         `);
         // wait enough time for it to open
-        await wait(200);
-
+        await wait(100);
         // cancel the dialog
-        await sendEscapeKey();
-
-        // wait for the dialog to close
-        await p1;
-
+        await vscode.commands.executeCommand("workbench.action.closeQuickOpen");
         // check the results
         const actual_input = await client.getVar("_res");
         assert.strictEqual(actual_input, null);

--- a/src/test/suite/vscode-integration-specific.test.ts
+++ b/src/test/suite/vscode-integration-specific.test.ts
@@ -568,9 +568,11 @@ describe("VSCode integration specific stuff", () => {
         // select the first item
         await vscode.commands.executeCommand("workbench.action.acceptSelectedQuickOpenItem");
         // check the results
-        const actual_item = await client.getVar("_ret_item");
+        const actual_item = (await client.getVar("_ret_item")) as { label: string; detail: string };
         const actual_idx = await client.getVar("_ret_idx");
-        assert.strictEqual(actual_item, "apple");
+        assert.ok(typeof actual_item === "object");
+        assert.strictEqual(actual_item.label, "apple");
+        assert.strictEqual(actual_item.detail, "red");
         assert.strictEqual(actual_idx, 1);
     });
 


### PR DESCRIPTION
Override the default vim.ui interfaces using the QuickPick and InputBox APIs. Uses two new actions, ui_select and ui_input to wire up the ui functions.
* Previous pull request: https://github.com/vscode-neovim/vscode-neovim/pull/1709