### PR TITLE
build: enable recommended typechecked rules

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -8,7 +8,7 @@ const globals = require("globals");
 
 module.exports = tseslint.config(
     eslint.configs.recommended,
-    ...tseslint.configs.recommended,
+    ...tseslint.configs.recommendedTypeChecked,
     {
         plugins: {
             import: importsPlugin,
@@ -19,6 +19,10 @@ module.exports = tseslint.config(
             globals: {
                 ...globals.node,
                 ...globals.es6,
+            },
+            parserOptions: {
+                project: true,
+                tsconfigRootDir: __dirname,
             },
         },
         rules: {
@@ -65,6 +69,19 @@ module.exports = tseslint.config(
             "@typescript-eslint/explicit-function-return-type": "off",
             "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-explicit-any": "off",
+
+            "@typescript-eslint/no-misused-promises": "off",
+            "@typescript-eslint/no-unsafe-argument": "off",
+            "@typescript-eslint/no-unsafe-assignment": "off",
+            "@typescript-eslint/no-unsafe-call": "off",
+            "@typescript-eslint/no-unsafe-declaration-merging": "off",
+            "@typescript-eslint/no-unsafe-enum-comparison": "off",
+            "@typescript-eslint/no-unsafe-member-access": "off",
+            "@typescript-eslint/no-unsafe-return": "off",
+            "@typescript-eslint/restrict-template-expressions": "off", // too jumpy
+            "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these
+            "@typescript-eslint/unbound-method": "off", // jumpy, given how vscode's API binds this. Would be good to remove.
+            "@typescript-eslint/require-await": "off", // TODO: remove
         },
     },
     {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -80,7 +80,6 @@ module.exports = tseslint.config(
             "@typescript-eslint/restrict-template-expressions": "off", // too jumpy
             "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these
             "@typescript-eslint/unbound-method": "off", // jumpy, given how vscode's API binds this. Would be good to remove.
-            "@typescript-eslint/require-await": "off", // TODO: remove
         },
     },
     {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -69,15 +69,13 @@ module.exports = tseslint.config(
             "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-explicit-any": "off",
 
-            "@typescript-eslint/no-misused-promises": "off",
             "@typescript-eslint/no-unsafe-argument": "off",
             "@typescript-eslint/no-unsafe-assignment": "off",
             "@typescript-eslint/no-unsafe-call": "off",
-            "@typescript-eslint/no-unsafe-declaration-merging": "off",
-            "@typescript-eslint/no-unsafe-enum-comparison": "off",
             "@typescript-eslint/no-unsafe-member-access": "off",
             "@typescript-eslint/no-unsafe-return": "off",
             "@typescript-eslint/restrict-template-expressions": "off", // too jumpy
+            "@typescript-eslint/no-misused-promises": "off", // too jumpy
             "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these
             "@typescript-eslint/unbound-method": "off", // jumpy, given how vscode's API binds this. Would be good to remove.
         },

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -24,6 +24,9 @@ module.exports = tseslint.config(
                 tsconfigRootDir: __dirname,
             },
         },
+        linterOptions: {
+            reportUnusedDisableDirectives: "error",
+        },
         rules: {
             // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
             // e.g. "@typescript-eslint/explicit-function-return-type": "off",

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,5 +1,3 @@
-/* eslint-env es2019 */
-
 const eslint = require("@eslint/js");
 const tseslint = require("typescript-eslint");
 const eslintPluginPrettierRecommended = require("eslint-plugin-prettier/recommended");
@@ -13,6 +11,7 @@ module.exports = tseslint.config(
         plugins: {
             import: importsPlugin,
         },
+        ignores: ["eslint.config.cjs"],
         languageOptions: {
             ecmaVersion: 2019, // Allows for the parsing of modern ECMAScript features
             sourceType: "module", // Allows for the use of imports

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -69,11 +69,12 @@ module.exports = tseslint.config(
             "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-explicit-any": "off",
 
+            // This codebase interacts with `any` a lot, so for now, all no-unsafe-* we violate are currently disabled
             "@typescript-eslint/no-unsafe-argument": "off",
             "@typescript-eslint/no-unsafe-assignment": "off",
-            "@typescript-eslint/no-unsafe-call": "off",
             "@typescript-eslint/no-unsafe-member-access": "off",
             "@typescript-eslint/no-unsafe-return": "off",
+
             "@typescript-eslint/restrict-template-expressions": "off", // too jumpy
             "@typescript-eslint/no-misused-promises": "off", // too jumpy
             "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -68,17 +68,16 @@ module.exports = tseslint.config(
             "@typescript-eslint/explicit-function-return-type": "off",
             "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/restrict-template-expressions": "off", // too jumpy
+            "@typescript-eslint/no-misused-promises": "off", // too jumpy
+            "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these
+            "@typescript-eslint/unbound-method": "off", // jumpy, given how vscode's API binds this. Would be good to remove.
 
             // This codebase interacts with `any` a lot, so for now, all no-unsafe-* we violate are currently disabled
             "@typescript-eslint/no-unsafe-argument": "off",
             "@typescript-eslint/no-unsafe-assignment": "off",
             "@typescript-eslint/no-unsafe-member-access": "off",
             "@typescript-eslint/no-unsafe-return": "off",
-
-            "@typescript-eslint/restrict-template-expressions": "off", // too jumpy
-            "@typescript-eslint/no-misused-promises": "off", // too jumpy
-            "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these
-            "@typescript-eslint/unbound-method": "off", // jumpy, given how vscode's API binds this. Would be good to remove.
         },
     },
     {

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -24,7 +24,8 @@ void logger;
 export async function eval_for_client(code: string, args: any): Promise<any> {
     void args;
 
-    const result = await eval("async () => {" + code + "}")();
+    const func: () => Promise<any> = eval("async () => {" + code + "}");
+    const result = await func();
 
     let data: string | undefined;
     try {

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import neovim from "neovim";
 import { Disposable, EventEmitter } from "vscode";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ export function deactivate(isRestart = false) {
     if (!isRestart) disposeAll(disposables);
 }
 
-async function verifyExperimentalAffinity(): Promise<void> {
+function verifyExperimentalAffinity(): void {
     const extensionsConfiguration = vscode.workspace.getConfiguration("extensions");
     const affinityConfiguration = extensionsConfiguration.inspect<{ [key: string]: [number] }>("experimental.affinity");
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import fs from "fs";
 import { inspect } from "util";
 

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -280,7 +280,7 @@ export class MainController implements vscode.Disposable {
     private onNeovimNotification = async (method: string, events: [string, ...any[]]) => {
         switch (method) {
             case "vscode-action": {
-                const action = events[0] as string;
+                const action = events[0];
                 let options = events[1] as VSCodeActionOptions | [];
                 if (Array.isArray(options)) options = {}; // empty lua table
 
@@ -353,7 +353,7 @@ export class MainController implements vscode.Disposable {
     ): Promise<void> => {
         switch (method) {
             case "vscode-action": {
-                const action = requestArgs[0] as string;
+                const action = requestArgs[0];
                 let options = requestArgs[1] as Omit<VSCodeActionOptions, "callback"> | [];
                 if (Array.isArray(options)) options = {}; // empty lua table
 

--- a/src/test/integ/extmark.test.ts
+++ b/src/test/integ/extmark.test.ts
@@ -26,7 +26,7 @@ describe("Test ext mark", () => {
         await closeNvimClient(client);
     });
 
-    afterEach(async () => {
+    afterEach(() => {
         restoreWindow();
     });
 

--- a/src/test/integ/integrationUtils.ts
+++ b/src/test/integ/integrationUtils.ts
@@ -49,13 +49,12 @@ export async function attachTestNvimClient(): Promise<NeovimClient> {
     const client = attach({ writer: conn, reader: conn });
     // wait for connection
     await client.channelId;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     (client as any).testConn = conn;
     return client;
 }
 
 export async function closeNvimClient(client: NeovimClient): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const conn: net.Socket = (client as any).testConn;
 
     // Try to gracefully close the socket first, this prevents noisy errors if it works.

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -184,7 +184,7 @@ export class TypingManager implements Disposable {
         this.useCompositeKeys = this.compositeFirstKeys.length > 0;
     }
 
-    private onModeChange = async (): Promise<void> => {
+    private onModeChange = (): void => {
         if (this.main.modeManager.isInsertMode && this.takeOverVSCodeInput && !this.isRecordingInInsertMode) {
             const editor = window.activeTextEditor;
             const documentPromise = editor && this.main.changeManager.getDocumentChangeCompletionLock(editor.document);
@@ -218,11 +218,11 @@ export class TypingManager implements Disposable {
         }
     };
 
-    async compositeInput(key: string) {
+    compositeInput(key: string) {
         if (!this.compositeMatchedFirstKey) {
             if (this.compositeFirstKeys.includes(key)) {
                 this.compositeMatchedFirstKey = key;
-                this.compositeTimer = setTimeout(async () => {
+                this.compositeTimer = setTimeout(() => {
                     this.compositeTimer = undefined;
                     this.compositeMatchedFirstKey = undefined;
                     this.vscodeDefaultType(key);

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -152,7 +152,7 @@ export class TypingManager implements Disposable {
         };
 
         this.takeOverVSCodeInput = true;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         const registerCommand = (cmd: string, cb: (...args: any[]) => any) => {
             this.disposables.push(commands.registerCommand(cmd, cb, this));
         };

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -97,7 +97,7 @@ export class ViewportManager implements Disposable {
         return new Position(view.topline, view.leftcol);
     }
 
-    private async handleRedraw({ name, args }: EventBusData<"redraw">) {
+    private handleRedraw({ name, args }: EventBusData<"redraw">) {
         switch (name) {
             case "win_viewport": {
                 for (const [grid, , topline, botline, curline, curcol] of args) {
@@ -164,7 +164,7 @@ export class ViewportManager implements Disposable {
             trailing: true,
         });
     }
-    private onDidChangeVisibleRange = async (e: TextEditorVisibleRangesChangeEvent): Promise<void> => {
+    private onDidChangeVisibleRange = (e: TextEditorVisibleRangesChangeEvent) => {
         if (!this.debouncedScrollNeovim) {
             this.refreshDebounceTime();
             this.refreshDebounceScroll();


### PR DESCRIPTION
I'm still in my linting rabbit hole for right now... I've gone ahead and enabled the `recommendedTypeChecked` rules in the linter. I want to eventually move towards `strictTypeChecked` (especially rules like [`no-unnecessary-condition`](https://typescript-eslint.io/rules/no-unnecessary-condition), which are very helpful for catching bugs), but one step at a time.

You can view the rules which are enabled, here https://typescript-eslint.io/rules/?=recommended-typeInformation

There are some code changes involved here, but I'm fairly confident they won't cause any issues. You can review the commits individually to better understand why each change was made