### PR TITLE
feat: `vscode.eval()`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ Note: some messages are not logged to the Output channel, to avoid infinite loop
 
 1. Open the repo in VSCode.
 2. Go to debug view and click `Extension Tests` (F5).
-3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts` or set the `VSCODE_NEOVIM_TEST_REGEX`
-   environment variable, e.g. `VSCODE_NEOVIM_TEST_REGEX=foo npm run test`.
+3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts` or set the `NEOVIM_TEST_REGEX`
+   environment variable, e.g. `NEOVIM_TEST_REGEX=foo npm run test`.
 
 ## Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ Note: some messages are not logged to the Output channel, to avoid infinite loop
 
 1. Open the repo in VSCode.
 2. Go to debug view and click `Extension Tests` (F5).
-3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts` or set the `NEOVIM_TEST_REGEX`
-   environment variable, e.g. `NEOVIM_TEST_REGEX=foo npm run test`.
+3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts` or set the `NEOVIM_TEST_REGEX` environment
+   variable, e.g. `NEOVIM_TEST_REGEX=foo npm run test`.
 
 ## Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Note: some messages are not logged to the Output channel, to avoid infinite loop
 1. Open the repo in VSCode.
 2. Go to debug view and click `Extension Tests` (F5).
 3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts` or set the `NEOVIM_TEST_REGEX` environment
-   variable, e.g. `NEOVIM_TEST_REGEX=foo npm run test`.
+   variable, e.g. `NEOVIM_TEST_REGEX="foo bar" npm run test`.
 
 ## Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ Note: some messages are not logged to the Output channel, to avoid infinite loop
 
 1. Open the repo in VSCode.
 2. Go to debug view and click `Extension Tests` (F5).
-3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts`.
+3. To run individual tests, modify `grep: ".*"` in `src/test/suite/index.ts` or set the `VSCODE_NEOVIM_TEST_REGEX`
+   environment variable, e.g. `VSCODE_NEOVIM_TEST_REGEX=foo npm run test`.
 
 ## Design Principles
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ local vscode = require('vscode-neovim')
    statusbar item.
 10. `g:vscode_clipboard`: Clipboard provider using VSCode's clipboard API. Used by default when in WSL. See
     `:h g:clipboard` for more details. Usage: `let g:clipboard = g:vscode_clipboard`
-11. `vscode.eval()`: evaluate javascript in vscode and return the result
+11. `vscode.eval()`: evaluate javascript synchronously in vscode and return the result
+12. `vscode.eval_async()`: evaluate javascript asynchronously in vscode
 
 ### vscode.action(name, opts)
 
@@ -478,7 +479,7 @@ test.text = nil -- Close the item
 test.text = '' -- error: The status item "test" has been closed
 ```
 
-### vscode.eval(code[, args])
+### vscode.eval(code[, opts])
 
 Evaluate javascript inside vscode and return the result. The code is executed in an async function context (so `await`
 can be used). Use a `return` statement to return a value back to lua. Arguments passed from lua are available as the
@@ -496,8 +497,9 @@ Tips:
 Parameters:
 
 -   `code (string)`: The javascript to execute.
--   `args (any)`: Optionally provide arguments that are accessible as the `args` variable in javascript. Can be a single
-    value such as a string or a table of multiple values.
+-   `opts` (table): Map of optional parameters:
+    -   `args` (any): a value to make available as the `args` variable in javascript. Can be a single value such as a
+        string or a table of multiple values.
 
 Returns:
 
@@ -509,8 +511,26 @@ Examples:
 ```lua
 local current_file = vscode.eval("return vscode.window.activeTextEditor.document.fileName")
 local current_tab_is_pinned = vscode.eval("return vscode.window.tabGroups.activeTabGroup.activeTab.isPinned")
-vscode.eval("await vscode.env.clipboard.writeText(args.text)", { text = "some text" })
+vscode.eval("await vscode.env.clipboard.writeText(args.text)", { args = { text = "some text" } })
 ```
+
+### vscode.eval_async(code[, opts])
+
+Like `vscode.eval()` but returns immediately and evaluates in the background instead.
+
+Parameters:
+
+-   `code (string)`: The javascript to execute.
+-   `opts` (table): Map of optional parameters:
+    -   `args` (any): a value to make available as the `args` variable in javascript. Can be a single value such as a
+        string or a table of multiple values.
+    -   `callback`: Function to handle the action result. Must have this signature:
+        ```lua
+        function(err: string|nil, ret: any)
+        ```
+        -   `err` is the error message, if any
+        -   `ret` is the result
+        -   If no callback is provided, error will be shown as a VSCode notification.
 
 ### VimScript
 

--- a/README.md
+++ b/README.md
@@ -248,16 +248,17 @@ local vscode = require('vscode-neovim')
 
 1. `vscode.action()`: asynchronously executes a vscode command.
 2. `vscode.call()`: synchronously executes a vscode command.
-3. `vscode.on()`: defines a handler for some Nvim UI events.
-4. `vscode.has_config()`: checks if a vscode setting exists.
-5. `vscode.get_config()`: gets a vscode setting value.
-6. `vscode.update_config()`: sets a vscode setting.
-7. `vscode.notify()`: shows a vscode message (see also Nvim's `vim.notify`).
-8. `vscode.to_op()`: A helper for `map-operator`. See [code_actions.lua](./runtime/plugin/code_actions.lua) for the
+3. `vscode.get()`: obtain a vscode API value.
+4. `vscode.on()`: defines a handler for some Nvim UI events.
+5. `vscode.has_config()`: checks if a vscode setting exists.
+6. `vscode.get_config()`: gets a vscode setting value.
+7. `vscode.update_config()`: sets a vscode setting.
+8. `vscode.notify()`: shows a vscode message (see also Nvim's `vim.notify`).
+9. `vscode.to_op()`: A helper for `map-operator`. See [code_actions.lua](./runtime/plugin/code_actions.lua) for the
    usage
-9. `vscode.get_status_item`: Gets a vscode statusbar item. Properties can be assigned, which magically updates the
-   statusbar item.
-10. `g:vscode_clipboard`: Clipboard provider using VSCode's clipboard API. Used by default when in WSL. See
+10. `vscode.get_status_item`: Gets a vscode statusbar item. Properties can be assigned, which magically updates the
+    statusbar item.
+11. `g:vscode_clipboard`: Clipboard provider using VSCode's clipboard API. Used by default when in WSL. See
     `:h g:clipboard` for more details. Usage: `let g:clipboard = g:vscode_clipboard`
 
 ### vscode.action(name, opts)
@@ -300,7 +301,7 @@ Parameters:
 
 Returns: the result of the action
 
-### Examples
+#### Examples
 
 -   Format selection (default binding):
     ```vim
@@ -370,6 +371,29 @@ print(vscode.call("_wait", { args = { 1000 } })) -- outputs: ok
 -- Wait for 2 seconds with a timeout of 1 second
 print(vscode.call("_wait", { args = { 2000 } }), 1000)
 -- error: Call '_wait' timed out
+```
+
+### vscode.get(name)
+
+Obtain a [VSCode API](https://code.visualstudio.com/api/references/vscode-api) value.
+
+Parameters:
+
+-   `name (string)`: The name of the variable to obtain
+    -   use `foo.bar` to access nested properties. e.g. `window.activeTextEditor.document.fileName`
+    -   use `.123` instead of `[123]` for array access e.g. `extensions.all.0`
+
+Returns:
+
+-   return the value of the requested variable. Converted to a string if the value is not representable in lua (i.e.
+    "object" or "function")
+
+Examples:
+
+```lua
+local current_file = vscode.get("window.activeTextEditor.document.fileName")
+local current_tab_is_pinned = vscode.get("window.tabGroups.activeTabGroup.activeTab.isPinned")
+local workspace_uri = vscode.get("workspace.workspaceFolders.0.uri")
 ```
 
 ### vscode.on(event, callback)

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ test.text = nil -- Close the item
 test.text = '' -- error: The status item "test" has been closed
 ```
 
-### vscode.eval(code)
+### vscode.eval(code[, args])
 
 Evaluate javascript inside vscode and return the result. The code is executed in an async function context (so `await`
 can be used). Use a `return` statement to return a value back to lua. Arguments passed from lua are available as the
@@ -489,16 +489,15 @@ Tips:
 
 -   Make sure to `await` on asynchronous functions when accessing the API.
 -   Plain data such as strings, integers etc can be returned directly, but even simple objects such as `{foo: 123}` are
-    returned as `"[object Object]"`. `JSON.stringify()` can be used to serialize plain objects that can be deserialized
-    with `vim.json.decode()` in lua.
+    converted to strings and returned as `"[object Object]"`. `JSON.stringify()` can be used to serialize plain objects
+    to JSON that can be deserialized with `vim.json.decode()` in lua.
 -   `globalThis['some_name'] = ...` can be used to persist values between calls.
 
 Parameters:
 
 -   `code (string)`: The javascript to execute.
--   `args (any)`: Optionally provide arguments that are accessible as the `args` variable in javascript.
-    -   Use `foo.bar` to access nested properties. e.g. `window.activeTextEditor.document.fileName`.
-    -   Use `.123` instead of `[123]` for array access e.g. `extensions.all.0`.
+-   `args (any)`: Optionally provide arguments that are accessible as the `args` variable in javascript. Can be a single
+    value such as a string or a table of multiple values.
 
 Returns:
 

--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ can be used). Use a `return` statement to return a value back to lua. Arguments 
 Tips:
 
 -   Make sure to `await` on asynchronous functions when accessing the API.
+-   the global `logger` (e.g. `logger.info(...)`) to log messages to the output of vscode-neovim (logging level
+    controlled with the `vscode-neovim.logLevel` setting)
 -   Plain data such as strings, integers etc can be returned directly, but even simple objects such as `{foo: 123}` are
     converted to strings and returned as `"[object Object]"`. `JSON.stringify()` can be used to serialize plain objects
     to JSON that can be deserialized with `vim.json.decode()` in lua.

--- a/runtime/lua/vscode-neovim.lua
+++ b/runtime/lua/vscode-neovim.lua
@@ -19,6 +19,7 @@ local vscode = {
   action = api.action,
   call = api.call,
   eval = api.eval,
+  eval_async = api.eval_async,
   -- hooks
   on = api.on,
   -- vscode settings

--- a/runtime/lua/vscode-neovim.lua
+++ b/runtime/lua/vscode-neovim.lua
@@ -18,7 +18,7 @@ local vscode = {
   -- actions
   action = api.action,
   call = api.call,
-  get = api.get,
+  eval = api.eval,
   -- hooks
   on = api.on,
   -- vscode settings

--- a/runtime/lua/vscode-neovim.lua
+++ b/runtime/lua/vscode-neovim.lua
@@ -18,6 +18,7 @@ local vscode = {
   -- actions
   action = api.action,
   call = api.call,
+  get = api.get,
   -- hooks
   on = api.on,
   -- vscode settings

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -171,19 +171,49 @@ function M.call(name, opts, timeout)
   end
 end
 
---- Evaluate javascript inside vscode with access to the [vscode API](https://code.visualstudio.com/api/references/vscode-api)
---
+--- Evaluate javascript synchronously inside vscode with access to the
+--- [vscode API](https://code.visualstudio.com/api/references/vscode-api) and return the result.
+---
 ---@param code string the javascript code to run
 ---           - the code runs in an async function context
 ---             (so `await` can be used. Make sure to `await` if calling an async function from the VSCode API)
 ---           - use `return` to return a value to lua
 ---           - use the `vscode` variable to access the VSCode API
 ---           - use the `args` variable to access any arguments passed from lua
----@param args string arguments to serialize and make available to the code being run (as the `args` variable)
+---@param opts? table Optional options table, all fields are optional
+---            - args: (any) Optional arguments to serialize and make available to the code being run (as the `args` variable)
+---@param timeout? number Timeout in milliseconds. The default value is -1, which means no timeout.
 ---
 ---@return any: the result of evaluating the given code in VSCode
-function M.eval(code, args)
-  return M.call("eval", { args = { code, args } })
+function M.eval(code, opts)
+  vim.validate({
+    code = { code, "string" },
+    opts = { opts, "table", true },
+    timeout = { timeout, "number", true },
+  })
+  opts = opts or {}
+  opts.args = { code, opts.args }
+  return M.call("eval", opts)
+end
+
+--- Evaluate javascript asynchronously inside vscode with access to the
+--- [vscode API](https://code.visualstudio.com/api/references/vscode-api).
+---
+---@param code string the javascript code to run
+---@param opts? table Optional options table, all fields are optional
+---            - args: (any) Optional arguments to serialize and make available to the code being run (as the `args` variable)
+---            - callback: (function(err: string|nil, ret: any))
+---                        Optional callback function to handle the evaluated result.
+---                        The first argument is the error message, and the second is the result.
+---                        If no callback is provided, any error message will be shown as a notification in VSCode.
+function M.eval_async(code, opts)
+  vim.validate({
+    code = { code, "string" },
+    opts = { opts, "table", true },
+  })
+  opts = opts or {}
+  opts.args = { code, opts.args }
+  M.action("eval", opts)
 end
 
 ---------------------------

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -171,6 +171,16 @@ function M.call(name, opts, timeout)
   end
 end
 
+--- Obtain a vscode API value (https://code.visualstudio.com/api/references/vscode-api)
+---@param name the variable name to obtain.
+---           - use `foo.bar` to access nested properties. e.g. `window.activeTextEditor.document.fileName`
+---           - use `.123` instead of `[123]` for array access e.g. `extensions.all.0`
+---
+---@return any: result
+function M.get(name)
+  return M.call("get", { args = { name } })
+end
+
 ---------------------------
 ------- Event Hooks -------
 ---------------------------

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -324,13 +324,14 @@ function M.notify(msg, level, opts)
   end
 
   if level >= levels.ERROR then
-    level_name = "error"
+    cmd = "await vscode.window.showErrorMessage(args)"
   elseif level >= levels.WARN then
-    level_name = "warn"
+    cmd = "await vscode.window.showWarningMessage(args)"
   else
-    level_name = "info"
+    cmd = "await vscode.window.showInformationMessage(args)"
   end
-  M.action("notify", { args = { msg, level_name } })
+
+  M.eval_async(cmd, { args = msg })
 end
 
 ---------------------------------

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -171,14 +171,19 @@ function M.call(name, opts, timeout)
   end
 end
 
---- Obtain a vscode API value (https://code.visualstudio.com/api/references/vscode-api)
----@param name the variable name to obtain.
----           - use `foo.bar` to access nested properties. e.g. `window.activeTextEditor.document.fileName`
----           - use `.123` instead of `[123]` for array access e.g. `extensions.all.0`
+--- Evaluate javascript inside vscode with access to the [vscode API](https://code.visualstudio.com/api/references/vscode-api)
+--
+---@param code string the javascript code to run
+---           - the code runs in an async function context
+---             (so `await` can be used. Make sure to `await` if calling an async function from the VSCode API)
+---           - use `return` to return a value to lua
+---           - use the `vscode` variable to access the VSCode API
+---           - use the `args` variable to access any arguments passed from lua
+---@param args string arguments to serialize and make available to the code being run (as the `args` variable)
 ---
----@return any: result
-function M.get(name)
-  return M.call("get", { args = { name } })
+---@return any: the result of evaluating the given code in VSCode
+function M.eval(code, args)
+  return M.call("eval", { args = { code, args } })
 end
 
 ---------------------------

--- a/runtime/modules/clipboard.lua
+++ b/runtime/modules/clipboard.lua
@@ -3,7 +3,7 @@ local code = require("vscode-neovim")
 local last_item = nil
 
 local function paste()
-  local curr_text = code.call("clipboard_read"):gsub("\r\n", "\n")
+  local curr_text = code.eval("return await vscode.env.clipboard.readText()"):gsub("\r\n", "\n")
   local curr_item = { vim.split(curr_text, "\n"), "v" }
 
   if not last_item then
@@ -20,7 +20,7 @@ end
 local function copy(lines, regtype)
   last_item = { lines, regtype }
   local text = table.concat(lines, "\n")
-  code.call("clipboard_write", { args = { text } })
+  code.eval("await vscode.env.clipboard.writeText(args)", text)
 end
 
 vim.g.vscode_clipboard = {

--- a/runtime/modules/clipboard.lua
+++ b/runtime/modules/clipboard.lua
@@ -20,7 +20,7 @@ end
 local function copy(lines, regtype)
   last_item = { lines, regtype }
   local text = table.concat(lines, "\n")
-  code.eval("await vscode.env.clipboard.writeText(args)", text)
+  code.eval("await vscode.env.clipboard.writeText(args)", { args = text })
 end
 
 vim.g.vscode_clipboard = {

--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -65,7 +65,7 @@ local function vscode_ui_select(items, opts, on_choice)
   }
 
   -- open the select dialog
-  vscode.action("ui_select", {
+  vscode.eval_async("await vscode.window.showQuickPick(args.items, args.opts)", {
     args = {
       items = vscode_items,
       opts = vscode_opts,
@@ -121,7 +121,7 @@ local function vscode_ui_input(opts, on_confirm)
   }
 
   -- open the input dialog
-  vscode.action("ui_input", {
+  vscode.eval_async("await vscode.window.showInputBox(args.opts)", {
     args = {
       opts = vscode_opts,
     },

--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -65,17 +65,17 @@ local function vscode_ui_select(items, opts, on_choice)
   }
 
   -- open the select dialog
-  vscode.eval_async("return await vscode.window.showQuickPick(args.items, args.opts)", {
+  vscode.eval_async("return JSON.stringify(await vscode.window.showQuickPick(args.items, args.opts))", {
     args = {
       items = vscode_items,
       opts = vscode_opts,
     },
     callback = function(err, res)
-      -- distinguish between success and cancelled
-      if not err and type(res) == "table" and res.idx then
-        on_choice(items[res.idx], res.idx)
-      else
+      if err or res == vim.NIL then -- vim.NIL if cancelled
         on_choice(nil, nil)
+      else
+        res = vim.json.decode(res)
+        on_choice(items[res.idx], res.idx)
       end
     end,
   })

--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -65,7 +65,7 @@ local function vscode_ui_select(items, opts, on_choice)
   }
 
   -- open the select dialog
-  vscode.eval_async("await vscode.window.showQuickPick(args.items, args.opts)", {
+  vscode.eval_async("return await vscode.window.showQuickPick(args.items, args.opts)", {
     args = {
       items = vscode_items,
       opts = vscode_opts,
@@ -121,7 +121,7 @@ local function vscode_ui_input(opts, on_confirm)
   }
 
   -- open the input dialog
-  vscode.eval_async("await vscode.window.showInputBox(args.opts)", {
+  vscode.eval_async("return await vscode.window.showInputBox(args.opts)", {
     args = {
       opts = vscode_opts,
     },

--- a/runtime/modules/ui.lua
+++ b/runtime/modules/ui.lua
@@ -126,11 +126,10 @@ local function vscode_ui_input(opts, on_confirm)
       opts = vscode_opts,
     },
     callback = function(err, res)
-      -- distinguish between empty and cancelled
-      if not err and res ~= nil then
-        on_confirm(res)
-      else
+      if err or res == vim.NIL then -- vim.NIL if cancelled
         on_confirm(nil)
+      else
+        on_confirm(res)
       end
     end,
   })

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,16 +1,6 @@
 import { NeovimClient } from "neovim";
 import { VimValue } from "neovim/lib/types/VimValue";
-import {
-    ConfigurationTarget,
-    Disposable,
-    InputBoxOptions,
-    QuickPickItem,
-    QuickPickOptions,
-    Range,
-    commands,
-    window,
-    workspace,
-} from "vscode";
+import { ConfigurationTarget, Disposable, Range, commands, window, workspace } from "vscode";
 
 import { eval_for_client } from "./actions_eval";
 import { VSCodeContext, disposeAll, rangesToSelections } from "./utils";
@@ -123,10 +113,6 @@ class ActionManager implements Disposable {
                 editor.selections = rangesToSelections(ranges, editor.document);
             }
         });
-        this.add("ui_select", (args: { items: QuickPickItem[]; opts: QuickPickOptions }) =>
-            window.showQuickPick(args.items, args.opts),
-        );
-        this.add("ui_input", (args: { opts: InputBoxOptions }) => window.showInputBox(args.opts));
         this.add("setContext", (key: string, value: any) => VSCodeContext.set(key, value));
     }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,6 @@
 import { NeovimClient } from "neovim";
 import { VimValue } from "neovim/lib/types/VimValue";
-import vscode, {
+import {
     ConfigurationTarget,
     Disposable,
     InputBoxOptions,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -86,9 +86,7 @@ class ActionManager implements Disposable {
             await new Promise((resolve) => setTimeout(resolve, ms));
             return "ok";
         });
-        this.add("eval", async (code: string, args: any): Promise<any> => {
-            return await eval_for_client(code, args);
-        });
+        this.add("eval", (code: string, args: any) => eval_for_client(code, args));
         this.add("has_config", (names: string | string[]): boolean | boolean[] => {
             const config = workspace.getConfiguration();
             if (Array.isArray(names)) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -117,22 +117,6 @@ class ActionManager implements Disposable {
                 await config.update(name, values[idx], targetConfig);
             }
         });
-        this.add("notify", (msg: string, level: "info" | "warn" | "error") => {
-            switch (level) {
-                case "warn": {
-                    window.showWarningMessage(msg);
-                    break;
-                }
-                case "error": {
-                    window.showErrorMessage(msg);
-                    break;
-                }
-                default: {
-                    window.showInformationMessage(msg);
-                    break;
-                }
-            }
-        });
         this.add("start-multiple-cursors", (ranges: Range[]) => {
             const editor = window.activeTextEditor;
             if (editor && ranges.length) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,6 +18,24 @@ function getActionName(action: string) {
     return `neovim:${action}`;
 }
 
+function getVariable(name: string): any {
+    const names = name.split(".");
+    let item: any = vscode;
+    for (let i = 0; i < names.length; i++) {
+        const integer_name = parseInt(names[i]);
+        if (isNaN(integer_name)) {
+            item = item[names[i]];
+        } else {
+            item = item[integer_name];
+        }
+
+        if (typeof item === "undefined") {
+            return item;
+        }
+    }
+    return item;
+}
+
 class ActionManager implements Disposable {
     private disposables: Disposable[] = [];
     private actions: string[] = [];
@@ -84,6 +102,18 @@ class ActionManager implements Disposable {
         this.add("_wait", async (ms = 1000) => {
             await new Promise((resolve) => setTimeout(resolve, ms));
             return "ok";
+        });
+        this.add("get", (name: string): string | boolean | null => {
+            const value = getVariable(name);
+            const value_type = typeof value;
+            if (value_type === "object") {
+                return String(value);
+            } else if (value_type === "function") {
+                // pretend like all functions are native code even when they aren't since it doesn't matter to neovim
+                return `function ${value.name}() { [native code] }`;
+            } else {
+                return value;
+            }
         });
         this.add("has_config", (names: string | string[]): boolean | boolean[] => {
             const config = workspace.getConfiguration();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -139,8 +139,6 @@ class ActionManager implements Disposable {
                 editor.selections = rangesToSelections(ranges, editor.document);
             }
         });
-        this.add("clipboard_read", () => vscode.env.clipboard.readText());
-        this.add("clipboard_write", (text: string) => vscode.env.clipboard.writeText(text));
         this.add("ui_select", (args: { items: QuickPickItem[]; opts: QuickPickOptions }) =>
             window.showQuickPick(args.items, args.opts),
         );

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -3,6 +3,11 @@
 
 import * as _vscode from "vscode";
 
+import { createLogger } from "./logger";
+
+// @ts-ignore
+const logger = createLogger("eval");
+
 // for some reason, the name used in the import statement is not always visible to the code being run with eval()
 // but global variables/constants are always visible.
 // @ts-ignore

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import * as _vscode from "vscode";
+
+// for some reason, the name used in the import statement is not always visible to the code being run with eval()
+// but global variables/constants are always visible.
+// @ts-ignore
+const vscode = _vscode;
+
+/**
+ * Execute javascript code passed from lua in an async function context
+ *
+ * - the variable `vscode` can be used to access the VSCode API
+ * - the variable `args` can be used to access the arguments passed from lua
+ *
+ * @param code the code to evaluate
+ * @param args arguments passed from lua
+ *
+ * @returns the result of evaluating the code, serialized to send back to lua
+ */
+export async function eval_for_client(code: string, args: any): Promise<any> {
+    const result = await eval("async () => {" + code + "}")();
+
+    const value_type = typeof result;
+    if (value_type === "object") {
+        return String(result);
+    } else if (value_type === "function") {
+        return `[Function: ${result.name}]`;
+    } else {
+        return result;
+    }
+}

--- a/src/test/suite/actions.test.ts
+++ b/src/test/suite/actions.test.ts
@@ -11,11 +11,18 @@ import {
     closeAllActiveEditors,
     closeNvimClient,
     openTextDocument,
+    wait,
 } from "../utils";
 
-async function get(client: NeovimClient, name: string): Promise<any> {
+async function eval_from_nvim(client: NeovimClient, code: string): Promise<any> {
     return JSON.parse(
-        await client.commandOutput(`lua print(vim.fn.json_encode(require'vscode-neovim'.get('${name}')))`),
+        await client.commandOutput(`lua print(vim.fn.json_encode(require'vscode-neovim'.eval('${code}')))`),
+    );
+}
+
+async function eval_from_nvim_with_args(client: NeovimClient, code: string, args: string): Promise<any> {
+    return JSON.parse(
+        await client.commandOutput(`lua print(vim.fn.json_encode(require'vscode-neovim'.eval('${code}', ${args})))`),
     );
 }
 
@@ -27,7 +34,7 @@ function pathsEqual(a: string, b: string) {
     }
 }
 
-describe("Actions", () => {
+describe("Eval VSCode", () => {
     let client: NeovimClient;
     before(async () => {
         client = await attachTestNvimClient();
@@ -41,7 +48,42 @@ describe("Actions", () => {
         await closeAllActiveEditors();
     });
 
-    it("Get simple properties", async () => {
+    it("Javascript Evaluation", async () => {
+        let output = await eval_from_nvim(client, "");
+        assert.equal(output, null);
+
+        output = await eval_from_nvim(client, "123");
+        assert.equal(output, null);
+
+        output = await eval_from_nvim(client, "return 123");
+        assert.equal(output, 123);
+
+        output = await eval_from_nvim(client, "return {foo: 123};");
+        assert.equal(output, "[object Object]");
+
+        output = await eval_from_nvim(client, "return JSON.stringify({foo: 123});");
+        assert.equal(output, '{"foo":123}');
+
+        output = await eval_from_nvim(client, "function foo() {}; return foo;");
+        assert.equal(output, "[Function: foo]");
+
+        output = await eval_from_nvim(client, "function f(v) {return 100 + v;}; return f(2);");
+        assert.equal(output, 102);
+
+        output = await eval_from_nvim(client, "async function f(v) {return 100 + v;}; return await f(2);");
+        assert.equal(output, 102);
+
+        output = await eval_from_nvim_with_args(client, "return args;", "12");
+        assert.equal(output, 12);
+
+        output = await eval_from_nvim_with_args(client, "return args.foo", "{ foo = 12 }");
+        assert.equal(output, 12);
+
+        output = await eval_from_nvim_with_args(client, "return args[0]", "{ 12 }");
+        assert.equal(output, 12);
+    });
+
+    it("API interactions", async () => {
         const filePath = path.join(os.tmpdir(), Math.random().toString());
         fs.writeFileSync(filePath, ["line 1", "line 2"].join("\n"), {
             encoding: "utf8",
@@ -49,62 +91,55 @@ describe("Actions", () => {
 
         await openTextDocument(filePath);
 
-        let output = await get(client, "");
-        assert.equal(output, null);
-
-        output = await get(client, "window");
+        let output = await eval_from_nvim(client, "return vscode.window");
         assert.equal(output, "[object Object]");
 
-        output = await get(client, "window.showWarningMessage");
-        assert.equal(output, "function showWarningMessage() { [native code] }");
+        output = await eval_from_nvim(client, "return vscode.window.showWarningMessage");
+        assert.equal(output, "[Function: showWarningMessage]");
 
-        output = await get(client, "window.activeTextEditor.document.fileName");
+        output = await eval_from_nvim(client, "return vscode.window.activeTextEditor.document.fileName");
         assert.ok(pathsEqual(output, filePath), `${output} != ${filePath}`);
 
-        output = await get(client, "window.tabGroups.activeTabGroup.activeTab.isPinned");
+        output = await eval_from_nvim(client, "return vscode.window.tabGroups.activeTabGroup.activeTab.isPinned");
         assert.equal(output, false);
 
-        await sendVSCodeCommand("workbench.action.pinEditor");
+        await eval_from_nvim(client, 'await vscode.commands.executeCommand("workbench.action.pinEditor", "")');
+        await wait(200);
         try {
-            output = await get(client, "window.tabGroups.activeTabGroup.activeTab.isPinned");
+            output = await eval_from_nvim(client, "return vscode.window.tabGroups.activeTabGroup.activeTab.isPinned");
             assert.equal(output, true);
         } finally {
             await sendVSCodeCommand("workbench.action.unpinEditor");
         }
+
+        await eval_from_nvim_with_args(client, "await vscode.env.clipboard.writeText(args.text)", "{ text = 'hi'}");
+        output = await eval_from_nvim(client, "return await vscode.env.clipboard.readText()");
+        assert.equal(output, "hi");
+
+        output = await eval_from_nvim(client, 'return globalThis["foo"];');
+        assert.equal(output, null);
+        await eval_from_nvim(client, 'globalThis["foo"] = 123');
+        output = await eval_from_nvim(client, 'return globalThis["foo"];');
+        assert.equal(output, 123);
     });
 
-    it("Get missing properties", async () => {
-        let output = await get(client, "window.property_that_does_not_exist");
+    it("Error handling", async () => {
+        await assert.rejects(async () => {
+            await eval_from_nvim(client, "!$%");
+        }, /Error executing lua Unexpected token '}'/);
+
+        let output = await eval_from_nvim(client, "return vscode.window.property_that_does_not_exist");
         assert.equal(output, null);
 
-        output = await get(client, "window.property_that_does_not_exist.nested_property");
+        await assert.rejects(async () => {
+            await eval_from_nvim(client, "return vscode.window.property_that_does_not_exist.nested_property");
+        }, /Error executing lua Cannot read properties of undefined \(reading 'nested_property'\)/);
+
+        output = await eval_from_nvim(client, "return vscode.window.visibleTextEditors[99]");
         assert.equal(output, null);
 
-        output = await get(client, "window.visibleTextEditors.99"); // .99 instead of [99] to make parsing simpler
-        assert.equal(output, null);
-    });
-
-    it("Get array", async () => {
-        const filePath = path.join(os.tmpdir(), `${Math.random().toString()}.js`);
-        fs.writeFileSync(filePath, ["line 1", "line 2"].join("\n"), {
-            encoding: "utf8",
-        });
-
-        let output = await get(client, "window.visibleTextEditors.length");
-        assert.equal(output, 0);
-
-        output = await get(client, "window.visibleTextEditors.0"); // .0 instead of [0] to make parsing simpler
-        assert.equal(output, null);
-
-        await openTextDocument(filePath);
-
-        output = await get(client, "window.visibleTextEditors.length");
-        assert.equal(output, 1);
-
-        output = await get(client, "window.visibleTextEditors.0");
-        assert.equal(output, "[object Object]");
-
-        output = await get(client, "window.visibleTextEditors.0.document.fileName");
-        assert.ok(pathsEqual(output, filePath), `${output} != ${filePath}`);
+        await assert.rejects(async () => {
+            await eval_from_nvim(client, 'await vscode.commands.executeCommand("unknown_action", "")');
+        }, /Error executing lua command 'unknown_action' not found/);
     });
 });

--- a/src/test/suite/actions.test.ts
+++ b/src/test/suite/actions.test.ts
@@ -20,8 +20,8 @@ async function get(client: NeovimClient, name: string): Promise<any> {
 }
 
 function pathsEqual(a: string, b: string) {
-    if (process.platform == "win32") {
-        return path.win32.normalize(a) == path.win32.normalize(b);
+    if (process.platform === "win32") {
+        return a.toLowerCase() === b.toLowerCase();
     } else {
         return a == b;
     }
@@ -59,7 +59,7 @@ describe("Actions", () => {
         assert.equal(output, "function showWarningMessage() { [native code] }");
 
         output = await get(client, "window.activeTextEditor.document.fileName");
-        assert.ok(pathsEqual(output, filePath));
+        assert.ok(pathsEqual(output, filePath), `${output} != ${filePath}`);
 
         output = await get(client, "window.tabGroups.activeTabGroup.activeTab.isPinned");
         assert.equal(output, false);
@@ -105,6 +105,6 @@ describe("Actions", () => {
         assert.equal(output, "[object Object]");
 
         output = await get(client, "window.visibleTextEditors.0.document.fileName");
-        assert.ok(pathsEqual(output, filePath));
+        assert.ok(pathsEqual(output, filePath), `${output} != ${filePath}`);
     });
 });

--- a/src/test/suite/actions.test.ts
+++ b/src/test/suite/actions.test.ts
@@ -21,7 +21,7 @@ async function get(client: NeovimClient, name: string): Promise<any> {
 
 function pathsEqual(a: string, b: string) {
     if (process.platform == "win32") {
-        return path.win32.normalize(output) == path.win32.normalize(b);
+        return path.win32.normalize(a) == path.win32.normalize(b);
     } else {
         return a == b;
     }
@@ -50,13 +50,13 @@ describe("Actions", () => {
         await openTextDocument(filePath);
 
         let output = await get(client, "");
-        assert.equal(null, output);
+        assert.equal(output, null);
 
         output = await get(client, "window");
-        assert.equal("[object Object]", output);
+        assert.equal(output, "[object Object]");
 
         output = await get(client, "window.showWarningMessage");
-        assert.equal("function showWarningMessage() { [native code] }", output);
+        assert.equal(output, "function showWarningMessage() { [native code] }");
 
         output = await get(client, "window.activeTextEditor.document.fileName");
         assert.ok(pathsEqual(output, filePath));

--- a/src/test/suite/actions.test.ts
+++ b/src/test/suite/actions.test.ts
@@ -1,0 +1,102 @@
+import os from "os";
+import path from "path";
+import fs from "fs";
+import { strict as assert } from "assert";
+
+import { NeovimClient } from "neovim";
+
+import {
+    attachTestNvimClient,
+    sendVSCodeCommand,
+    closeAllActiveEditors,
+    closeNvimClient,
+    openTextDocument,
+} from "../utils";
+
+async function get(client: NeovimClient, name: string): Promise<any> {
+    return JSON.parse(
+        await client.commandOutput(`lua print(vim.fn.json_encode(require'vscode-neovim'.get('${name}')))`),
+    );
+}
+
+describe("Actions", () => {
+    let client: NeovimClient;
+    before(async () => {
+        client = await attachTestNvimClient();
+    });
+    after(async () => {
+        await closeNvimClient(client);
+        await closeAllActiveEditors();
+    });
+
+    beforeEach(async () => {
+        await closeAllActiveEditors();
+    });
+
+    it("Get simple properties", async () => {
+        const filePath = path.join(os.tmpdir(), Math.random().toString());
+        fs.writeFileSync(filePath, ["line 1", "line 2"].join("\n"), {
+            encoding: "utf8",
+        });
+
+        await openTextDocument(filePath);
+
+        let output = await get(client, "");
+        assert.equal(null, output);
+
+        output = await get(client, "window");
+        assert.equal("[object Object]", output);
+
+        output = await get(client, "window.showWarningMessage");
+        assert.equal("function showWarningMessage() { [native code] }", output);
+
+        output = await get(client, "window.activeTextEditor.document.fileName");
+        assert.equal(output, filePath);
+
+        output = await get(client, "window.tabGroups.activeTabGroup.activeTab.isPinned");
+        assert.equal(output, false);
+
+        await sendVSCodeCommand("workbench.action.pinEditor");
+        try {
+            output = await get(client, "window.tabGroups.activeTabGroup.activeTab.isPinned");
+            assert.equal(output, true);
+        } finally {
+            await sendVSCodeCommand("workbench.action.unpinEditor");
+        }
+    });
+
+    it("Get missing properties", async () => {
+        let output = await get(client, "window.property_that_does_not_exist");
+        assert.equal(output, null);
+
+        output = await get(client, "window.property_that_does_not_exist.nested_property");
+        assert.equal(output, null);
+
+        output = await get(client, "window.visibleTextEditors.99"); // .99 instead of [99] to make parsing simpler
+        assert.equal(output, null);
+    });
+
+    it("Get array", async () => {
+        const filePath = path.join(os.tmpdir(), `${Math.random().toString()}.js`);
+        fs.writeFileSync(filePath, ["line 1", "line 2"].join("\n"), {
+            encoding: "utf8",
+        });
+
+        let output = await get(client, "window.visibleTextEditors.length");
+        assert.equal(output, 0);
+
+        output = await get(client, "window.visibleTextEditors.0"); // .0 instead of [0] to make parsing simpler
+        assert.equal(output, null);
+
+        await openTextDocument(filePath);
+
+        output = await get(client, "window.visibleTextEditors.length");
+        assert.equal(output, 1);
+
+        output = await get(client, "window.visibleTextEditors.0");
+        assert.equal(output, "[object Object]");
+
+        output = await get(client, "window.visibleTextEditors.0.document.fileName");
+        assert.equal(output, filePath);
+    });
+});

--- a/src/test/suite/actions.test.ts
+++ b/src/test/suite/actions.test.ts
@@ -19,6 +19,14 @@ async function get(client: NeovimClient, name: string): Promise<any> {
     );
 }
 
+function pathsEqual(a: string, b: string) {
+    if (process.platform == "win32") {
+        return path.win32.normalize(output) == path.win32.normalize(b);
+    } else {
+        return a == b;
+    }
+}
+
 describe("Actions", () => {
     let client: NeovimClient;
     before(async () => {
@@ -51,7 +59,7 @@ describe("Actions", () => {
         assert.equal("function showWarningMessage() { [native code] }", output);
 
         output = await get(client, "window.activeTextEditor.document.fileName");
-        assert.equal(output, filePath);
+        assert.ok(pathsEqual(output, filePath));
 
         output = await get(client, "window.tabGroups.activeTabGroup.activeTab.isPinned");
         assert.equal(output, false);
@@ -97,6 +105,6 @@ describe("Actions", () => {
         assert.equal(output, "[object Object]");
 
         output = await get(client, "window.visibleTextEditors.0.document.fileName");
-        assert.equal(output, filePath);
+        assert.ok(pathsEqual(output, filePath));
     });
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -5,6 +5,13 @@ import Mocha from "mocha";
 import "source-map-support/register";
 
 export async function run(): Promise<void> {
+    let test_regex = process.env.VSCODE_NEOVIM_TEST_REGEX;
+    if (test_regex !== undefined) {
+        console.log(`running tests by regex: ${test_regex}`);
+    } else {
+        test_regex = ".*";
+    }
+
     // Create the mocha test
     const mocha = new Mocha({
         ui: "bdd",
@@ -12,7 +19,7 @@ export async function run(): Promise<void> {
         bail: false,
         slow: 20000,
         fullTrace: true,
-        grep: ".*",
+        grep: test_regex,
         retries: 2,
     });
     const testsRoot = path.resolve(__dirname, "..");

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -5,12 +5,11 @@ import Mocha from "mocha";
 import "source-map-support/register";
 
 export async function run(): Promise<void> {
-    let test_regex = process.env.VSCODE_NEOVIM_TEST_REGEX;
-    if (test_regex !== undefined) {
-        console.log(`running tests by regex: ${test_regex}`);
-    } else {
+    let test_regex = process.env.NEOVIM_TEST_REGEX;
+    if (test_regex === undefined) {
         test_regex = ".*";
     }
+    console.log(`running tests by regex: ${test_regex}`);
 
     // Create the mocha test
     const mocha = new Mocha({

--- a/src/test/suite/yanking.test.ts
+++ b/src/test/suite/yanking.test.ts
@@ -75,7 +75,7 @@ describe("Yanking and pasting", () => {
 
     it.skip("pasting line after vi{", async () => {
         // see https://github.com/asvetliakov/vscode-neovim/issues/116
-        await openTextDocument(["var test='a'", "", "function blah() {", "    var another;", "}", ""].join("\n"));
+        await openTextDocument({ content: ["var test='a'", "", "function blah() {", "    var another;", "}", ""].join("\n") });
 
         await sendVSCodeKeys("yy");
         await sendVSCodeKeys("jjj");

--- a/src/test/suite/yanking.test.ts
+++ b/src/test/suite/yanking.test.ts
@@ -75,7 +75,9 @@ describe("Yanking and pasting", () => {
 
     it.skip("pasting line after vi{", async () => {
         // see https://github.com/asvetliakov/vscode-neovim/issues/116
-        await openTextDocument({ content: ["var test='a'", "", "function blah() {", "    var another;", "}", ""].join("\n") });
+        await openTextDocument({
+            content: ["var test='a'", "", "function blah() {", "    var another;", "}", ""].join("\n"),
+        });
 
         await sendVSCodeKeys("yy");
         await sendVSCodeKeys("jjj");

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -21,7 +21,7 @@ if outdated then
   local msg = "vscode-neovim requires nvim version "
     .. MIN_VERSION
     .. " or higher. Install the [latest stable version](https://github.com/neovim/neovim/releases/latest)."
-  local cmd = "vscode.window.showErrorMessage(args)"
+  local cmd = "await vscode.window.showErrorMessage(args)"
   vim.rpcnotify(vim.g.vscode_channel, "vscode-action", "eval", { args = { cmd, msg } })
 end
 EOF

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -21,7 +21,8 @@ if outdated then
   local msg = "vscode-neovim requires nvim version "
     .. MIN_VERSION
     .. " or higher. Install the [latest stable version](https://github.com/neovim/neovim/releases/latest)."
-  vim.rpcnotify(vim.g.vscode_channel, "vscode-action", "notify", { args = { msg, "error" } })
+  local cmd = "vscode.window.showErrorMessage(args)"
+  vim.rpcnotify(vim.g.vscode_channel, "vscode-action", "eval", { args = { cmd, msg } })
 end
 EOF
 


### PR DESCRIPTION
This PR introduces `vscode.eval()` which can be used to evaluate javascript passed as a string from lua. This can then be used to interact with the vscode API from neovim.

~~This PR introduces `vscode.get()` which can be used to obtain javascript values from lua. This is a simpler implementation than I originally imagined, but providing full API access including the ability to call arbitrary functions would be very complex and potentially error prone. `vscode.get()` is sufficient for the purposes of my original issue.~~

Fixes: https://github.com/vscode-neovim/vscode-neovim/issues/1760

