### PR TITLE
feat!: use VSCode log level instead of our own

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,19 @@ npx vsce package -o vscode-neovim.vsix
 
 ### Logging
 
-You can observe the extension logs via the `vscode-neovim` Output channel or from the dev tools console (run the
-`Developer: Toggle Developer Tools` vscode command to see the console).
+You can view the extension logs in one of three locations
 
-Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
-[`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).
+1. Via the `vscode-neovim` Output channel
+
+    - **NOTE**: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
+      [`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).
+
+2. From the dev tools console (run the `Developer: Toggle Developer Tools` vscode command to see the console) by
+   enabling the `vscode-neovim.logOutputToConsole` setting.
+3. From a log file of your choosing, by configuring the `vscode-neovim.logPath` setting.
+
+VSCode, by default will only show messages at the "Info" level or above, but than can be changed by running the command
+"Developer Set Log Level..." -> "vscode-neovim" and selecting the desired log level.
 
 ### Run Unit Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You can view the extension logs in one of three locations
 
 1. Via the `vscode-neovim` Output channel
 
-    - **NOTE**: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
+    - Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
       [`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).
 
 2. From the dev tools console (run the `Developer: Toggle Developer Tools` vscode command to see the console) by
@@ -49,7 +49,8 @@ You can view the extension logs in one of three locations
 3. From a log file of your choosing, by configuring the `vscode-neovim.logPath` setting.
 
 VSCode, by default will only show messages at the "Info" level or above, but than can be changed by running the command
-"Developer Set Log Level..." -> "vscode-neovim" and selecting the desired log level.
+`Developer Set Log Level...` -> `vscode-neovim` and selecting the desired log level. You can also do this by clicking
+the gear icon in the output pane, with `vscode-neovim` selected.
 
 ### Run Unit Tests
 

--- a/package.json
+++ b/package.json
@@ -295,18 +295,6 @@
                     "default": "",
                     "description": "Log file path"
                 },
-                "vscode-neovim.logLevel": {
-                    "type": "string",
-                    "default": "error",
-                    "enum": [
-                        "none",
-                        "error",
-                        "warn",
-                        "info",
-                        "debug"
-                    ],
-                    "markdownDescription": "Log Level. See also `vscode-neovim.logOutputToConsole`."
-                },
                 "vscode-neovim.logOutputToConsole": {
                     "type": "boolean",
                     "default": false,

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -9,6 +9,7 @@ import {
     Disposable,
     EndOfLine,
     EventEmitter,
+    LogLevel,
     NotebookDocument,
     Selection,
     TextDocument,
@@ -27,7 +28,7 @@ import {
 import actions from "./actions";
 import { config } from "./config";
 import { EventBusData, eventBus } from "./eventBus";
-import { LogLevel, createLogger } from "./logger";
+import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
 import { ManualPromise, convertByteNumToCharNum, disposeAll, wait } from "./utils";
 
@@ -265,7 +266,7 @@ export class BufferManager implements Disposable {
                 doc ??= await workspace.openTextDocument(uri);
             }
         } catch (error) {
-            logger.log(doc?.uri, LogLevel.error, `Error opening file ${fileName}, ${error}`);
+            logger.log(doc?.uri, LogLevel.Error, `Error opening file ${fileName}, ${error}`);
         }
         if (!doc) {
             return;
@@ -300,17 +301,17 @@ export class BufferManager implements Disposable {
         }
 
         const uri = Uri.parse(vscode_uri, true);
-        logger.log(uri, LogLevel.debug, `Buffer request for ${uri.fsPath}, bufId: ${bufnr}`);
+        logger.log(uri, LogLevel.Debug, `Buffer request for ${uri.fsPath}, bufId: ${bufnr}`);
         try {
             let doc = this.findDocFromUri(uri.toString());
             if (!doc) {
-                logger.log(uri, LogLevel.debug, `Opening a doc: ${uri.fsPath}`);
+                logger.log(uri, LogLevel.Debug, `Opening a doc: ${uri.fsPath}`);
                 doc = await workspace.openTextDocument(uri);
             }
             if (!this.textDocumentToBufferId.has(doc)) {
                 logger.log(
                     uri,
-                    LogLevel.debug,
+                    LogLevel.Debug,
                     `No doc -> buffer mapping exists, assigning mapping and init buffer options`,
                 );
                 const buffers = await this.client.buffers;
@@ -473,12 +474,12 @@ export class BufferManager implements Disposable {
         // Open/change neovim windows
         for (const editor of visibleEditors) {
             const { document: doc } = editor;
-            logger.log(doc.uri, LogLevel.debug, `Visible editor, viewColumn: ${editor.viewColumn}, doc: ${doc.uri}`);
+            logger.log(doc.uri, LogLevel.Debug, `Visible editor, viewColumn: ${editor.viewColumn}, doc: ${doc.uri}`);
             // create buffer first if not known to the system
             // creating initially not listed buffer to prevent firing autocmd events when
             // buffer name/lines are not yet set. We'll set buflisted after setup
             if (!this.textDocumentToBufferId.has(doc)) {
-                logger.log(doc.uri, LogLevel.debug, `Document not known, init in neovim`);
+                logger.log(doc.uri, LogLevel.Debug, `Document not known, init in neovim`);
                 const buf = await this.client.createBuffer(false, true);
                 if (typeof buf === "number") {
                     logger.error(`Cannot create a buffer, code: ${buf}`);
@@ -486,7 +487,7 @@ export class BufferManager implements Disposable {
                 }
                 await this.initBufferForDocument(doc, buf, editor);
 
-                logger.log(doc.uri, LogLevel.debug, `Document: ${doc.uri}, BufId: ${buf.id}`);
+                logger.log(doc.uri, LogLevel.Debug, `Document: ${doc.uri}, BufId: ${buf.id}`);
                 this.textDocumentToBufferId.set(doc, buf.id);
             }
             if (this.textEditorToWinId.has(editor)) continue;
@@ -494,16 +495,16 @@ export class BufferManager implements Disposable {
             try {
                 logger.log(
                     doc.uri,
-                    LogLevel.debug,
+                    LogLevel.Debug,
                     `Creating new window for ${editor.viewColumn} column (undefined is OK here)`,
                 );
                 const winId = await this.createNeovimWindow(editorBufferId);
-                logger.log(doc.uri, LogLevel.debug, `Created new window: ${winId} ViewColumn: ${editor.viewColumn}`);
+                logger.log(doc.uri, LogLevel.Debug, `Created new window: ${winId} ViewColumn: ${editor.viewColumn}`);
                 this.textEditorToWinId.set(editor, winId);
                 this.winIdToEditor.set(winId, editor);
                 await this.main.cursorManager.updateNeovimCursorPosition(editor, editor.selection.active);
             } catch (e) {
-                logger.log(doc.uri, LogLevel.error, (e as Error).message);
+                logger.log(doc.uri, LogLevel.Error, (e as Error).message);
             }
         }
     }
@@ -519,7 +520,7 @@ export class BufferManager implements Disposable {
             // when in normal mode
             logger.log(
                 uri,
-                LogLevel.error,
+                LogLevel.Error,
                 `Unable to determine neovim window id for editor, viewColumn: ${activeEditor.viewColumn}, docUri: ${uri}`,
             );
             return;
@@ -527,7 +528,7 @@ export class BufferManager implements Disposable {
         if ((await this.client.window).id === winId) return;
         logger.log(
             uri,
-            LogLevel.debug,
+            LogLevel.Debug,
             `Setting active editor - viewColumn: ${activeEditor.viewColumn}, winId: ${winId}`,
         );
         await this.main.cursorManager.updateNeovimCursorPosition(activeEditor, activeEditor.selection.active);
@@ -535,7 +536,7 @@ export class BufferManager implements Disposable {
             // https://github.com/vscode-neovim/vscode-neovim/issues/1577
             logger.log(
                 uri,
-                LogLevel.debug,
+                LogLevel.Debug,
                 `Cancel visual mode to prevent selection from previous editor to carry over to active editor`,
             );
             await this.client.input("<Esc>");
@@ -543,7 +544,7 @@ export class BufferManager implements Disposable {
         try {
             await this.client.request("nvim_set_current_win", [winId]);
         } catch (e) {
-            logger.log(uri, LogLevel.error, (e as Error).message);
+            logger.log(uri, LogLevel.Error, (e as Error).message);
         }
     }
     // #endregion
@@ -574,11 +575,11 @@ export class BufferManager implements Disposable {
         // the event notifying the doc provider of any changes
         (async () => {
             const uri = this.buildExternalBufferUri(await buffer.name, buffer.id);
-            logger.log(uri, LogLevel.debug, `received buffer event for ${uri}`);
+            logger.log(uri, LogLevel.Debug, `received buffer event for ${uri}`);
             this.bufferProvider.documentDidChange.fire(uri);
             return uri;
         })().then(undefined, (e) => {
-            logger.log(undefined, LogLevel.error, `failed to notify document change: ${e}`);
+            logger.log(undefined, LogLevel.Error, `failed to notify document change: ${e}`);
         });
     };
 
@@ -588,7 +589,7 @@ export class BufferManager implements Disposable {
     private async initBufferForDocument(document: TextDocument, buffer: Buffer, editor?: TextEditor): Promise<void> {
         const bufId = buffer.id;
         const { uri: docUri } = document;
-        logger.log(docUri, LogLevel.debug, `Init buffer for ${bufId}, doc: ${docUri}`);
+        logger.log(docUri, LogLevel.Debug, `Init buffer for ${bufId}, doc: ${docUri}`);
 
         const eol = document.eol === EndOfLine.LF ? "\n" : "\r\n";
         const lines = document.getText().split(eol);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
     disposables.push(outputChannel);
 
     config.init();
-    rootLogger.init(vscode.env.logLevel, config.logPath, config.outputToConsole, outputChannel);
+    rootLogger.init(outputChannel.logLevel, config.logPath, config.outputToConsole, outputChannel);
     eventBus.init();
     actions.init();
     context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import actions from "./actions";
 import { config } from "./config";
 import { EXT_ID, EXT_NAME } from "./constants";
 import { eventBus } from "./eventBus";
-import { LogLevel, createLogger, logger as rootLogger } from "./logger";
+import { createLogger, logger as rootLogger } from "./logger";
 import { MainController } from "./main_controller";
 import { VSCodeContext, disposeAll } from "./utils";
 
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
     disposables.push(outputChannel);
 
     config.init();
-    rootLogger.init(LogLevel[config.logLevel], config.logPath, config.outputToConsole, outputChannel);
+    rootLogger.init(vscode.env.logLevel, config.logPath, config.outputToConsole, outputChannel);
     eventBus.init();
     actions.init();
     context.subscriptions.push(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -91,18 +91,20 @@ export class Logger implements Disposable {
 
         try {
             this.fd = fs.openSync(this.filePath, "w");
-            this.disposables.push({
-                dispose: () => {
-                    if (!this.fd) {
-                        return;
-                    }
-
-                    fs.closeSync(this.fd);
-                },
-            });
-        } catch {
-            // ignore
+        } catch (err) {
+            window.showErrorMessage(`Can not open log file at ${this.filePath}: ${err}`);
+            return;
         }
+
+        this.disposables.push({
+            dispose: () => {
+                if (!this.fd) {
+                    return;
+                }
+
+                fs.closeSync(this.fd);
+            },
+        });
     }
 
     private log(level: vscode.LogLevel, scope: string, logToOutputChannel: boolean, args: any[]): void {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -59,23 +59,21 @@ export class Logger implements Disposable {
         this.outputChannel = outputChannel;
         this.filePath = filePath;
 
-        this.listenForLogLevelChanges();
         this.setupLogFile();
+        this.outputChannel?.onDidChangeLogLevel(
+            (level: vscode.LogLevel) => this.onLogLevelChanged(level),
+            undefined,
+            this.disposables,
+        );
     }
 
     public dispose(): void {
         disposeAll(this.disposables);
     }
 
-    private listenForLogLevelChanges() {
-        this.outputChannel?.onDidChangeLogLevel(
-            (level) => {
-                this.level = level;
-                this.setupLogFile();
-            },
-            undefined,
-            this.disposables,
-        );
+    private onLogLevelChanged(level: vscode.LogLevel) {
+        this.level = level;
+        this.setupLogFile();
     }
 
     private setupLogFile() {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,16 +7,8 @@ import * as vscode from "vscode";
 
 import { disposeAll } from "./utils";
 
-export enum LogLevel {
-    /** Disables all logging. */
-    none = 0,
-    error = 1,
-    warn = 2,
-    info = 3,
-    debug = 4,
-}
-
 export interface ILogger {
+    trace(...args: any[]): void;
     debug(...args: any[]): void;
     info(...args: any[]): void;
     warn(...args: any[]): void;
@@ -31,7 +23,7 @@ export interface ILogger {
      * @param level Log level.
      * @param logArgs Log message format string followed by values.
      */
-    log(uri: vscode.Uri | undefined, level: LogLevel, ...logArgs: any[]): void;
+    log(uri: vscode.Uri | undefined, level: vscode.LogLevel, ...logArgs: any[]): void;
 }
 
 function getTimestamp(): string {
@@ -40,9 +32,10 @@ function getTimestamp(): string {
 
 export class Logger implements Disposable {
     private disposables: Disposable[] = [];
-    private fd = 0;
+    private fd: number | undefined;
+    private filePath: string | undefined;
     private loggers: Map<string, ILogger> = new Map();
-    private level!: LogLevel;
+    private level!: vscode.LogLevel;
     private logToConsole!: boolean;
     private outputChannel?: vscode.LogOutputChannel;
 
@@ -50,32 +43,69 @@ export class Logger implements Disposable {
      * Setup logging for the extension. Logs are dropped unless one or more of
      * `filePath`, `logToConsole`, or `outputChannel` is given.
      *
-     * @param level Only log messages at or above this level, or never if set to `LogLevel.none`.
+     * @param level Only log messages at or above this level, or never if set to `vscode.LogLevel.Off`.
      * @param filePath Write messages to this file.
      * @param logToConsole Write messages to the `console` (Hint: run the "Developer: Toggle Developer Tools" vscode command to see the console).
      * @param outputChannel Write messages to this vscode output channel.
      */
-    public init(level: LogLevel, filePath: string, logToConsole = false, outputChannel?: vscode.LogOutputChannel) {
+    public init(
+        level: vscode.LogLevel,
+        filePath: string,
+        logToConsole = false,
+        outputChannel?: vscode.LogOutputChannel,
+    ) {
         this.level = level;
         this.logToConsole = logToConsole;
         this.outputChannel = outputChannel;
-        if (filePath && level !== LogLevel.none) {
-            try {
-                this.fd = fs.openSync(filePath, "w");
-                this.disposables.push({
-                    dispose: () => fs.closeSync(this.fd),
-                });
-            } catch {
-                // ignore
-            }
-        }
+        this.filePath = filePath;
+
+        this.listenForLogLevelChanges();
+        this.setupLogFile();
     }
 
     public dispose(): void {
         disposeAll(this.disposables);
     }
 
-    private log(level: LogLevel, scope: string, logToOutputChannel: boolean, args: any[]): void {
+    private listenForLogLevelChanges() {
+        this.outputChannel?.onDidChangeLogLevel(
+            (level) => {
+                this.level = level;
+                this.setupLogFile();
+            },
+            undefined,
+            this.disposables,
+        );
+    }
+
+    private setupLogFile() {
+        if (!this.filePath) {
+            return;
+        } else if (this.level !== vscode.LogLevel.Off && this.fd) {
+            return;
+        } else if (this.level === vscode.LogLevel.Off && this.fd) {
+            fs.closeSync(this.fd);
+            this.fd = undefined;
+            return;
+        }
+
+        try {
+            this.fd = fs.openSync(this.filePath, "w");
+            this.disposables.push({
+                dispose: () => {
+                    if (!this.fd) {
+                        return;
+                    }
+
+                    fs.closeSync(this.fd);
+                },
+            });
+        } catch {
+            // ignore
+        }
+    }
+
+    private log(level: vscode.LogLevel, scope: string, logToOutputChannel: boolean, args: any[]): void {
         const msg = args.reduce((p, c, i) => {
             if (typeof c === "object") {
                 try {
@@ -90,39 +120,38 @@ export class Logger implements Disposable {
         if (this.fd || this.logToConsole) {
             const logMsg = `${getTimestamp()} ${scope}: ${msg}`;
             this.fd && fs.appendFileSync(this.fd, logMsg + "\n");
-            this.logToConsole && console[level == LogLevel.error ? "error" : "log"](logMsg);
+            this.logToConsole && console[level == vscode.LogLevel.Error ? "error" : "log"](logMsg);
         }
 
         // Half-baked attempt to avoid infinite loop.
         // Preferred approach is for modules to decide this via `createLogger(…, logToOutputChannel=…)`.
         const activeDoc = window.activeTextEditor?.document; // "output:asvetliakov.vscode-neovim.vscode-neovim"
         const outputFocused = activeDoc?.uri.scheme === "output" || activeDoc?.fileName?.startsWith("output:");
-
         if (logToOutputChannel && this.outputChannel && activeDoc && !outputFocused) {
             const fullMsg = `${scope}: ${msg}`;
             switch (level) {
-                case LogLevel.error:
+                case vscode.LogLevel.Error:
                     this.outputChannel.error(fullMsg);
                     break;
-                case LogLevel.warn:
+                case vscode.LogLevel.Warning:
                     this.outputChannel.warn(fullMsg);
                     break;
-                case LogLevel.info:
-                case LogLevel.debug:
-                    // XXX: `vscode.LogOutputChannel` loglevel is currently readonly:
-                    //      https://github.com/microsoft/vscode/issues/170450
-                    //      https://github.com/PowerShell/vscode-powershell/issues/4441
-                    // So debug() drops messages unless the user has increased vscode's log-level.
-                    // Use info() until vscode adds a way to set the loglevel.
+                case vscode.LogLevel.Info:
                     this.outputChannel.info(fullMsg);
                     break;
-                case LogLevel.none:
-                    // Do nothing. This should never happen because the logger isn't setup for level=none.
+                case vscode.LogLevel.Debug:
+                    this.outputChannel.debug(fullMsg);
+                    break;
+                case vscode.LogLevel.Trace:
+                    this.outputChannel.trace(fullMsg);
+                    break;
+                case vscode.LogLevel.Off:
+                    // Do nothing. This should never happen because the logger isn't setup for level=off.
                     break;
             }
         }
 
-        if (level === LogLevel.error) {
+        if (level === vscode.LogLevel.Error) {
             window.showErrorMessage(msg);
         }
     }
@@ -131,27 +160,32 @@ export class Logger implements Disposable {
         const logger = this.loggers.has(scope)
             ? this.loggers.get(scope)!
             : {
+                  trace: (...args: any[]) => {
+                      if (this.level <= vscode.LogLevel.Trace) {
+                          this.log(vscode.LogLevel.Trace, scope, logToOutputChannel, args);
+                      }
+                  },
                   debug: (...args: any[]) => {
-                      if (this.level >= LogLevel.debug) {
-                          this.log(LogLevel.debug, scope, logToOutputChannel, args);
+                      if (this.level <= vscode.LogLevel.Debug) {
+                          this.log(vscode.LogLevel.Debug, scope, logToOutputChannel, args);
                       }
                   },
                   info: (...args: any[]) => {
-                      if (this.level >= LogLevel.info) {
-                          this.log(LogLevel.info, scope, logToOutputChannel, args);
+                      if (this.level <= vscode.LogLevel.Info) {
+                          this.log(vscode.LogLevel.Info, scope, logToOutputChannel, args);
                       }
                   },
                   warn: (...args: any[]) => {
-                      if (this.level >= LogLevel.warn) {
-                          this.log(LogLevel.warn, scope, logToOutputChannel, args);
+                      if (this.level <= vscode.LogLevel.Warning) {
+                          this.log(vscode.LogLevel.Warning, scope, logToOutputChannel, args);
                       }
                   },
                   error: (...args: any[]) => {
-                      if (this.level >= LogLevel.error) {
-                          this.log(LogLevel.error, scope, logToOutputChannel, args);
+                      if (this.level <= vscode.LogLevel.Error) {
+                          this.log(vscode.LogLevel.Error, scope, logToOutputChannel, args);
                       }
                   },
-                  log(uri: vscode.Uri | undefined, level: LogLevel, ...logArgs: any[]) {
+                  log(uri: vscode.Uri | undefined, level: vscode.LogLevel, ...logArgs: any[]) {
                       const isLogSink =
                           !uri ||
                           uri.scheme === "output" ||
@@ -166,18 +200,23 @@ export class Logger implements Disposable {
                       }
 
                       switch (level) {
-                          case LogLevel.error:
+                          case vscode.LogLevel.Error:
                               logger.error(...logArgs);
                               break;
-                          case LogLevel.warn:
+                          case vscode.LogLevel.Warning:
                               logger.warn(...logArgs);
                               break;
-                          case LogLevel.info:
-                          case LogLevel.debug:
+                          case vscode.LogLevel.Info:
+                              logger.info(...logArgs);
+                              break;
+                          case vscode.LogLevel.Debug:
                               logger.debug(...logArgs);
                               break;
-                          case LogLevel.none:
-                              // Do nothing. This should never happen because the logger isn't setup for level=none.
+                          case vscode.LogLevel.Trace:
+                              logger.trace(...logArgs);
+                              break;
+                          case vscode.LogLevel.Off:
+                              // Do nothing. This should never happen because the logger isn't setup for level=off.
                               break;
                       }
                   },


### PR DESCRIPTION
After my confusion [here](https://github.com/vscode-neovim/vscode-neovim/discussions/1952), I changed the extension logging to use the VSCode setting, rather than our own. This also removes the `logLevel` setting we previously had.

The biggest change here, by far, is the movement from our `LogLevel` to the VSCode `LogLevel` (which unfortunately, reverses the order of the levels! Argh!)