### PR TITLE
make visual-multi works again! #1056 #409 #97 #992

### DIFF
--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -80,6 +80,9 @@ function! s:onInsertEnter()
     if !empty(reg)
         call VSCodeExtensionNotify('notify-recording', reg)
     endif
+    if exists("b:VM_Selection") && !empty(b:VM_Selection)
+        call VSCodeExtensionNotify('notify-recording', reg)
+    endif
 endfunction
 
 


### PR DESCRIPTION
# Background
As #1056 said, #992 breaks my favorite plugin [https://github.com/mg979/vim-visual-multi](https://github.com/mg979/vim-visual-multi),  I simply can't work without it. from neovim to ideavim, it’s always with me.
The vscode-neovim is a perfect tool except that it lacks this plugin. It's such a shame!
So, I decided to fix it.
I start from https://github.com/vscode-neovim/vscode-neovim/issues/1056#issuecomment-1280190144 , and study a lot by https://github.com/vscode-neovim/vscode-neovim/pull/992 , then study many Neovim api..., and then, I follow @theol0403 to convert the `nvim_buf_set_text` param `{buffer}, {start_row}, {start_col}, {end_row}, {end_col}, {replacement}` to nvim_input.
The 1st step is check it's on multi edit or not. this is easy by read the `visual-multi` source code, we can check it by 
```lua
local success, selection = pcall(vim.api.nvim_buf_get_var, bufnr, 'VM_Selection')
if success and selection ~= '' then
  print("In selection mode")
else
  print("Not in selection mode")
end
```
we can add this code to https://github.com/vscode-neovim/vscode-neovim/blob/d93300bc193c2fee18465f29acadff08c19bac6a/runtime/lua/vscode-neovim/internal.lua#L48-L52, since we can o avoid RPC round trips.

 At first, it ran very nice until I hit the backspace key, it broke me! I spent two hours hard work code to compare the old and new lines, and then figure out where the backspace key was needed. now I met Left and Right! Obviously, this cannot be calculated from these parameters. 😢 

It is also possible to roll back to the previous code, because according to the issue, it can be used before 0.9. It can be clearly seen from the pull request record that the `nvim_buf_set_lines` api was used before. Fortunately, there is not much difference between the two APIs. The original lines can be obtained through `nvim_buf_get_lines`, merged to produce the final lines, then updated with `nvim_buf_set_lines`. However, this does not work at all and does not restore visual-multi to its original state.


Finally, it was 2 o'clock in the morning and I still couldn't get it done. I thought it was time to give up. It seemed like an impossible task.
 At this moment, I suddenly thought that what I just did was to restore the user input to the keys queue and then pass it to `nvim_input`. If we capture the user's keys input and then send it directly to neovim without vscode processing, then Isn't that what we want?

https://github.com/vscode-neovim/vscode-neovim/blob/d93300bc193c2fee18465f29acadff08c19bac6a/src/typing_manager.ts#L128-L134

it check the isInsertMode  and not in Recording mode then bind the keys to neovim, we just update Recording to `isRecordingInInsertMode` when we met visual-multi, and when we final the edit, it will back to normal mode, now `mode_manager` will set `isRecordingInInsertMode` back!
https://github.com/vscode-neovim/vscode-neovim/blob/d93300bc193c2fee18465f29acadff08c19bac6a/src/mode_manager.ts#L105-L110

So, the final code is very simple.

By the way, it also fixes the previous problem of displaying content synchronously after editing is completed. Now, it works very well, just like in real neovim.
