### PR TITLE
Add neovim.fullMode context key for mode(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,19 @@ To pass custom bindings to Neovim, for example <kbd>C-h</kbd> in normal mode, ad
 }
 ```
 
+If you need more precise information about the mode (i.e. `mode(1)` in neovim),
+you can use the `neovim.fullMode` context key for matching:
+
+```jsonc
+{
+    "command": "vscode-neovim.send",
+    "key": "ctrl+h",
+    // don't activate during insert or operator-pending mode
+    "when": "editorTextFocus && !(neovim.fullMode =~ /^(i|no)/)",
+    "args": "<C-h>"
+}
+```
+
 ### Disable keybindings
 
 There are three configurations for toggling keybindings:

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -115,7 +115,7 @@ type EventsMapping = {
     ["open-file"]: [string, 1 | 0 | "all"];
     ["external-buffer"]: [BufferInfo, 1 | 0, number];
     ["window-changed"]: [number];
-    ["mode-changed"]: [string];
+    ["mode-changed"]: [string, string];
     ["notify-recording"]: undefined;
     reveal: ["center" | "top" | "bottom", boolean];
     ["move-cursor"]: ["top" | "middle" | "bottom"];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,7 @@ export function deactivate(isRestart = false) {
     // Reset all when clause contexts that impact the keybindings
     VSCodeContext.set("neovim.init");
     VSCodeContext.set("neovim.mode");
+    VSCodeContext.set("neovim.fullMode");
     VSCodeContext.set("neovim.recording");
     if (!isRestart) disposeAll(disposables);
 }

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -105,7 +105,7 @@ augroup VscodeGeneral
     " Looks like external windows are coming with "set wrap" set automatically, disable them
     " autocmd WinNew,WinEnter * :set nowrap
     autocmd WinScrolled * call VSCodeExtensionNotify('window-scroll', win_getid(), winsaveview())
-    autocmd VimEnter,ModeChanged * call VSCodeExtensionNotify('mode-changed', mode())
+    autocmd VimEnter,ModeChanged * call VSCodeExtensionNotify('mode-changed', mode(), mode(1))
     autocmd WinEnter * call VSCodeExtensionNotify('window-changed', win_getid())
     " LazyVim will clear runtimepath by default. To avoid user intervention, we need to set it again.
     autocmd User LazyDone let &runtimepath = &runtimepath . ',' . s:runtimePath


### PR DESCRIPTION
Closes #1718 

Similar to `neovim.mode` but simpler, this is just a raw passthrough of `mode(1)` to the VScode keybinding contexts.

I'm happy to adjust the implementation if an alternative seems preferable, but this was easy enough to write so just figured I'd put up a PR based on my thoughts there.