### PR TITLE
fix: vscode null in eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Tips:
 
 -   Make sure to `await` on asynchronous functions when accessing the API.
 -   Use the global `logger` (e.g. `logger.info(...)`) to log messages to the output of vscode-neovim (logging level
-    controlled with the `vscode-neovim.logLevel` setting)
+    controlled with the `vscode-neovim.logLevel` setting).
 -   Plain data such as strings, integers etc can be returned directly, but even simple objects such as `{foo: 123}` are
     converted to strings and returned as `"[object Object]"`. `JSON.stringify()` can be used to serialize plain objects
     to JSON that can be deserialized with `vim.json.decode()` in lua.
@@ -498,11 +498,11 @@ Tips:
 
 Parameters:
 
--   `code (string)`: The javascript to execute.
--   `opts (table)`: Map of optional parameters:
+-   `code` (string): The javascript to execute.
+-   `opts` (table): Map of optional parameters:
     -   `args` (any): a value to make available as the `args` variable in javascript. Can be a single value such as a
         string or a table of multiple values.
--   `timeout (number)`: The number of milliseconds to wait for the evalution to complete before cancelling. By default
+-   `timeout` (number): The number of milliseconds to wait for the evalution to complete before cancelling. By default
     there is no timeout.
 
 Returns:
@@ -524,11 +524,11 @@ Like `vscode.eval()` but returns immediately and evaluates in the background ins
 
 Parameters:
 
--   `code (string)`: The javascript to execute.
+-   `code` (string): The javascript to execute.
 -   `opts` (table): Map of optional parameters:
     -   `args` (any): a value to make available as the `args` variable in javascript. Can be a single value such as a
         string or a table of multiple values.
-    -   `callback`: Function to handle the action result. Must have this signature:
+    -   `callback`: Function to handle the eval result. Must have this signature:
         ```lua
         function(err: string|nil, ret: any)
         ```

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -1,17 +1,11 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-import * as _vscode from "vscode";
+import _vscode from "vscode";
 
 import { createLogger } from "./logger";
 
-// @ts-ignore
+const vscode = _vscode;
 const logger = createLogger("eval");
 
-// for some reason, the name used in the import statement is not always visible to the code being run with eval()
-// but global variables/constants are always visible.
-// @ts-ignore
-const vscode = _vscode;
+_use_variables([vscode, logger]);
 
 /**
  * Execute javascript code passed from lua in an async function context
@@ -27,6 +21,8 @@ const vscode = _vscode;
 export async function eval_for_client(code: string, args: any): Promise<any> {
     const result = await eval("async () => {" + code + "}")();
 
+    _use_variables([args]);
+
     const value_type = typeof result;
     if (value_type === "object") {
         return String(result);
@@ -34,5 +30,17 @@ export async function eval_for_client(code: string, args: any): Promise<any> {
         return `[Function: ${result.name}]`;
     } else {
         return result;
+    }
+}
+
+/**
+ * Re-assure static analysis tools that the given variables are used.
+ * This prevents them from being removed at build time.
+ *
+ * @param variables list of variables to mark as used.
+ */
+function _use_variables(variables: any[]) {
+    if (variables.length === 0) {
+        return;
     }
 }

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -5,7 +5,10 @@ import { createLogger } from "./logger";
 const vscode = _vscode;
 const logger = createLogger("eval");
 
-_use_variables([vscode, logger]);
+// Ensure that the globals are 'used' so that they are not removed at build time
+// and linters do not complain about them.
+void vscode;
+void logger;
 
 /**
  * Execute javascript code passed from lua in an async function context
@@ -21,7 +24,7 @@ _use_variables([vscode, logger]);
 export async function eval_for_client(code: string, args: any): Promise<any> {
     const result = await eval("async () => {" + code + "}")();
 
-    _use_variables([args]);
+    void args;
 
     const value_type = typeof result;
     if (value_type === "object") {
@@ -30,17 +33,5 @@ export async function eval_for_client(code: string, args: any): Promise<any> {
         return `[Function: ${result.name}]`;
     } else {
         return result;
-    }
-}
-
-/**
- * Re-assure static analysis tools that the given variables are used.
- * This prevents them from being removed at build time.
- *
- * @param variables list of variables to mark as used.
- */
-function _use_variables(variables: any[]) {
-    if (variables.length === 0) {
-        return;
     }
 }


### PR DESCRIPTION
Prevent `vscode` from becoming `null` during build. Fixes: https://github.com/vscode-neovim/vscode-neovim/issues/1864

Observations:
- with `import vscode from "vscode"`, the name `vscode` is completely removed.
- with `import _vscode from "vscode"; const vscode = _vscode;`, the name `vscode` is set to null at build time.
- with `const vscode = require("vscode")`, everything works but `vscode` is identified as unused and linters prefer `import` over `require`.

Instead of relying on require to not have the global removed, I think the most robust solution is to make sure the static analysis tools don't think any of these variables are unused in the first place. The most correct approach in the presence of `eval()` is for the tools to assume nothing, but that isn't what happens in practice. This PR introduces a hack so that (basic) static analysis does not think that the variables we want to keep around are unused.

I have tested this approach including compiling to `.vsix` and `vscode` seems to now be set correctly.