### PR TITLE
fix: handle timeout in eval properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ test.text = nil -- Close the item
 test.text = '' -- error: The status item "test" has been closed
 ```
 
-### vscode.eval(code[, opts])
+### vscode.eval(code[, opts, timeout])
 
 Evaluate javascript inside vscode and return the result. The code is executed in an async function context (so `await`
 can be used). Use a `return` statement to return a value back to lua. Arguments passed from lua are available as the
@@ -489,7 +489,7 @@ can be used). Use a `return` statement to return a value back to lua. Arguments 
 Tips:
 
 -   Make sure to `await` on asynchronous functions when accessing the API.
--   the global `logger` (e.g. `logger.info(...)`) to log messages to the output of vscode-neovim (logging level
+-   Use the global `logger` (e.g. `logger.info(...)`) to log messages to the output of vscode-neovim (logging level
     controlled with the `vscode-neovim.logLevel` setting)
 -   Plain data such as strings, integers etc can be returned directly, but even simple objects such as `{foo: 123}` are
     converted to strings and returned as `"[object Object]"`. `JSON.stringify()` can be used to serialize plain objects
@@ -499,9 +499,11 @@ Tips:
 Parameters:
 
 -   `code (string)`: The javascript to execute.
--   `opts` (table): Map of optional parameters:
+-   `opts (table)`: Map of optional parameters:
     -   `args` (any): a value to make available as the `args` variable in javascript. Can be a single value such as a
         string or a table of multiple values.
+-   `timeout (number)`: The number of milliseconds to wait for the evalution to complete before cancelling. By default
+    there is no timeout.
 
 Returns:
 

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -172,7 +172,7 @@ function M.call(name, opts, timeout)
 end
 
 --- Evaluate javascript synchronously inside vscode with access to the
---- [vscode API](https://code.visualstudio.com/api/references/vscode-api) and return the result.
+--- [VSCode API](https://code.visualstudio.com/api/references/vscode-api) and return the result.
 ---
 ---@param code string the javascript code to run
 ---           - the code runs in an async function context
@@ -197,7 +197,7 @@ function M.eval(code, opts, timeout)
 end
 
 --- Evaluate javascript asynchronously inside vscode with access to the
---- [vscode API](https://code.visualstudio.com/api/references/vscode-api).
+--- [VSCode API](https://code.visualstudio.com/api/references/vscode-api).
 ---
 ---@param code string the javascript code to run
 ---@param opts? table Optional options table, all fields are optional

--- a/runtime/lua/vscode-neovim/api.lua
+++ b/runtime/lua/vscode-neovim/api.lua
@@ -185,7 +185,7 @@ end
 ---@param timeout? number Timeout in milliseconds. The default value is -1, which means no timeout.
 ---
 ---@return any: the result of evaluating the given code in VSCode
-function M.eval(code, opts)
+function M.eval(code, opts, timeout)
   vim.validate({
     code = { code, "string" },
     opts = { opts, "table", true },
@@ -193,7 +193,7 @@ function M.eval(code, opts)
   })
   opts = opts or {}
   opts.args = { code, opts.args }
-  return M.call("eval", opts)
+  return M.call("eval", opts, timeout)
 end
 
 --- Evaluate javascript asynchronously inside vscode with access to the

--- a/src/test/suite/actions.test.ts
+++ b/src/test/suite/actions.test.ts
@@ -158,6 +158,14 @@ describe("Eval VSCode", () => {
             await eval_from_nvim(client, "!$%");
         }, /Error executing lua Unexpected token '}'/);
 
+        await assert.rejects(async () => {
+            await eval_from_nvim_with_opts(
+                client,
+                "await new Promise((resolve) => setTimeout(resolve, 1000))",
+                "{}, 100",
+            );
+        }, /Error executing lua .* Call 'eval' timed out/);
+
         let output = await eval_from_nvim(client, "return vscode.window.property_that_does_not_exist");
         assert.equal(output, null);
 


### PR DESCRIPTION
as mentioned here https://github.com/vscode-neovim/vscode-neovim/pull/1854#issuecomment-2018676517 I accidentally didn't handle the `timeout` parameter to `eval()` properly. This PR fixes the issue and adds a unit test.