### PR TITLE
feat: expose logs in OutputChannel, log info on startup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,22 +6,22 @@ body:
     - type: markdown
       attributes:
           value: |
-                ### Before reporting an issue:
-                - Set `vscode-neovim.neovimClean` in VSCode settings to confirm if the issue is caused by an Nvim plugin.
-                - Read the [documentation](https://github.com/vscode-neovim/vscode-neovim/) and search [existing issues](https://github.com/vscode-neovim/vscode-neovim/issues).
-                - Usage questions such as ***"How do I...?"*** belong in [Discussions](https://github.com/vscode-neovim/vscode-neovim/discussions) and will be closed.
-                - Plugins that provide their own UI, or work during _insert-mode_, are not supported.
-                - Nvim can only interact with one window at a time.
-                - Highlights are best-effort.
+              ### Before reporting an issue:
+              - Set `vscode-neovim.neovimClean` in VSCode settings to confirm if the issue is caused by an Nvim plugin.
+              - Read the [documentation](https://github.com/vscode-neovim/vscode-neovim/) and search [existing issues](https://github.com/vscode-neovim/vscode-neovim/issues).
+              - Usage questions such as ***"How do I...?"*** belong in [Discussions](https://github.com/vscode-neovim/vscode-neovim/discussions) and will be closed.
+              - Plugins that provide their own UI, or work during _insert-mode_, are not supported.
+              - Nvim can only interact with one window at a time.
+              - Highlights are best-effort.
     - type: checkboxes
       attributes:
-          label: 'Check the following:'
+          label: "Check the following:"
           options:
               - label: 'I have checked the behavior after setting "vscode-neovim.neovimClean" in VSCode settings.'
                 required: true
-              - label: 'I have read the vscode-neovim docs.'
+              - label: "I have read the vscode-neovim docs."
                 required: true
-              - label: 'I have searched existing issues.'
+              - label: "I have searched existing issues."
                 required: true
     - type: input
       attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,14 @@ npx vsce package -o vscode-neovim.vsix
 1. Open the repo in VSCode.
 2. Go to debug view and click `Run Extension` (F5).
 
+### Logging
+
+You can observe the extension logs via the `vscode-neovim` Output channel or from the dev tools
+console (run the `Developer: Toggle Developer Tools` vscode command to see the console).
+
+Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by
+the [`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).
+
 ### Run Tests
 
 1. Open the repo in VSCode.

--- a/README.md
+++ b/README.md
@@ -127,15 +127,17 @@ have built-in support for `cond = vim.g.vscode`. See
 
 ### Troubleshooting
 
-- Enable `vscode-neovim.neovimClean` in VSCode settings, which starts Nvim _without_ your plugins
-  (`nvim --clean`). Nvim plugins can do _anything_. Visual effects in particular can cause visual
-  artifacts. vscode-neovim does its best to merge the visual effects of Nvim and VSCode, but it's
-  far from perfect. You may need to disable some Nvim plugins that cause visual effects.
-- If you encounter rendering issues (visual artifacts), try <kbd>CTRL-L</kbd> to force Nvim to redraw.
-- If you get the `Unable to init vscode-neovim: command 'type' already exists` message, uninstall
-  other VSCode extensions that use `registerTextEditorCommand("type", …)` (like
-  [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
-  [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
+-   Set the `vscode-neovim.logLevel` setting to "info", then restart vscode. View the logs via
+    `Output: Focus on Output View` and select `vscode-neovim`.
+-   Enable `vscode-neovim.neovimClean` in VSCode settings, which starts Nvim _without_ your plugins (`nvim --clean`).
+    Nvim plugins can do _anything_. Visual effects in particular can cause visual artifacts. vscode-neovim does its best
+    to merge the visual effects of Nvim and VSCode, but it's far from perfect. You may need to disable some Nvim plugins
+    that cause visual effects.
+-   If you encounter rendering issues (visual artifacts), try <kbd>CTRL-L</kbd> to force Nvim to redraw.
+-   If you get the `Unable to init vscode-neovim: command 'type' already exists` message, uninstall other VSCode
+    extensions that use `registerTextEditorCommand("type", …)` (like
+    [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
+    [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
 
 ### Performance
 

--- a/package.json
+++ b/package.json
@@ -43,51 +43,49 @@
                     "type": "string",
                     "default": "",
                     "title": "Neovim path",
-                    "markdownDescription": "*Windows, OSX, Linux in Neovim path settings won`t work if this setting is set* Full path to Neovim executable. If you have enabled `useWSL` setting, specify the Linux path to nvim executable instead.",
-                    "deprecationMessage": "This setting is deprecated. Remove this setting and use neovimExecutablePaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimExecutablePaths.windows/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
+                    "deprecationMessage": "Remove this setting and use neovimExecutablePaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimExecutablePaths.windows/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
                 },
                 "vscode-neovim.neovimExecutablePaths.win32": {
                     "type": "string",
                     "default": "nvim",
                     "title": "Neovim executable path on Windows",
-                    "markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Windows.  \nExample:  \nC:\\tools\\neovim\\Neovim\\bin\\nvim.exe (if you installed using Chocolatey)  \nIf you want to use Windows Subsystem for Linux, enable the `useWSL` setting and set `neovimExecutablePaths.linux` instead"
+                    "markdownDescription": "Path to Nvim executable if running VS Code on Windows. \n- Example: `C:\\tools\\neovim\\Neovim\\bin\\nvim.exe` (if you installed using Chocolatey)\n- If you want to use Windows Subsystem for Linux, enable the `useWSL` setting and set `neovimExecutablePaths.linux` instead"
                 },
                 "vscode-neovim.neovimExecutablePaths.darwin": {
                     "type": "string",
                     "default": "nvim",
-                    "title": "Neovim executable path on OSX",
-                    "description": "Full path to Neovim executable that should be used by the extension if running VS Code on OSX."
+                    "title": "Neovim executable path on macOS",
+                    "markdownDescription": "Path to Nvim executable if running VS Code on macOS."
                 },
                 "vscode-neovim.neovimExecutablePaths.linux": {
                     "type": "string",
                     "default": "nvim",
                     "title": "Neovim executable path on Linux (and in WSL)",
-                    "markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Linux or WSL. If `useWSL` setting is checked, vscode-neovim will look for this path in default WSL distro  \nExample:  \n/usr/bin/nvim"
+                    "markdownDescription": "Path to Nvim executable if running VS Code on Linux or WSL. \n- Example: `/usr/bin/nvim`\n- If `useWSL` setting is checked, vscode-neovim will look for this path in default WSL distro."
                 },
                 "vscode-neovim.neovimInitPath": {
                     "type": "string",
                     "default": "",
                     "title": "Custom init.vim path",
-                    "description": "Full path to custom neovim init file, equals to startup option -u. If checked useWSL flag specify a Linux path. You can also use exists('g:vscode') in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode",
-                    "deprecationMessage": "This setting is deprecated. Use neovimInitVimPaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimInitVimPaths.win32/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
+                    "deprecationMessage": "Use neovimInitVimPaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimInitVimPaths.win32/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
                 },
                 "vscode-neovim.neovimInitVimPaths.win32": {
                     "type": "string",
                     "default": "",
                     "title": "Custom init.vim path on Windows",
-                    "markdownDescription": "Full path to custom neovim init.vim file on Windows, equals to startup option `-u`. If the `useWSL` setting is checked, the value of the `neovimInitVimPaths.linux` setting will be used to find the init.vim file instead. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
+                    "markdownDescription": "Path to alternative `init.vim` file on Windows, equivalent to Nvim startup option `-u`. If `useWSL` is enabled, the value of the `neovimInitVimPaths.linux` setting will be used to find the init.vim file instead. You can also use `exists('g:vscode')` in your `init.vim` to check if Nvim is running in vscode."
                 },
                 "vscode-neovim.neovimInitVimPaths.darwin": {
                     "type": "string",
                     "default": "",
-                    "title": "Custom init.vim path on OSX",
-                    "markdownDescription": "Full path to custom neovim init.vim file on OSX, equals to startup option `-u`. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
+                    "title": "Custom init.vim path on macOS",
+                    "markdownDescription": "Path to alternative `init.vim` file on macOS, equivalent to Nvim startup option `-u`. You can also use `exists('g:vscode')` in your `init.vim` to check if Nvim is running in vscode."
                 },
                 "vscode-neovim.neovimInitVimPaths.linux": {
                     "type": "string",
                     "default": "",
                     "title": "Custom init.vim path on Linux",
-                    "markdownDescription": "Full path to custom neovim init.vim file on Linux or default WSL distro, equals to startup option `-u`. If the `useWSL` setting is checked, this path will be used to find `init.vim` in Windows Subsystem for Linux. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
+                    "markdownDescription": "Path to alternative `init.vim` file on Linux or default WSL distro, equivalent to Nvim startup option `-u`. If the `useWSL` setting is checked, this path will be used to find `init.vim` in Windows Subsystem for Linux. You can also use `exists('g:vscode')` in your `init.vim` to check if Nvim is running in vscode."
                 },
                 "vscode-neovim.afterInitConfig": {
                     "type": "array",
@@ -106,7 +104,7 @@
                 "vscode-neovim.NVIM_APPNAME": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "See `:h NVIM_APPNAME`."
+                    "markdownDescription": "See `:help NVIM_APPNAME`."
                 },
                 "vscode-neovim.neovimWidth": {
                     "type": "number",
@@ -127,16 +125,14 @@
                     "description": "How much to extend neovim viewport on each side beyond vscode editor size. Increase if you are not seeing decorations or highlights on the edges of the editor."
                 },
                 "vscode-neovim.useCtrlKeysForNormalMode": {
-                    "deprecationMessage": "Use vscode-neovim.ctrlKeysForNormalMode instead (Set it to empty)",
+                    "deprecationMessage": "Use `vscode-neovim.ctrlKeysForNormalMode` instead (Set it to empty)",
                     "type": "boolean",
-                    "default": true,
-                    "description": "Use Ctrl keys in normal/visual/etc...(except insert) modes"
+                    "default": true
                 },
                 "vscode-neovim.useCtrlKeysForInsertMode": {
-                    "deprecationMessage": "Use vscode-neovim.ctrlKeysForInsertMode instead (Set it to empty)",
+                    "deprecationMessage": "Use `vscode-neovim.ctrlKeysForInsertMode` instead (Set it to empty)",
                     "type": "boolean",
-                    "default": true,
-                    "description": "Use Ctrl keys in insert mode"
+                    "default": true
                 },
                 "vscode-neovim.ctrlKeysForNormalMode": {
                     "type": "array",
@@ -304,14 +300,15 @@
                         "none",
                         "error",
                         "warn",
+                        "info",
                         "debug"
                     ],
-                    "description": "Log Level"
+                    "markdownDescription": "Log Level. See also `vscode-neovim.logOutputToConsole`."
                 },
                 "vscode-neovim.logOutputToConsole": {
                     "type": "boolean",
                     "default": false,
-                    "description": "When on, print log messages to vscode developer console (not output channel!)"
+                    "markdownDescription": "Log to vscode developer console (not output channel!). \n- Hint: Run the `Developer: Toggle Developer Tools` command to see the console. \n- Hint: Adjust the `vscode-neovim.logLevel` setting to see more messages."
                 },
                 "vscode-neovim.highlightGroups.highlights": {
                     "type": "object",

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -26,7 +26,7 @@ import {
     rangesToSelections,
 } from "./utils";
 
-const logger = createLogger("CursorManager");
+const logger = createLogger("CursorManager", false);
 
 interface CursorInfo {
     cursorShape: "block" | "horizontal" | "vertical";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 
 import actions from "./actions";
 import { config } from "./config";
-import { EXT_ID } from "./constants";
+import { EXT_ID, EXT_NAME } from "./constants";
 import { eventBus } from "./eventBus";
 import { LogLevel, createLogger, logger as rootLogger } from "./logger";
 import { MainController } from "./main_controller";
@@ -27,8 +27,11 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
         verifyExperimentalAffinity();
     }
 
+    const outputChannel = vscode.window.createOutputChannel(EXT_NAME, { log: true });
+    disposables.push(outputChannel);
+
     config.init();
-    rootLogger.init(LogLevel[config.logLevel], config.logPath, config.outputToConsole);
+    rootLogger.init(LogLevel[config.logLevel], config.logPath, config.outputToConsole, outputChannel);
     eventBus.init();
     actions.init();
     context.subscriptions.push(
@@ -42,7 +45,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
     try {
         const plugin = new MainController(context);
         context.subscriptions.push(plugin);
-        await plugin.init();
+        await plugin.init(outputChannel);
     } catch (e) {
         vscode.window
             .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart")

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,20 +3,35 @@ import fs from "fs";
 import { inspect } from "util";
 
 import { Disposable, window } from "vscode";
+import * as vscode from "vscode";
 
 import { disposeAll } from "./utils";
 
 export enum LogLevel {
+    /** Disables all logging. */
     none = 0,
     error = 1,
     warn = 2,
-    debug = 3,
+    info = 3,
+    debug = 4,
 }
 
 export interface ILogger {
     debug(...args: any[]): void;
+    info(...args: any[]): void;
     warn(...args: any[]): void;
     error(...args: any[]): void;
+    /**
+     * Logs a message only if `uri` is not a log file/channel (to avoid infinite loop).
+     *
+     * If the user is viewing the extension OutputChannel or logfile, we must
+     * not log events triggered by that channel or file itself.
+     *
+     * @param uri Document that triggered the log event.
+     * @param level Log level.
+     * @param logArgs Log message format string followed by values.
+     */
+    log(uri: vscode.Uri | undefined, level: LogLevel, ...logArgs: any[]): void;
 }
 
 function getTimestamp(): string {
@@ -28,11 +43,22 @@ export class Logger implements Disposable {
     private fd = 0;
     private loggers: Map<string, ILogger> = new Map();
     private level!: LogLevel;
-    private outputToConsole!: boolean;
+    private logToConsole!: boolean;
+    private outputChannel?: vscode.LogOutputChannel;
 
-    public init(level: LogLevel, filePath: string, outputToConsole = false) {
+    /**
+     * Setup logging for the extension. Logs are dropped unless one or more of
+     * `filePath`, `logToConsole`, or `outputChannel` is given.
+     *
+     * @param level Only log messages at or above this level, or never if set to `LogLevel.none`.
+     * @param filePath Write messages to this file.
+     * @param logToConsole Write messages to the `console` (Hint: run the "Developer: Toggle Developer Tools" vscode command to see the console).
+     * @param outputChannel Write messages to this vscode output channel.
+     */
+    public init(level: LogLevel, filePath: string, logToConsole = false, outputChannel?: vscode.LogOutputChannel) {
         this.level = level;
-        this.outputToConsole = outputToConsole;
+        this.logToConsole = logToConsole;
+        this.outputChannel = outputChannel;
         if (filePath && level !== LogLevel.none) {
             try {
                 this.fd = fs.openSync(filePath, "w");
@@ -43,15 +69,13 @@ export class Logger implements Disposable {
                 // ignore
             }
         }
-        // this.channel = window.createOutputChannel(EXT_NAME);
-        // this.disposables.push(this.channel);
     }
 
     public dispose(): void {
         disposeAll(this.disposables);
     }
 
-    private log(level: LogLevel, scope: string, args: any[]): void {
+    private log(level: LogLevel, scope: string, logToOutputChannel: boolean, args: any[]): void {
         const msg = args.reduce((p, c, i) => {
             if (typeof c === "object") {
                 try {
@@ -66,31 +90,87 @@ export class Logger implements Disposable {
         if (this.fd) {
             fs.appendFileSync(this.fd, msg + "\n");
         }
-        if (this.outputToConsole) {
+        if (this.logToConsole) {
             console[level == LogLevel.error ? "error" : "log"](`${getTimestamp()} ${scope}: ${msg}`);
         }
+
+        // Half-baked attempt to avoid infinite loop.
+        // Preferred approach is for modules to decide this via `createLogger(…, logToOutputChannel=…)`.
+        const activeDoc = window.activeTextEditor?.document; // "output:asvetliakov.vscode-neovim.vscode-neovim"
+        const outputFocused = activeDoc?.uri.scheme === "output" || activeDoc?.fileName?.startsWith("output:");
+
+        if (logToOutputChannel && this.outputChannel && activeDoc && !outputFocused) {
+            const fullMsg = `${scope}: ${msg}`;
+            switch (level) {
+                case LogLevel.error:
+                    this.outputChannel.error(fullMsg);
+                    break;
+                case LogLevel.warn:
+                    this.outputChannel.warn(fullMsg);
+                    break;
+                case LogLevel.info:
+                case LogLevel.debug:
+                    // XXX: `vscode.LogOutputChannel` loglevel is currently readonly:
+                    //      https://github.com/microsoft/vscode/issues/170450
+                    //      https://github.com/PowerShell/vscode-powershell/issues/4441
+                    // So debug() drops messages unless the user has increased vscode's log-level.
+                    // Use info() until vscode adds a way to set the loglevel.
+                    this.outputChannel.info(fullMsg);
+                    break;
+                case LogLevel.none:
+                    // Do nothing. This should never happen because the logger isn't setup for level=none.
+                    break;
+            }
+        }
+
         if (level === LogLevel.error) {
             window.showErrorMessage(msg);
         }
     }
 
-    public createLogger(scope: string): ILogger {
+    public createLogger(scope: string, logToOutputChannel: boolean): ILogger {
         const logger = this.loggers.has(scope)
             ? this.loggers.get(scope)!
             : {
                   debug: (...args: any[]) => {
                       if (this.level >= LogLevel.debug) {
-                          this.log(LogLevel.debug, scope, args);
+                          this.log(LogLevel.debug, scope, logToOutputChannel, args);
+                      }
+                  },
+                  info: (...args: any[]) => {
+                      if (this.level >= LogLevel.info) {
+                          this.log(LogLevel.info, scope, logToOutputChannel, args);
                       }
                   },
                   warn: (...args: any[]) => {
                       if (this.level >= LogLevel.warn) {
-                          this.log(LogLevel.warn, scope, args);
+                          this.log(LogLevel.warn, scope, logToOutputChannel, args);
                       }
                   },
                   error: (...args: any[]) => {
                       if (this.level >= LogLevel.error) {
-                          this.log(LogLevel.error, scope, args);
+                          this.log(LogLevel.error, scope, logToOutputChannel, args);
+                      }
+                  },
+                  log(uri: vscode.Uri | undefined, level: LogLevel, ...logArgs: any[]) {
+                      const isLogSink = uri?.scheme === "output" || uri?.toString().startsWith("output:");
+                      if (!uri || isLogSink) {
+                          return;
+                      }
+                      switch (level) {
+                          case LogLevel.error:
+                              logger.error(...logArgs);
+                              break;
+                          case LogLevel.warn:
+                              logger.warn(...logArgs);
+                              break;
+                          case LogLevel.info:
+                          case LogLevel.debug:
+                              logger.debug(...logArgs);
+                              break;
+                          case LogLevel.none:
+                              // Do nothing. This should never happen because the logger isn't setup for level=none.
+                              break;
                       }
                   },
               };
@@ -101,6 +181,6 @@ export class Logger implements Disposable {
 
 export const logger = new Logger();
 
-export function createLogger(scope = "Neovim"): ILogger {
-    return logger.createLogger(scope);
+export function createLogger(scope = "Neovim", logToOutputChannel = true): ILogger {
+    return logger.createLogger(scope, logToOutputChannel);
 }

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -1,17 +1,12 @@
-import { Disposable, OutputChannel, window } from "vscode";
+import { Disposable, LogOutputChannel } from "vscode";
 
-import { EXT_NAME } from "./constants";
 import { EventBusData, eventBus } from "./eventBus";
 import { disposeAll } from "./utils";
 
-export class MultilineMessagesManager implements Disposable {
+export class MessagesManager implements Disposable {
     private disposables: Disposable[] = [];
 
-    private channel: OutputChannel;
-
-    public constructor() {
-        this.channel = window.createOutputChannel(`${EXT_NAME}`);
-        this.disposables.push(this.channel);
+    public constructor(readonly channel: LogOutputChannel) {
         eventBus.on("redraw", this.handleRedraw, this, this.disposables);
     }
 


### PR DESCRIPTION
- Introduce `Logger.info()` and "info" log-level.
- Cleanup settings descriptions.
- Create outputChannel as a `{ log: true }` channel for enhanced rendering and features.
- Allow the logger to log to the vscode Output channel. 
    - But disable it for noisy (and looping) sources like `CursorManager` and `DocumentChangeManager`.


![image](https://github.com/vscode-neovim/vscode-neovim/assets/1359421/9442cdde-43d6-43df-bc6b-ec653304899e)
