### PR TITLE
fix: support up/down for cmdline history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1008,6 +1008,18 @@
             },
             {
                 "command": "vscode-neovim.send-cmdline",
+                "key": "up",
+                "when": "neovim.init && neovim.mode == cmdline",
+                "args": "<Up>"
+            },
+            {
+                "command": "vscode-neovim.send-cmdline",
+                "key": "down",
+                "when": "neovim.init && neovim.mode == cmdline",
+                "args": "<Down>"
+            },
+            {
+                "command": "vscode-neovim.send-cmdline",
                 "key": "ctrl+h",
                 "when": "neovim.init && neovim.mode == cmdline",
                 "args": "<C-h>"

--- a/scripts/keybindings/4_cmdline.cjs
+++ b/scripts/keybindings/4_cmdline.cjs
@@ -5,6 +5,10 @@ const [_add, keybinds] = addKeybinds();
 const add = (key, args, cmd = "vscode-neovim.send-cmdline") =>
     _add(key, "neovim.init && neovim.mode == cmdline", args, cmd);
 
+// up/down
+add("up", "<Up>");
+add("down", "<Down>");
+
 // ctrl keys
 [..."hwunplgtmj", "up", "down"].forEach((k) => {
     let key = `ctrl+${k}`;


### PR DESCRIPTION
Fixes https://github.com/vscode-neovim/vscode-neovim/issues/288

As of https://github.com/microsoft/vscode/pull/211756, arrow keys are now bindable in quickpick.