### PR TITLE
fix(incsearch): win cursor not properly revealed

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -111,6 +111,7 @@ export class CursorManager implements Disposable {
                     window.visibleTextEditors.forEach((e) => (e.options.cursorStyle = style));
                 },
             },
+            main.viewportManager.onCursorChanged((grid) => this.gridCursorUpdates.addForceUpdate(grid)),
         );
     }
 


### PR DESCRIPTION
- close #1969

Temporary solution. Need to refactor cursor manager and viewport manager. Merge the logic and redefine the necessity of some custom events, such as visual-changed and window-scroll.

Note: Handling the win_viewport event directly in the cursor manager does not work