### PR TITLE
build: pass --disable-extensions during debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": [
-                // "--disable-extensions",
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
+            "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
             "smartStep": true,
             "preLaunchTask": "Watch"


### PR DESCRIPTION
Enabling other extensions during debugging is incredibly irritating.