### PR TITLE
fix(startup): $VIMRUNTIME check fails on WSL

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -1,6 +1,5 @@
 import { ChildProcess, spawn } from "child_process";
 import path from "path";
-import fs from "node:fs";
 
 import { attach, NeovimClient } from "neovim";
 import vscode, { Disposable, Range, window, type ExtensionContext } from "vscode";
@@ -373,12 +372,13 @@ export class MainController implements vscode.Disposable {
         `;
         const runtimeDir = await this.client.executeLua(luaCode, []);
         try {
-            const files = typeof runtimeDir === "string" ? fs.readdirSync(runtimeDir) : [];
+            const runtimeDirUri = typeof runtimeDir === "string" ? vscode.Uri.file(runtimeDir) : undefined;
+            const files = runtimeDirUri ? await vscode.workspace.fs.readDirectory(runtimeDirUri) : [];
             if (files.length <= 0) {
                 throw new Error();
             }
             return;
-        } catch {
+        } catch (err) {
             logger.error(
                 `Cannot read $VIMRUNTIME directory "${runtimeDir}". Ensure that VSCode has access to that directory. Also try :checkhealth.`,
             );


### PR DESCRIPTION
Problem:
Since c9ddc3ea90444, on startup, on WSL and flatpak, vscode-neovim shows a $VIMRUNTIME read error.

    Cannot read $VIMRUNTIME directory "/opt/nvim-linux64/share/nvim/runtime".
    Ensure that VSCode has access to that directory. Also try :checkhealth.

Solution:
Use vscode's VFS (virtual filesystem) instead of the node API. TODO: we should use vscode's VFS _everywhere_, if possible.

Fix #1848