### PR TITLE
build: remove "glob" dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ support nvim bindings.
     -   All other files are managers responsible for syncing a specific aspect of the editor with nvim (such as mode)
         between vscode and nvim
 -   `package.json`: The extension manifest. This is where the extension is configured. This is also where:
-    -   Non-alphanumaric keyboard shortcuts are intercepted and sent to nvim.
+    -   Non-alphanumeric keyboard shortcuts are intercepted and sent to nvim.
     -   Default keybindings targeting vscode features are defined, to make vscode's interface feel more vim-like.
         Shortcuts defined here also have the advantage of having access to vscode's when clause contexts, and are easier
         for users to override.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-import": "^2.29.1",
                 "eslint-plugin-prettier": "^5.1.3",
-                "glob": "^8.0.3",
                 "husky": "^9.0.10",
                 "mocha": "^10.3.0",
                 "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -2096,7 +2096,6 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^5.1.3",
-        "glob": "^8.0.3",
         "husky": "^9.0.10",
         "mocha": "^10.3.0",
         "prettier": "^3.2.5",


### PR DESCRIPTION
Problem:
`glob` is only used by the test runner, which was likely copied from the starter code provided by vscode docs.

Solution:
Use vscode `findFiles()` and remove `glob` dependency.