### PR TITLE
fix(highlight): forward search / matching in long lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,8 +225,8 @@ HighlightManager listens to the `ext_linegrid` API and renders highlights using 
 ### ViewportManager
 
 ViewportManager is responsible for syncing the viewport (editor window, scroll position) between vscode and nvim. It
-listens to the `win_viewport` event, and supplements it with the custom `window-scroll` event triggered by the
-`WinScrolled` autocommand. It also keeps track of the cursor position more reliably than `grid_cursor_goto`.
+listens to the `win_viewport` event, and supplements it with the custom `viewport-changed` event. It also keeps track of
+the cursor position more reliably than `grid_cursor_goto`.
 
 ### CursorManager
 

--- a/runtime/lua/vscode-neovim.lua
+++ b/runtime/lua/vscode-neovim.lua
@@ -4,11 +4,13 @@ local default_optons = require("vscode-neovim.default-options")
 local cursor = require("vscode-neovim.cursor")
 local highlight = require("vscode-neovim.highlight")
 local sync_options = require("vscode-neovim.sync-options")
+local viewport = require("vscode-neovim.viewport")
 
 default_optons.setup()
 cursor.setup()
 highlight.setup()
 sync_options.setup()
+viewport.setup()
 
 local vscode = {
   -- actions

--- a/runtime/lua/vscode-neovim/viewport.lua
+++ b/runtime/lua/vscode-neovim/viewport.lua
@@ -1,0 +1,59 @@
+local M = {}
+
+local api, fn = vim.api, vim.fn
+
+M.event_group = api.nvim_create_augroup("vscode-neovim.viewport", { clear = true })
+M.viewport_changed_ns = api.nvim_create_namespace("vscode-neovim.viewport.changed")
+
+---@class WinContext
+---@field textoff integer
+---@field topline integer
+---@field botline integer
+---@field width integer
+---@field height integer
+---@field leftcol integer
+----@field winnr integer Don't use this
+---@field winid integer
+
+---@return WinContext
+local function get_win_context()
+  local info = fn.getwininfo(api.nvim_get_current_win())[1]
+  local view = fn.winsaveview()
+  return vim.tbl_extend("force", info, view)
+end
+
+local function setup_viewport_changed()
+  ---@type table<integer, WinContext>
+  local ctx_cache = {}
+
+  api.nvim_set_decoration_provider(M.viewport_changed_ns, {
+    on_win = function()
+      local ctx = get_win_context()
+      local cache = ctx_cache[ctx.winid]
+      if cache and vim.deep_equal(ctx, cache) then
+        return
+      end
+      ctx_cache[ctx.winid] = ctx
+      fn.VSCodeExtensionNotify("viewport-changed", ctx)
+    end,
+  })
+
+  -- cleanup cache
+  api.nvim_create_autocmd({ "WinClosed" }, {
+    group = M.event_group,
+    callback = function()
+      local wins = api.nvim_list_wins()
+      for win in pairs(ctx_cache) do
+        if not vim.tbl_contains(win, wins) then
+          ctx_cache[win] = nil
+        end
+      end
+    end,
+  })
+end
+
+function M.setup()
+  setup_viewport_changed()
+end
+
+return M

--- a/runtime/lua/vscode-neovim/viewport.lua
+++ b/runtime/lua/vscode-neovim/viewport.lua
@@ -56,7 +56,12 @@ local function setup_viewport_changed()
 end
 
 function M.setup()
-  setup_viewport_changed()
+  -- Highlighting needs to wait for the viewport-changed event to complete.
+  -- When the UI attaches, there are numerous highlight events (hl_attr_define, grid_line) to process.
+  --
+  -- Without delaying the setup, the viewport-changed event will cause frequent
+  -- pauses in highlight processing, resulting in screen flickering.
+  vim.defer_fn(setup_viewport_changed, 2000)
 end
 
 return M

--- a/runtime/lua/vscode-neovim/viewport.lua
+++ b/runtime/lua/vscode-neovim/viewport.lua
@@ -45,9 +45,9 @@ local function setup_viewport_changed()
   api.nvim_create_autocmd({ "WinClosed" }, {
     group = M.event_group,
     callback = function()
-      local wins = api.nvim_list_wins()
-      for win in pairs(view_cache) do
-        if not vim.tbl_contains(win, wins) then
+      local wins = vim.tbl_keys(view_cache)
+      for _, win in ipairs(wins) do
+        if not api.nvim_win_is_valid(win) then
           view_cache[win] = nil
         end
       end

--- a/runtime/lua/vscode-neovim/viewport.lua
+++ b/runtime/lua/vscode-neovim/viewport.lua
@@ -61,7 +61,13 @@ function M.setup()
   --
   -- Without delaying the setup, the viewport-changed event will cause frequent
   -- pauses in highlight processing, resulting in screen flickering.
-  vim.defer_fn(setup_viewport_changed, 2000)
+  api.nvim_create_autocmd({ "UIEnter" }, {
+    once = true,
+    callback = function()
+      -- Don't worry about whether it's set too late.
+      vim.defer_fn(setup_viewport_changed, 1000)
+    end,
+  })
 end
 
 return M

--- a/runtime/lua/vscode-neovim/viewport.lua
+++ b/runtime/lua/vscode-neovim/viewport.lua
@@ -5,36 +5,39 @@ local api, fn = vim.api, vim.fn
 M.event_group = api.nvim_create_augroup("vscode-neovim.viewport", { clear = true })
 M.viewport_changed_ns = api.nvim_create_namespace("vscode-neovim.viewport.changed")
 
----@class WinContext
----@field textoff integer
+---@class WinView All positions are 0-based
+---@field lnum integer
+---@field col integer
+---@field coladd integer
+---@field curswant integer
 ---@field topline integer
----@field botline integer
----@field width integer
----@field height integer
+---@field topfill integer
 ---@field leftcol integer
-----@field winnr integer Don't use this
+---@field skipcol integer
 ---@field winid integer
 
----@return WinContext
-local function get_win_context()
-  local info = fn.getwininfo(api.nvim_get_current_win())[1]
+---@return WinView
+local function get_winview()
   local view = fn.winsaveview()
-  return vim.tbl_extend("force", info, view)
+  view.lnum = view.lnum - 1
+  view.topline = view.topline - 1
+  view.winid = api.nvim_get_current_win()
+  return view
 end
 
 local function setup_viewport_changed()
-  ---@type table<integer, WinContext>
-  local ctx_cache = {}
+  ---@type table<integer, WinView>
+  local view_cache = {}
 
   api.nvim_set_decoration_provider(M.viewport_changed_ns, {
     on_win = function()
-      local ctx = get_win_context()
-      local cache = ctx_cache[ctx.winid]
-      if cache and vim.deep_equal(ctx, cache) then
+      local view = get_winview()
+      local cache = view_cache[view.winid]
+      if cache and vim.deep_equal(view, cache) then
         return
       end
-      ctx_cache[ctx.winid] = ctx
-      fn.VSCodeExtensionNotify("viewport-changed", ctx)
+      view_cache[view.winid] = view
+      fn.VSCodeExtensionNotify("viewport-changed", view)
     end,
   })
 
@@ -43,9 +46,9 @@ local function setup_viewport_changed()
     group = M.event_group,
     callback = function()
       local wins = api.nvim_list_wins()
-      for win in pairs(ctx_cache) do
+      for win in pairs(view_cache) do
         if not vim.tbl_contains(win, wins) then
-          ctx_cache[win] = nil
+          view_cache[win] = nil
         end
       end
     end,

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -118,9 +118,9 @@ type EventsMapping = {
     ["move-cursor"]: ["top" | "middle" | "bottom"];
     scroll: ["page" | "halfPage", "up" | "down"];
     ["scroll-line"]: ["up" | "down"];
-    ["window-scroll"]: [
-        number,
+    ["viewport-changed"]: [
         {
+            winid: number;
             lnum: number;
             col: number;
             coladd: number;

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -122,11 +122,13 @@ type EventsMapping = {
         {
             // All positions are 0-based
             winid: number;
+            bufnr: number;
             lnum: number;
             col: number;
             coladd: number;
             curswant: number;
             topline: number;
+            botline: number;
             topfill: number;
             leftcol: number;
             skipcol: number;

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -120,6 +120,7 @@ type EventsMapping = {
     ["scroll-line"]: ["up" | "down"];
     ["viewport-changed"]: [
         {
+            // All positions are 0-based
             winid: number;
             lnum: number;
             col: number;

--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -34,8 +34,6 @@ export class HighlightManager implements Disposable {
         // this function returns (and a flush event could begin)
         this.redrawWaitGroup.add();
 
-        await this.main.viewportManager.isSyncDone;
-
         try {
             switch (name) {
                 case "hl_attr_define": {

--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -34,6 +34,8 @@ export class HighlightManager implements Disposable {
         // this function returns (and a flush event could begin)
         this.redrawWaitGroup.add();
 
+        await this.main.viewportManager.isSyncDone;
+
         try {
             switch (name) {
                 case "hl_attr_define": {

--- a/src/test/integ/highlights.test.ts
+++ b/src/test/integ/highlights.test.ts
@@ -1,11 +1,18 @@
 import assert from "assert";
 
 import { NeovimClient } from "neovim";
-import vscode, { DecorationOptions, Position, window } from "vscode";
+import vscode, { DecorationOptions, Position, TextEditor, window } from "vscode";
 
-import { attachTestNvimClient, closeAllActiveEditors, closeNvimClient, wait } from "./integrationUtils";
+import {
+    attachTestNvimClient,
+    closeAllActiveEditors,
+    closeNvimClient,
+    sendEscapeKey,
+    sendNeovimKeys,
+    wait,
+} from "./integrationUtils";
 
-describe("Test ext mark", () => {
+describe("Test highlights", () => {
     let client: NeovimClient;
     let realWindow: typeof vscode.window | undefined;
 
@@ -21,9 +28,14 @@ describe("Test ext mark", () => {
         client = await attachTestNvimClient();
     });
 
+    beforeEach(async () => {
+        await closeAllActiveEditors();
+    });
+
     after(async () => {
         restoreWindow();
         await closeNvimClient(client);
+        await closeAllActiveEditors();
     });
 
     afterEach(() => {
@@ -37,12 +49,9 @@ describe("Test ext mark", () => {
         await wait(500);
         await vscode.window.showTextDocument(doc);
 
-        const stubTextEditor = new TextEditorStub();
         const curEditor = vscode.window.activeTextEditor;
         assert.ok(curEditor != null);
-        stubTextEditor.document = curEditor.document;
-        stubTextEditor.options = curEditor.options;
-        stubTextEditor.viewColumn = curEditor.viewColumn!;
+        const stubTextEditor = new TextEditorStub(curEditor);
         realWindow = vscode.window;
         vscode.window = {
             activeTextEditor: stubTextEditor,
@@ -74,25 +83,83 @@ describe("Test ext mark", () => {
         assert.ok(decoration.renderOptions?.before?.contentText == "j");
         assert.ok(decoration.renderOptions?.before?.color == "#ff0000");
     });
+
+    it("forward search / for long line", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["hello", " ".repeat(3000), "world", " ".repeat(1000)].join(""),
+        });
+        await vscode.window.showTextDocument(doc);
+
+        const curEditor = vscode.window.activeTextEditor;
+        assert.ok(curEditor != null);
+        const stubTextEditor = new TextEditorStub(curEditor);
+        realWindow = vscode.window;
+        vscode.window = {
+            ...realWindow,
+            activeTextEditor: stubTextEditor,
+            visibleTextEditors: [stubTextEditor],
+            createTextEditorDecorationType: window.createTextEditorDecorationType,
+        } as any;
+
+        {
+            await sendEscapeKey();
+            await sendNeovimKeys(client, "/orl");
+            await wait(500);
+            assert(stubTextEditor.decorationOptionsList.length > 0);
+            const decoration = stubTextEditor.decorationOptionsList[0][0] as DecorationOptions;
+            assert.ok(decoration.range.isEqual(new vscode.Range(0, 3006, 0, 3009)));
+        }
+    });
 });
 
 // https://github.com/VSCodeVim/Vim/blob/master/test/historyTracker.test.ts#L181
 // Fake class for testing
 /* eslint-disable */
 class TextEditorStub implements vscode.TextEditor {
-    document!: vscode.TextDocument;
-    selection!: vscode.Selection;
-    selections!: vscode.Selection[];
-    visibleRanges!: vscode.Range[];
-    options!: vscode.TextEditorOptions;
-    viewColumn!: vscode.ViewColumn;
-
     decorationOptionsList: Array<vscode.Range[] | vscode.DecorationOptions[]> = [];
 
-    constructor() {
-        this.selection = new vscode.Selection(0, 0, 0, 0);
-        this.selections = [this.selection];
+    get visibleRanges() {
+        return this.editor.visibleRanges;
     }
+
+    get selection() {
+        return this.editor.selection;
+    }
+
+    set selection(v) {
+        this.editor.selection = v;
+    }
+
+    get selections() {
+        return this.editor.selections;
+    }
+
+    set selections(v) {
+        this.editor.selections = v;
+    }
+
+    get document() {
+        return this.editor.document;
+    }
+
+    get options() {
+        return this.editor.options;
+    }
+
+    set options(v) {
+        this.editor.options = v;
+    }
+
+    get viewColumn() {
+        return this.editor.viewColumn;
+    }
+
+    get revealRange() {
+        return this.editor.revealRange;
+    }
+
+    constructor(private editor: TextEditor) {}
+
     async edit(
         callback: (editBuilder: vscode.TextEditorEdit) => void,
         options?: { undoStopBefore: boolean; undoStopAfter: boolean },
@@ -113,7 +180,6 @@ class TextEditorStub implements vscode.TextEditor {
     ) {
         this.decorationOptionsList.push(rangesOrOptions);
     }
-    revealRange(range: vscode.Range, revealType?: vscode.TextEditorRevealType) {}
     show(column?: vscode.ViewColumn) {}
     hide() {}
 }

--- a/src/test/integ/incsearch.test.ts
+++ b/src/test/integ/incsearch.test.ts
@@ -11,6 +11,7 @@ import {
     openTextDocument,
     sendNeovimKeys,
     sendVSCodeKeys,
+    wait,
 } from "./integrationUtils";
 
 describe("Test incsearch", () => {
@@ -35,7 +36,7 @@ describe("Test incsearch", () => {
     });
 
     it("Cursor is ok for incsearch even if register / is not empty", async function () {
-        this.retries(1);
+        this.retries(0);
         await openTextDocument(path.join(__dirname, "../../../test_fixtures/incsearch-scroll.ts"));
 
         await sendVSCodeKeys("gg");
@@ -44,6 +45,8 @@ describe("Test incsearch", () => {
         await sendNeovimKeys(client, "<cr>");
         await assertContent({ cursor: [115, 16] }, client);
         await sendNeovimKeys(client, "/h2");
+        await client.command("mode");
+        await wait(500);
         await assertContent({ cursor: [170, 21] }, client);
     });
 });

--- a/src/test/integ/incsearch.test.ts
+++ b/src/test/integ/incsearch.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from "assert";
+import path from "path";
+
+import { NeovimClient } from "neovim";
+
+import {
+    assertContent,
+    attachTestNvimClient,
+    closeAllActiveEditors,
+    closeNvimClient,
+    openTextDocument,
+    sendNeovimKeys,
+    sendVSCodeKeys,
+} from "./integrationUtils";
+
+describe("Test incsearch", () => {
+    let client: NeovimClient;
+    before(async () => {
+        client = await attachTestNvimClient();
+    });
+    after(async () => {
+        await closeNvimClient(client);
+        await closeAllActiveEditors();
+    });
+    afterEach(async () => {
+        await closeAllActiveEditors();
+    });
+    it("Cursor is ok for incsearch after scroll", async () => {
+        const e = await openTextDocument(path.join(__dirname, "../../../test_fixtures/incsearch-scroll.ts"));
+
+        await sendVSCodeKeys("gg");
+        await sendVSCodeKeys("/bla");
+        await assertContent({ cursor: [115, 19] }, client);
+        assert.ok(e.visibleRanges[0].start.line <= 115);
+    });
+
+    it("Cursor is ok for incsearch even if register / is not empty", async function () {
+        this.retries(1);
+        await openTextDocument(path.join(__dirname, "../../../test_fixtures/incsearch-scroll.ts"));
+
+        await sendVSCodeKeys("gg");
+        await sendVSCodeKeys("/bla");
+        await assertContent({ cursor: [115, 19] }, client);
+        await sendNeovimKeys(client, "<cr>");
+        await assertContent({ cursor: [115, 16] }, client);
+        await sendNeovimKeys(client, "/h2");
+        await assertContent({ cursor: [170, 21] }, client);
+    });
+});

--- a/src/test/integ/vscode-integration-specific.test.ts
+++ b/src/test/integ/vscode-integration-specific.test.ts
@@ -306,17 +306,6 @@ describe("VSCode integration specific stuff", () => {
         );
     });
 
-    it("Cursor is ok for incsearch after scroll", async () => {
-        const e = await openTextDocument(path.join(__dirname, "../../../test_fixtures/incsearch-scroll.ts"));
-
-        await sendVSCodeKeys("gg");
-        await wait(500);
-        await sendVSCodeKeys("/bla");
-        await wait(500);
-        await assertContent({ cursor: [115, 19] }, client);
-        assert.ok(e.visibleRanges[0].start.line <= 115);
-    });
-
     // !Passes only when the runner is in foreground
     it("Cursor is preserved if same doc is opened in two editor columns", async () => {
         const doc = (

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -53,11 +53,15 @@ export class ViewportManager implements Disposable {
                     return;
                 }
                 const view = this.getViewport(gridId);
+                const { line: oldLine, col: oldCol } = view;
                 view.line = saveView.lnum - 1;
                 view.col = saveView.col;
                 view.topline = saveView.topline;
                 view.leftcol = saveView.leftcol;
                 view.skipcol = saveView.skipcol;
+                if (oldLine !== view.line || oldCol !== view.col) {
+                    this.cursorChanged.fire(gridId);
+                }
             }),
         );
     }

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -46,19 +46,19 @@ export class ViewportManager implements Disposable {
             this.cursorChanged,
             window.onDidChangeTextEditorVisibleRanges(this.onDidChangeVisibleRange),
             eventBus.on("redraw", this.handleRedraw, this),
-            eventBus.on("window-scroll", ([winId, saveView]) => {
-                const gridId = this.main.bufferManager.getGridIdForWinId(winId);
+            eventBus.on("viewport-changed", ([{ winid, leftcol, skipcol, lnum, col, topline }]) => {
+                const gridId = this.main.bufferManager.getGridIdForWinId(winid);
                 if (!gridId) {
-                    logger.warn(`Unable to update scrolled view. No grid for winId: ${winId}`);
+                    logger.warn(`Unable to update scrolled view. No grid for winId: ${winid}`);
                     return;
                 }
                 const view = this.getViewport(gridId);
                 const { line: oldLine, col: oldCol } = view;
-                view.line = saveView.lnum - 1;
-                view.col = saveView.col;
-                view.topline = saveView.topline;
-                view.leftcol = saveView.leftcol;
-                view.skipcol = saveView.skipcol;
+                view.line = lnum - 1;
+                view.col = col;
+                view.topline = topline;
+                view.leftcol = leftcol;
+                view.skipcol = skipcol;
                 if (oldLine !== view.line || oldCol !== view.col) {
                     this.cursorChanged.fire(gridId);
                 }

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -53,6 +53,9 @@ export class ViewportManager implements Disposable {
                     return;
                 }
                 const view = this.getViewport(gridId);
+                view.line = saveView.lnum - 1;
+                view.col = saveView.col;
+                view.topline = saveView.topline;
                 view.leftcol = saveView.leftcol;
                 view.skipcol = saveView.skipcol;
             }),

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -52,15 +52,21 @@ export class ViewportManager implements Disposable {
             this.cursorChanged,
             window.onDidChangeTextEditorVisibleRanges(this.onDidChangeVisibleRange),
             eventBus.on("redraw", this.handleRedraw, this),
-            eventBus.on("viewport-changed", ([ctx]) => this.handleViewportChanged(ctx)),
+            eventBus.on("viewport-changed", ([view]) => this.handleViewportChanged(view)),
         );
     }
 
-    private handleViewportChanged(ctx: EventBusData<"viewport-changed">[0]) {
+    private handleViewportChanged({
+        winid,
+        leftcol,
+        skipcol,
+        lnum,
+        col,
+        topline,
+    }: EventBusData<"viewport-changed">[0]) {
         this.viewportChangedPromise?.resolve();
         this.viewportChangedPromise = new ManualPromise();
 
-        const { winid, leftcol, skipcol, lnum, col, topline } = ctx;
         const gridId = this.main.bufferManager.getGridIdForWinId(winid);
         if (!gridId) {
             logger.warn(`Unable to update scrolled view. No grid for winId: ${winid}`);
@@ -69,7 +75,7 @@ export class ViewportManager implements Disposable {
 
         const view = this.getViewport(gridId);
         const { line: oldLine, col: oldCol } = view;
-        view.line = lnum - 1;
+        view.line = lnum;
         view.col = col;
         view.topline = topline;
         view.leftcol = leftcol;

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -105,7 +105,6 @@ augroup VscodeGeneral
     autocmd InsertEnter * call <SID>onInsertEnter()
     " Trigger filetype detection
     autocmd BufAdd * do BufRead
-    autocmd WinScrolled * call VSCodeExtensionNotify('window-scroll', win_getid(), winsaveview())
     autocmd VimEnter,ModeChanged * call VSCodeExtensionNotify('mode-changed', mode())
     autocmd WinEnter * call VSCodeExtensionNotify('window-changed', win_getid())
     " LazyVim will clear runtimepath by default. To avoid user intervention, we need to set it again.


### PR DESCRIPTION
- fix: cursor position after scrolling with incsearch
- refactor: remove viewport hack when in cmdline mode

---

- Close #1975
- Fix #161
- Related:
	- #1575

Because it involves a few historical matters and dealing with hacks, I won't go into too much detail. Here are some debugging notes.

### Cursor position for incsearch

| Commit History                                         | Nvim 0.9 | Nvim 0.10 |
| ------------------------------------------------------ | -------- | --------- |
| Add test                                               | ❌       | ✅        |
| Remove hack                                            | ❌       | ✅        |
| Update cursor position on window-scroll                | ❌       | ✅        |
| Fire cursor change event on window-scroll              | ❌       | ✅        |
| custom viewport changed event                          | ❌       | ✅        |
| after searching, perform a redraw and wait for a while | ✅       | ✅        |

### Forward search matching in long line

Only tested in Nvim 0.10.

### Conclusion

Highly recommend to upgrade to Nvim 0.10.