### PR TITLE
feat!: better composite key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,32 +171,37 @@ reporting it.
 
 ### Composite escape keys
 
-Since VSCode is responsible for insert mode, custom insert-mode Vim mappings don't work. To map composite escape keys,
-put into your keybindings.json:
+Related configurations:
 
-for <kbd>jj</kbd>
+-   `compositeTimeout`
+-   `compositeKeys`
 
-```json
-{
-    "command": "vscode-neovim.compositeEscape1",
-    "key": "j",
-    "when": "neovim.mode == insert && editorTextFocus",
-    "args": "j"
-}
-```
+Examples:
 
-to enable <kbd>jk</kbd> add also:
+1. <kbd>jj</kbd> to escape
 
 ```json
 {
-    "command": "vscode-neovim.compositeEscape2",
-    "key": "k",
-    "when": "neovim.mode == insert && editorTextFocus",
-    "args": "k"
+    "vscode-neovim.compositeKeys": {
+        "jj": {
+            "command": "vscode-neovim.escape"
+        }
+    }
 }
 ```
 
-Currently, there is no way to map both `jk` and `kj`, or to map `jk` without also mapping `jj`.
+2. <kbd>jk</kbd> to escape and save
+
+```json
+{
+    "vscode-neovim.compositeKeys": {
+        "jk": {
+            "command": "vscode-neovim.lua",
+            "args": ["vim.api.nvim_input('<ESC>')\nrequire('vscode-neovim').action('workbench.action.files.save')"]
+        }
+    }
+}
+```
 
 ### Jumplist
 

--- a/package.json
+++ b/package.json
@@ -400,6 +400,14 @@
                                 "command": "vscode-neovim.escape",
                                 "args": []
                             }
+                        },
+                        {
+                            "jk": {
+                                "command": "vscode-neovim.lua",
+                                "args": [
+                                    "vim.api.nvim_input('<ESC>') require('vscode-neovim').action('workbench.action.files.save')"
+                                ]
+                            }
                         }
                     ],
                     "patternProperties": {
@@ -417,7 +425,8 @@
                                 "command"
                             ]
                         }
-                    }
+                    },
+                    "description": "Composite key bindings"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -389,6 +389,8 @@
                 "vscode-neovim.compositeTimeout": {
                     "type": "number",
                     "default": 300,
+                    "minimum": 100,
+                    "maximum": 1000,
                     "description": "Timeout in milliseconds to wait for the next key in a composite key sequence"
                 },
                 "vscode-neovim.compositeKeys": {

--- a/package.json
+++ b/package.json
@@ -385,6 +385,39 @@
                     "type": "string",
                     "default": "|",
                     "description": "Separator used by statusline"
+                },
+                "vscode-neovim.compositeTimeout": {
+                    "type": "number",
+                    "default": 300,
+                    "description": "Timeout in milliseconds to wait for the next key in a composite key sequence"
+                },
+                "vscode-neovim.compositeKeys": {
+                    "type": "object",
+                    "default": {},
+                    "examples": [
+                        {
+                            "jj": {
+                                "command": "vscode-neovim.escape",
+                                "args": []
+                            }
+                        }
+                    ],
+                    "patternProperties": {
+                        "^[a-zA-Z]{2}$": {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "string"
+                                },
+                                "args": {
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "command"
+                            ]
+                        }
+                    }
                 }
             }
         },
@@ -412,14 +445,6 @@
             {
                 "command": "vscode-neovim.escape",
                 "title": "Neovim: Send escape key to neovim, or other keys that will exit insert mode"
-            },
-            {
-                "command": "vscode-neovim.compositeEscape1",
-                "title": "Neovim: Composite escape key 1"
-            },
-            {
-                "command": "vscode-neovim.compositeEscape2",
-                "title": "Neovim: Composite escape key 2"
             },
             {
                 "command": "vscode-neovim.commit-cmdline",

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,8 @@ type LegacySettingName = "neovimPath" | "neovimInitPath";
 type SettingPrefix = "neovimExecutablePaths" | "neovimInitVimPaths"; //this needs to be aligned with setting names in package.json
 type Platform = "win32" | "darwin" | "linux";
 
+export type CompositeKeys = { [key: string]: { command: string; args?: any[] } };
+
 export class Config implements Disposable {
     private disposables: Disposable[] = [];
     private readonly root = EXT_NAME;
@@ -39,6 +41,7 @@ export class Config implements Disposable {
         "neovimExecutablePaths.linux",
         "neovimExecutablePaths.win32",
         "afterInitConfig",
+        "compositeKeys",
     ].map((c) => `${this.root}.${c}`);
 
     dispose() {
@@ -181,6 +184,13 @@ export class Config implements Disposable {
     }
     get disableMouseSelection() {
         return this.mouseSelectionDebounceTime === 0;
+    }
+
+    get compositeTimeout(): number {
+        return this.cfg.get("compositeTimeout", 300);
+    }
+    get compositeKeys(): CompositeKeys {
+        return this.cfg.get("compositeKeys", {});
     }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,6 @@ export class Config implements Disposable {
         "neovimExecutablePaths.linux",
         "neovimExecutablePaths.win32",
         "afterInitConfig",
-        "compositeKeys",
     ].map((c) => `${this.root}.${c}`);
 
     dispose() {

--- a/src/test/integ/composite-escape.test.ts
+++ b/src/test/integ/composite-escape.test.ts
@@ -1,7 +1,8 @@
+import { strict as assert } from "assert";
+
 import { NeovimClient } from "neovim";
 import vscode from "vscode";
 
-import { strict as assert } from "assert";
 import {
     assertContent,
     attachTestNvimClient,
@@ -11,7 +12,7 @@ import {
     sendEscapeKey,
     sendInsertKey,
     sendVSCodeKeys,
-    wait
+    wait,
 } from "./integrationUtils";
 
 describe("Composite escape key", () => {

--- a/src/test/integ/composite-escape.test.ts
+++ b/src/test/integ/composite-escape.test.ts
@@ -23,7 +23,7 @@ describe("Composite escape key", () => {
         await closeAllActiveEditors();
     });
 
-    it("Works", async () => {
+    it.skip("Works", async () => {
         await openTextDocument({ content: "" });
 
         await sendInsertKey();

--- a/src/test/integ/composite-escape.test.ts
+++ b/src/test/integ/composite-escape.test.ts
@@ -31,8 +31,7 @@ describe("Composite escape key", () => {
             },
             vscode.ConfigurationTarget.Global,
         );
-        await vscode.commands.executeCommand("vscode-neovim.restart");
-        await wait(300);
+        await wait(200);
         client = await attachTestNvimClient();
     });
     after(async () => {
@@ -41,7 +40,6 @@ describe("Composite escape key", () => {
         await vscode.workspace
             .getConfiguration("vscode-neovim")
             .update("compositeKeys", undefined, vscode.ConfigurationTarget.Global);
-        await vscode.commands.executeCommand("vscode-neovim.restart");
     });
 
     it("Works", async () => {

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -195,7 +195,7 @@ export class TypingManager implements Disposable {
 
     private onVSCodeType = async (_editor: TextEditor, _edit: TextEditorEdit, { text }: { text: string }) => {
         if (!this.takeOverVSCodeInput) {
-            if (this.isInsertMode) this.compositeInput(text);
+            if (this.isInsertMode && !this.isInComposition) this.compositeInput(text);
             else this.vscodeDefaultType(text);
             return;
         }

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -67,6 +67,12 @@ export class TypingManager implements Disposable {
         // Prepare configs for composite keys
         this.compositeKeys = config.compositeKeys;
         Object.keys(this.compositeKeys).forEach((key) => {
+            if (!/^[a-zA-Z]{2}$/.test(key)) {
+                window.showErrorMessage(
+                    `Invalid composite key: ${key}. Composite key must be exactly 2 characters long.`,
+                );
+                return;
+            }
             const [first, second] = key.split("");
             this.compositeFirstKeys.push(first);
             const secondKeys = this.compositeSecondKeysForFirstKey.get(first) || [];

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -3,7 +3,7 @@ import { commands, Disposable, TextEditor, TextEditorEdit, window } from "vscode
 import { CompositeKeys, config } from "./config";
 import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
-import { disposeAll, ManualPromise, normalizeInputString } from "./utils";
+import { disposeAll, normalizeInputString } from "./utils";
 
 const logger = createLogger("TypingManager");
 
@@ -47,7 +47,6 @@ export class TypingManager implements Disposable {
     // logic variables
     private compositeMatchedFirstKey?: string;
     private compositeTimer?: NodeJS.Timeout;
-    private compositePromise?: ManualPromise;
 
     private get client() {
         return this.main.client;
@@ -152,13 +151,10 @@ export class TypingManager implements Disposable {
         if (!this.compositeMatchedFirstKey) {
             if (this.compositeFirstKeys.includes(key)) {
                 this.compositeMatchedFirstKey = key;
-                this.compositePromise?.resolve();
-                this.compositePromise = new ManualPromise();
                 this.compositeTimer = setTimeout(async () => {
                     this.compositeTimer = undefined;
                     this.compositeMatchedFirstKey = undefined;
                     await this.vscodeDefaultType(key);
-                    this.compositePromise?.resolve();
                 }, config.compositeTimeout);
             } else {
                 await this.vscodeDefaultType(key);
@@ -188,7 +184,6 @@ export class TypingManager implements Disposable {
             return;
         }
 
-        await this.compositePromise?.promise;
         await this.vscodeDefaultType(key);
     }
 

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -126,21 +126,28 @@ export class TypingManager implements Disposable {
         if (!this.takeOverVSCodeInput) {
             return commands.executeCommand("default:type", { ...type });
         }
+
         if (this.isEnteringInsertMode) {
             this.pendingKeysAfterEnter += type.text;
-        } else if (this.isExitingInsertMode) {
+            return;
+        }
+        if (this.isExitingInsertMode) {
             this.pendingKeysAfterExit += type.text;
-        } else if (this.isInComposition) {
+            return;
+        }
+        if (this.isInComposition) {
             this.composingText += type.text;
-        } else if (this.main.modeManager.isInsertMode && !this.main.modeManager.isRecordingInInsertMode) {
-            if ((await this.client.mode).blocking) {
-                this.client.input(normalizeInputString(type.text, !this.main.modeManager.isRecordingInInsertMode));
-            } else {
-                this.takeOverVSCodeInput = false;
-                commands.executeCommand("default:type", { ...type });
-            }
-        } else {
+            return;
+        }
+        if (!this.main.modeManager.isInsertMode || this.main.modeManager.isRecordingInInsertMode) {
             this.client.input(normalizeInputString(type.text, !this.main.modeManager.isRecordingInInsertMode));
+            return;
+        }
+        if ((await this.client.mode).blocking) {
+            this.client.input(normalizeInputString(type.text, !this.main.modeManager.isRecordingInInsertMode));
+        } else {
+            this.takeOverVSCodeInput = false;
+            commands.executeCommand("default:type", { ...type });
         }
     };
 

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -1,9 +1,9 @@
 import { commands, Disposable, TextEditor, TextEditorEdit, window } from "vscode";
 
+import { CompositeKeys, config } from "./config";
 import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
 import { disposeAll, ManualPromise, normalizeInputString } from "./utils";
-import { CompositeKeys, config } from "./config";
 
 const logger = createLogger("TypingManager");
 
@@ -34,14 +34,20 @@ export class TypingManager implements Disposable {
      */
     private composingText = "";
 
+    /**
+     * Flag indicating that we should take over vscode input
+     * If false, we should forward all input received from "type" to "default:type"
+     */
     private takeOverVSCodeInput = false;
 
+    // configs
+    private compositeKeys: CompositeKeys;
     private compositeFirstKeys: string[] = [];
     private compositeSecondKeysForFirstKey = new Map<string, string[]>();
+    // logic variables
     private compositeMatchedFirstKey?: string;
     private compositeTimer?: NodeJS.Timeout;
     private compositePromise?: ManualPromise;
-    private compositeKeys: CompositeKeys;
 
     private get client() {
         return this.main.client;


### PR DESCRIPTION
The main idea is to always register the `type` command, but when there is no need to take over user input (generally in insert mode), forward the received inputs to the `default:type` command.

The implementation is to judge the input before forwarding. If it matches, call the configured command, otherwise continue to forward to the `default:type`

At present, this implementation is normal, but it feels that forwarding input causes a slight delay in input (this may be a psychological effect). Need help testing this. **If there is indeed a delay, consider forwarding inputs only when the user needs the composite keys. If the user does not need to use composite keys, then just dispose the command when there is no need to take over user input**. ( Even if there is a delay, it is very slight.)

---

New configurations:
- compositeTimeout
- compositeKeys

Removed commands: `vscode-neovim.compositeEscape1` `vscode-neovim.compositeEscape2`

**Usage**

1. jj to escape
```json
{
    "vscode-neovim.compositeKeys": {
        "jj": {
            "command": "vscode-neovim.escape"
        }
    }
}
```
2. jk to escape and save
```json
{
    "vscode-neovim.compositeKeys": {
        "jk": {
            "command": "vscode-neovim.lua",
            "args": ["vim.api.nvim_input('<ESC>')\nrequire('vscode-neovim').action('workbench.action.files.save')"]
        }
    }
}
```

---

- close #563
- close #460
- close #330
- close #493
- close #644
- close #892