### PR TITLE
fix(logging): infinite loop in BufferManager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,11 @@ npx vsce package -o vscode-neovim.vsix
 
 ### Logging
 
-You can observe the extension logs via the `vscode-neovim` Output channel or from the dev tools
-console (run the `Developer: Toggle Developer Tools` vscode command to see the console).
+You can observe the extension logs via the `vscode-neovim` Output channel or from the dev tools console (run the
+`Developer: Toggle Developer Tools` vscode command to see the console).
 
-Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by
-the [`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).
+Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
+[`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).
 
 ### Run Tests
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -153,10 +153,19 @@ export class Logger implements Disposable {
                       }
                   },
                   log(uri: vscode.Uri | undefined, level: LogLevel, ...logArgs: any[]) {
-                      const isLogSink = uri?.scheme === "output" || uri?.toString().startsWith("output:");
-                      if (!uri || isLogSink) {
+                      const isLogSink =
+                          !uri ||
+                          uri.scheme === "output" ||
+                          uri.toString().startsWith("output:") ||
+                          // XXX: may get filepath like
+                          //    "/my/workspace/path/output:asvetliakov.vscode-neovim.vscode-neovim"
+                          // This seems like a bug ("output:…" channel path appended to a workspace path?), but we should detect it here and avoid a loop nevertheless.
+                          /[/\\]output:[^/\\]+$/i.test(uri.path);
+
+                      if (isLogSink) {
                           return;
                       }
+
                       switch (level) {
                           case LogLevel.error:
                               logger.error(...logArgs);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ import {
 } from "vscode";
 
 import { config } from "./config";
-import { ILogger } from "./logger";
+import { ILogger, LogLevel } from "./logger";
 
 /**
  * Stores last changes information for dot repeat
@@ -302,7 +302,7 @@ export async function callAtomic(
     const res = (await client.callAtomic(requests)) as unknown as [unknown[], [number, unknown, string] | null];
     // Should never reach here if neovim is behaving correctly
     if (!(res && Array.isArray(res) && Array.isArray(res[0]))) {
-        logger.error(`Unexpected result from nvim_call_atomic`);
+        logger.log(undefined, LogLevel.error, `Unexpected result from nvim_call_atomic`);
         return;
     }
     const returned_errors = res[1];
@@ -313,9 +313,9 @@ export async function callAtomic(
         const errMsg = `${requestName}: ${err_msg} (Error type: ${err_type})`;
         // TODO: Determine cause for errors for both of these requests
         if (requestName === "nvim_input" || requestName === "nvim_win_close") {
-            logger.warn(errMsg);
+            logger.log(undefined, LogLevel.warn, errMsg);
         } else {
-            logger.error(errMsg);
+            logger.log(undefined, LogLevel.error, errMsg);
         }
     }
 }


### PR DESCRIPTION
## Problem:
BufferManager log messages can cause an infinite loop. #1788

## Solution:
- Pass the document URI to the BufferManager logger so that it can detect when a log message was triggered by the OutputChannel itself (causing a loop).
- Expand the `isLogSink` condition so that it can detect the OutputChannel even if its URI is nonsense such as `/my/workspace/path/output:asvetliakov.vscode-neovim.vscode-neovim`.

Fix #1788