### PR TITLE
fix: should setup highlights on WinNew,BufNew

### DIFF
--- a/runtime/lua/vscode-neovim/highlight.lua
+++ b/runtime/lua/vscode-neovim/highlight.lua
@@ -141,14 +141,19 @@ end
 
 local function setup_treesitter_highlighting()
   -- We don't need any treesitter highlights
-  vim.treesitter.stop()
+  for _, buf in ipairs(api.nvim_list_bufs()) do
+    vim.treesitter.stop(buf)
+  end
 end
 
 local function setup()
   local group = api.nvim_create_augroup("VSCodeNeovimHighlight", { clear = true })
-  api.nvim_create_autocmd({ "BufWinEnter", "BufEnter", "WinEnter", "WinScrolled" }, {
+  api.nvim_create_autocmd({ "WinNew", "WinEnter", "BufNew", "BufEnter", "BufWinEnter" }, {
     group = group,
-    callback = setup_win_hl_ns,
+    callback = function()
+      setup_win_hl_ns()
+      setup_treesitter_highlighting()
+    end,
   })
   api.nvim_create_autocmd({ "ColorScheme", "Syntax", "FileType" }, {
     group = group,
@@ -166,10 +171,6 @@ local function setup()
         setup_syntax_groups()
       end
     end,
-  })
-  api.nvim_create_autocmd({ "BufWinEnter", "BufEnter" }, {
-    group = group,
-    callback = setup_treesitter_highlighting,
   })
   api.nvim_create_autocmd({ "VimEnter", "UIEnter" }, {
     group = group,


### PR DESCRIPTION
- Always try stopping treesitter highlight for all buffers

Possibly not focusing on window after creating it, e.g. when using the peek window

![image](https://github.com/vscode-neovim/vscode-neovim/assets/47070852/f57347ce-9997-4cd1-b89a-c362a57b1e5e)
