### PR TITLE
refactor: extract highlight provider grid logic into its own data structure

### DIFF
--- a/src/highlight_grid.ts
+++ b/src/highlight_grid.ts
@@ -1,0 +1,241 @@
+import wcswidth from "ts-wcwidth";
+import GraphemeSplitter from "grapheme-splitter";
+
+import { calculateEditorColFromVimScreenCol, expandTabs } from "./utils";
+
+export interface ValidCell {
+    text: string;
+    hlId: number;
+}
+
+export interface Highlight extends ValidCell {
+    virtText?: string;
+}
+
+export interface HighlightCellsEvent {
+    row: number;
+    vimCol: number;
+    validCells: ValidCell[];
+    lineText: string;
+    tabSize: number;
+}
+
+export class HighlightGrid {
+    /**
+     * a three-dimensional array representing rows and columns.
+     * Each column can contain multiple highlights. e.g. double-width character, tab
+     */
+    private grid: Highlight[][][];
+
+    constructor() {
+        this.grid = [];
+    }
+
+    cleanRow(row: number) {
+        delete this.grid[row];
+    }
+
+    processHighlightCellsEvent({ row, vimCol, validCells, lineText, tabSize }: HighlightCellsEvent): boolean {
+        let hasUpdates = false;
+
+        if (!this.grid[row]) {
+            this.grid[row] = [];
+        }
+
+        const gridRow = this.grid[row];
+        const getWidth = (text?: string) => {
+            const t = expandTabs(text ?? "", tabSize);
+            return segment(t).reduce((p, c) => p + (isDouble(c) ? 2 : 1), 0);
+        };
+
+        const lineChars = segment(lineText);
+
+        // Calculates the number of spaces occupied by the tab
+        const calcTabCells = (tabCol: number) => {
+            let nearestTabIdx = lineChars.slice(0, tabCol).lastIndexOf("\t");
+            nearestTabIdx = nearestTabIdx === -1 ? 0 : nearestTabIdx + 1;
+            const center = lineChars.slice(nearestTabIdx, tabCol).join("");
+            return tabSize - (getWidth(center) % tabSize);
+        };
+
+        const editorCol = calculateEditorColFromVimScreenCol(lineText, vimCol, tabSize);
+        const cellIter = new CellIter(validCells);
+
+        // #region
+        // If the previous column can contain multiple cells,
+        // then the redraw cells may contain cells from the previous column.
+        if (editorCol > 0) {
+            const prevCol = editorCol - 1;
+            const prevChar = lineChars[prevCol];
+            const expectedCells = prevChar === "\t" ? calcTabCells(prevCol) : getWidth(prevChar);
+            if (expectedCells > 1) {
+                const expectedVimCol = getWidth(lineChars.slice(0, editorCol).join(""));
+                if (expectedVimCol > vimCol) {
+                    const rightHls: Highlight[] = [];
+                    for (let i = 0; i < expectedVimCol - vimCol; i++) {
+                        const cell = cellIter.next();
+                        cell && rightHls.push({ ...cell, virtText: cell.text });
+                    }
+                    const leftHls: Highlight[] = [];
+                    if (expectedCells - rightHls.length) {
+                        leftHls.push(...(gridRow[prevCol] ?? []).slice(0, expectedCells - rightHls.length));
+                    }
+                    gridRow[prevCol] = [...leftHls, ...rightHls];
+                }
+            }
+        }
+        // #endregion
+
+        // Insert additional columns for characters with length greater than 1.
+        const filledLineText = segment(lineText).reduce((p, c) => p + c + " ".repeat(c.length - 1), "");
+
+        const filledLineChars = segment(filledLineText);
+        let currCharCol = editorCol;
+        let cell = cellIter.next();
+        while (cell) {
+            const hls: Highlight[] = [];
+            const add = (cell: ValidCell, virtText?: string) => hls.push({ ...cell, virtText });
+            const currChar = filledLineChars[currCharCol];
+            const extraCols = currChar ? currChar.length - 1 : 0;
+            currCharCol += extraCols;
+            // ... some emojis have text versions e.g. [..."❤️"] == ['❤', '️']
+            const hlCol = currCharCol - (currChar ? [...currChar].length - 1 : 0);
+
+            do {
+                if (currChar === "\t") {
+                    add(cell, cell.text);
+                    for (let i = 0; i < calcTabCells(currCharCol) - 1; i++) {
+                        cell = cellIter.next();
+                        cell && add(cell, cell.text);
+                    }
+
+                    break;
+                }
+
+                if (currChar && isDouble(currChar)) {
+                    if (currChar === cell.text) {
+                        add(cell);
+                        break;
+                    }
+
+                    add(cell, cell.text);
+                    if (!isDouble(cell.text)) {
+                        const nextCell = cellIter.next();
+                        nextCell && add(nextCell, nextCell.text);
+                        extraCols && add(nextCell ?? cell, " ".repeat(extraCols));
+                    }
+
+                    break;
+                }
+
+                if (currChar === cell.text) {
+                    add(cell);
+                } else {
+                    add(cell, cell.text);
+                    if (isDouble(cell.text)) {
+                        currCharCol++;
+                    }
+                }
+
+                // eslint-disable-next-line no-constant-condition
+            } while (false);
+
+            if (!hls.length || !hls.some((d) => d.hlId !== 0)) {
+                if (gridRow[hlCol]) {
+                    hasUpdates = true;
+                    delete gridRow[hlCol];
+                }
+            } else {
+                hasUpdates = true;
+                gridRow[hlCol] = hls;
+            }
+            /////////////////////////////////////////////
+            currCharCol++;
+            cell = cellIter.next();
+        }
+
+        return hasUpdates;
+    }
+
+    shiftHighlights(by: number, from: number): void {
+        if (by > 0) {
+            // remove clipped out rows
+            for (let i = 0; i < by; i++) {
+                delete this.grid[from + i];
+            }
+            // first get non empty indexes, then process, seems faster than iterating whole array
+            const idxs: number[] = [];
+            this.grid.forEach((_row, idx) => {
+                idxs.push(idx);
+            });
+            // shift
+            for (const idx of idxs) {
+                if (idx <= from) {
+                    continue;
+                }
+                this.grid[idx - by] = this.grid[idx];
+                delete this.grid[idx];
+            }
+        } else if (by < 0) {
+            // remove clipped out rows
+            for (let i = 0; i < Math.abs(by); i++) {
+                delete this.grid[from !== 0 ? from + i : this.grid.length - 1 - i];
+            }
+            const idxs: number[] = [];
+            this.grid.forEach((_row, idx) => {
+                idxs.push(idx);
+            });
+            for (const idx of idxs.reverse()) {
+                if (idx <= from) {
+                    continue;
+                }
+                this.grid[idx + Math.abs(by)] = this.grid[idx];
+                delete this.grid[idx];
+            }
+        }
+    }
+
+    maxColInRow(row: number) {
+        const gridRow = this.grid[row];
+        if (!gridRow) {
+            return 0;
+        }
+
+        let currMaxCol = 0;
+        gridRow.forEach((_, col) => {
+            if (col > currMaxCol) currMaxCol = col;
+        });
+
+        return currMaxCol;
+    }
+
+    forEachRow(func: (rowHighlights: Highlight[][], row: number) => void) {
+        this.grid.forEach(func);
+    }
+}
+
+class CellIter {
+    private _index = 0;
+    constructor(private _cells: ValidCell[]) {}
+    next(): { text: string; hlId: number } | undefined {
+        return this._cells[this._index++];
+    }
+    getNext(): { text: string; hlId: number } | undefined {
+        return this._cells[this._index];
+    }
+    setNext(hlId: number, text: string) {
+        if (this._index < this._cells.length) {
+            this._cells[this._index] = { hlId, text };
+        }
+    }
+}
+
+// 你 length:1 width:2
+// 🚀 length:2 width:2
+// 🕵️ length:3 width:2
+// ❤️ length:2 width:1
+const isDouble = (c?: string) => wcswidth(c) === 2 || (c ?? "").length > 1;
+const segment: (str: string) => string[] = (() => {
+    const splitter = new GraphemeSplitter();
+    return (str) => splitter.splitGraphemes(str);
+})();

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -13,8 +13,9 @@ import {
     window,
 } from "vscode";
 
-import { calculateEditorColFromVimScreenCol, expandTabs } from "./utils";
+import { expandTabs } from "./utils";
 import { config } from "./config";
+import { Highlight, HighlightGrid, ValidCell } from "./highlight_grid";
 
 export interface VimHighlightUIAttributes {
     foreground?: number;
@@ -42,13 +43,6 @@ export interface HighlightConfiguration {
 }
 
 type Cell = [string, number?, number?];
-interface ValidCell {
-    text: string;
-    hlId: number;
-}
-interface Highlight extends ValidCell {
-    virtText?: string;
-}
 
 /**
  * Convert VIM HL attributes to vscode text decoration attributes
@@ -116,28 +110,11 @@ const segment: (str: string) => string[] = (() => {
     return (str) => splitter.splitGraphemes(str);
 })();
 
-class CellIter {
-    private _index = 0;
-    constructor(private _cells: ValidCell[]) {}
-    next(): { text: string; hlId: number } | undefined {
-        return this._cells[this._index++];
-    }
-    getNext(): { text: string; hlId: number } | undefined {
-        return this._cells[this._index];
-    }
-    setNext(hlId: number, text: string) {
-        if (this._index < this._cells.length) {
-            this._cells[this._index] = { hlId, text };
-        }
-    }
-}
-
 export class HighlightProvider implements Disposable {
     /**
-     * key is the grid id and values is a three-dimensional array representing rows and columns.
-     * Each column can contain multiple highlights. e.g. double-width character, tab
+     * key is the grid id and values is a grid representing those highlights
      */
-    private highlights: Map<number, Highlight[][][]> = new Map();
+    private highlights: Map<number, HighlightGrid> = new Map();
     private prevGridHighlightsIds: Map<number, Set<number>> = new Map();
     /**
      * HL group id to text decorator
@@ -215,7 +192,8 @@ export class HighlightProvider implements Disposable {
         if (!gridHl) {
             return;
         }
-        delete gridHl[row];
+
+        gridHl.cleanRow(row);
     }
 
     public processHLCellsEvent(
@@ -226,40 +204,22 @@ export class HighlightProvider implements Disposable {
         lineText: string,
         tabSize: number,
     ): boolean {
-        let hasUpdates = false;
-
         if (!this.highlights.has(grid)) {
-            this.highlights.set(grid, []);
+            this.highlights.set(grid, new HighlightGrid());
         }
         const gridHl = this.highlights.get(grid)!;
-        if (!gridHl[row]) {
-            gridHl[row] = [];
-        }
 
+        // TODO: Remove this from here
         const getWidth = (text?: string) => {
             const t = expandTabs(text ?? "", tabSize);
             return segment(t).reduce((p, c) => p + (isDouble(c) ? 2 : 1), 0);
         };
 
-        const lineChars = segment(lineText);
-
-        // Calculates the number of spaces occupied by the tab
-        const calcTabCells = (tabCol: number) => {
-            let nearestTabIdx = lineChars.slice(0, tabCol).lastIndexOf("\t");
-            nearestTabIdx = nearestTabIdx === -1 ? 0 : nearestTabIdx + 1;
-            const center = lineChars.slice(nearestTabIdx, tabCol).join("");
-            return tabSize - (getWidth(center) % tabSize);
-        };
-
-        const editorCol = calculateEditorColFromVimScreenCol(lineText, vimCol, tabSize);
-
+        // TODO: Break this out somehow
         const validCells: ValidCell[] = [];
         {
             const idealMaxCells = Math.max(0, getWidth(lineText) - vimCol);
-            let currMaxCol = 0;
-            gridHl[row].forEach((_, col) => {
-                if (col > currMaxCol) currMaxCol = col;
-            });
+            const currMaxCol = gridHl.maxColInRow(row);
             const maxValidCells = Math.max(idealMaxCells, currMaxCol);
             const eolCells: ValidCell[] = [];
             let currHlId = 0;
@@ -297,102 +257,8 @@ export class HighlightProvider implements Disposable {
             }
             validCells.push(...finalEolCells);
         }
-        const cellIter = new CellIter(validCells);
 
-        // #region
-        // If the previous column can contain multiple cells,
-        // then the redraw cells may contain cells from the previous column.
-        if (editorCol > 0) {
-            const prevCol = editorCol - 1;
-            const prevChar = lineChars[prevCol];
-            const expectedCells = prevChar === "\t" ? calcTabCells(prevCol) : getWidth(prevChar);
-            if (expectedCells > 1) {
-                const expectedVimCol = getWidth(lineChars.slice(0, editorCol).join(""));
-                if (expectedVimCol > vimCol) {
-                    const rightHls: Highlight[] = [];
-                    for (let i = 0; i < expectedVimCol - vimCol; i++) {
-                        const cell = cellIter.next();
-                        cell && rightHls.push({ ...cell, virtText: cell.text });
-                    }
-                    const leftHls: Highlight[] = [];
-                    if (expectedCells - rightHls.length) {
-                        leftHls.push(...(gridHl[row][prevCol] ?? []).slice(0, expectedCells - rightHls.length));
-                    }
-                    gridHl[row][prevCol] = [...leftHls, ...rightHls];
-                }
-            }
-        }
-        // #endregion
-
-        // Insert additional columns for characters with length greater than 1.
-        const filledLineText = segment(lineText).reduce((p, c) => p + c + " ".repeat(c.length - 1), "");
-
-        const filledLineChars = segment(filledLineText);
-        let currCharCol = editorCol;
-        let cell = cellIter.next();
-        while (cell) {
-            const hls: Highlight[] = [];
-            const add = (cell: ValidCell, virtText?: string) => hls.push({ ...cell, virtText });
-            const currChar = filledLineChars[currCharCol];
-            const extraCols = currChar ? currChar.length - 1 : 0;
-            currCharCol += extraCols;
-            // ... some emojis have text versions e.g. [..."❤️"] == ['❤', '️']
-            const hlCol = currCharCol - (currChar ? [...currChar].length - 1 : 0);
-
-            do {
-                if (currChar === "\t") {
-                    add(cell, cell.text);
-                    for (let i = 0; i < calcTabCells(currCharCol) - 1; i++) {
-                        cell = cellIter.next();
-                        cell && add(cell, cell.text);
-                    }
-
-                    break;
-                }
-
-                if (currChar && isDouble(currChar)) {
-                    if (currChar === cell.text) {
-                        add(cell);
-                        break;
-                    }
-
-                    add(cell, cell.text);
-                    if (!isDouble(cell.text)) {
-                        const nextCell = cellIter.next();
-                        nextCell && add(nextCell, nextCell.text);
-                        extraCols && add(nextCell ?? cell, " ".repeat(extraCols));
-                    }
-
-                    break;
-                }
-
-                if (currChar === cell.text) {
-                    add(cell);
-                } else {
-                    add(cell, cell.text);
-                    if (isDouble(cell.text)) {
-                        currCharCol++;
-                    }
-                }
-
-                // eslint-disable-next-line no-constant-condition
-            } while (false);
-
-            if (!hls.length || !hls.some((d) => d.hlId !== 0)) {
-                if (gridHl[row][hlCol]) {
-                    hasUpdates = true;
-                    delete gridHl[row][hlCol];
-                }
-            } else {
-                hasUpdates = true;
-                gridHl[row][hlCol] = hls;
-            }
-            /////////////////////////////////////////////
-            currCharCol++;
-            cell = cellIter.next();
-        }
-
-        return hasUpdates;
+        return gridHl.processHighlightCellsEvent({ row, vimCol, validCells, lineText, tabSize });
     }
 
     public shiftGridHighlights(grid: number, by: number, from: number): void {
@@ -400,41 +266,8 @@ export class HighlightProvider implements Disposable {
         if (!gridHl) {
             return;
         }
-        if (by > 0) {
-            // remove clipped out rows
-            for (let i = 0; i < by; i++) {
-                delete gridHl[from + i];
-            }
-            // first get non empty indexes, then process, seems faster than iterating whole array
-            const idxs: number[] = [];
-            gridHl.forEach((_row, idx) => {
-                idxs.push(idx);
-            });
-            // shift
-            for (const idx of idxs) {
-                if (idx <= from) {
-                    continue;
-                }
-                gridHl[idx - by] = gridHl[idx];
-                delete gridHl[idx];
-            }
-        } else if (by < 0) {
-            // remove clipped out rows
-            for (let i = 0; i < Math.abs(by); i++) {
-                delete gridHl[from !== 0 ? from + i : gridHl.length - 1 - i];
-            }
-            const idxs: number[] = [];
-            gridHl.forEach((_row, idx) => {
-                idxs.push(idx);
-            });
-            for (const idx of idxs.reverse()) {
-                if (idx <= from) {
-                    continue;
-                }
-                gridHl[idx + Math.abs(by)] = gridHl[idx];
-                delete gridHl[idx];
-            }
-        }
+
+        gridHl.shiftHighlights(by, from);
     }
 
     public getGridHighlights(
@@ -452,7 +285,7 @@ export class HighlightProvider implements Disposable {
 
         const gridHl = this.highlights.get(grid);
         if (gridHl) {
-            gridHl.forEach((rowHighlights, row) => {
+            gridHl.forEachRow((rowHighlights, row) => {
                 const line = row + topLine;
                 // FIXME: Possibly due to viewport desync
                 if (line >= editor.document.lineCount) {

--- a/src/test/unit/utils/text_cells.test.ts
+++ b/src/test/unit/utils/text_cells.test.ts
@@ -1,0 +1,66 @@
+import { strict as assert } from "assert";
+
+import { getWidth, isDouble } from "../../../utils/text_cells";
+
+describe("isDouble", () => {
+    [
+        {
+            char: "a", // length 1
+            expectedDouble: false,
+        },
+        {
+            char: "₪", // length 1
+            expectedDouble: false,
+        },
+        {
+            char: "你", // length 1
+            expectedDouble: true,
+        },
+        {
+            char: "🚀", // length 2
+            expectedDouble: true,
+        },
+        {
+            char: "🕵️", // length 3
+            expectedDouble: true,
+        },
+        {
+            char: "❤️", // length 2
+            expectedDouble: true,
+        },
+    ].forEach(({ char, expectedDouble }) => {
+        it(`${expectedDouble ? "should" : "should not"} consider '${char}' to be double-width`, () => {
+            assert.equal(isDouble(char), expectedDouble);
+        });
+    });
+});
+
+describe("getWidth", () => {
+    [
+        {
+            testName: "normal ascii should have a width equal to the length",
+            text: "hello world",
+            expectedWidth: 11,
+        },
+        {
+            testName: "double-wide chars should count twice in the length",
+            text: "ship it 🚀🚀", // rockets are double-wide, so count twice
+            expectedWidth: 12,
+        },
+        {
+            testName: "tabs at the start of a line should count for their full tab width",
+            text: "\treturn 0;",
+            expectedWidth: 13,
+        },
+        {
+            // see expandTabs for more tests like this
+            testName: "tabs in the middle of a line should only count up to their next tabstop",
+            text: "\treturn\t0;",
+            expectedWidth: 14,
+        },
+    ].forEach(({ testName, text, expectedWidth }) => {
+        it(testName, () => {
+            assert.equal(getWidth(text, 4), expectedWidth);
+        });
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 export * from "./utils/text";
+export * from "./utils/text_cells";
 export * from "./utils/vscode";
 export * from "./utils/nvim";
 export * from "./utils/async";

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,3 +1,4 @@
+import GraphemeSplitter from "grapheme-splitter";
 import wcswidth from "ts-wcwidth";
 
 export function expandTabs(line: string, tabWidth: number): string {
@@ -15,6 +16,11 @@ export function expandTabs(line: string, tabWidth: number): string {
     );
 
     return expanded;
+}
+
+export function splitGraphemes(str: string): string[] {
+    const splitter = new GraphemeSplitter();
+    return splitter.splitGraphemes(str);
 }
 
 export function calculateEditorColFromVimScreenCol(line: string, screenCol: number, tabSize: number): number {

--- a/src/utils/text_cells.ts
+++ b/src/utils/text_cells.ts
@@ -1,0 +1,23 @@
+import wcswidth from "ts-wcwidth";
+
+import { expandTabs, splitGraphemes } from "./text";
+
+/**
+ * Checks whether or not the contents of a text cell should actually span two cells. For instance:
+ * a  length:1 width:1
+ * 你 length:1 width:2
+ * 🚀 length:2 width:2
+ * 🕵️ length:3 width:2
+ * ❤️ length:2 width:1
+ *
+ * @param cellText The cell text to check
+ * @returns Whether or not this cell is a double-width cell
+ */
+export function isDouble(cellText: string): boolean {
+    return wcswidth(cellText) === 2 || cellText.length > 1;
+}
+
+export function getWidth(text: string, tabSize: number): number {
+    const t = expandTabs(text ?? "", tabSize);
+    return splitGraphemes(t).reduce((p, c) => p + (isDouble(c) ? 2 : 1), 0);
+}


### PR DESCRIPTION
There's a bunch of things I want to do before undrafting this, but my goal is to move all "grid calculations" into an isolated data structure -- `HighlightGrid` -- rather than the `HighlightProvider`. By separating the logic of providing the highlights to VSCode from the logic to keep track of the highlights, we can much more easily unit test the highlight logic. You'll notice that most of the code in `HighlightGrid` is just a copy/paste from the previous `HighlightProvider`; this is deliberate, and I'm thinking of keeping it mostly the same for now, just not to change too much at once.

Current TODO
- [ ] Add a more functional way to get highlight ranges out of the `HighlightGrid`
- [ ] Add unit tests around some basic highlighting cases
- [ ] Use this new highlight range extraction to build highlight decorations
- [ ] (Maybe another PR?) simplify the old highlight building logic from the `HighlightProvider` 