### PR TITLE
refactor: register type commands only when needed

### DIFF
--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -65,6 +65,8 @@ export class TypingManager implements Disposable {
     // 2. When composite keys are not needed, only register type and
     //    replacePreviousChar when it's necessary to take over vscode input.
 
+    // "type" and "replacePreviousChar" are commands that vscode provides to handle user typing.
+
     private typeHandler?: Disposable;
     private replacePreviousCharHandler?: Disposable;
 

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -1,3 +1,5 @@
+// Override vscode commands: "type", "replacePreviousChar", "compositionStart", "compositionEnd"
+// Learn more: https://github.com/microsoft/vscode-extension-samples/tree/main/vim-sample
 import { commands, Disposable, TextEditor, TextEditorEdit, window, workspace } from "vscode";
 
 import { CompositeKeys, config } from "./config";


### PR DESCRIPTION
At present, the problem in #1921 seems to be unavoidable. The current approach is that when composite keys are not used, the logic is the same as before. See if users can accept it  @theol0403 @wenfangdu @vlwkaos