### PR TITLE
fix: set an explicit id for status bar item

### DIFF
--- a/src/status_line_manager.ts
+++ b/src/status_line_manager.ts
@@ -28,7 +28,7 @@ export class StatusLineManager implements Disposable {
     }
 
     public constructor(private main: MainController) {
-        this.statusBar = window.createStatusBarItem(StatusBarAlignment.Left, -10);
+        this.statusBar = window.createStatusBarItem("vscode-neovim-status", StatusBarAlignment.Left, -10);
         this.statusBar.show();
         this.disposables.push(this.statusBar, eventBus.on("redraw", this.handleRedraw, this));
 


### PR DESCRIPTION
Fix #1572 (probably related: #1251 #843)

A similar issue can be observed in combination with other extensions

The issue https://github.com/microsoft/vscode/issues/201795 causes status bar items to clash if they are created without explicit ids and in different extension hosts (e.g. by setting extension affinity).

While the underlying issue is not fixed, it can be avoided by assigning an explicit id (and there are no downsides to doing this, as far as I am aware).