### PR TITLE
ci: update homebrew formulae before running tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,11 +16,17 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v4
+
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
                   node-version: "18"
                   cache: "npm"
+
+            - name: Update Homebrew Caches
+              if: matrix.os == 'macos-latest'
+              run: brew update
+
             - name: Install Neovim
               uses: rhysd/action-setup-vim@v1
               id: vim
@@ -30,10 +36,13 @@ jobs:
                   # version: v0.9.0
             - name: npm install
               run: npm ci --silent
+
             - name: Build
               run: npm run test-compile
+
             - name: Webpack
               run: npm run webpack
+
             - name: Test
               uses: coactions/setup-xvfb@v1
               env:


### PR DESCRIPTION
Closes #1980. I must admit, I'm no Homebrew expert (I actually don't have a mac handy), but from my testing (and reading of the [man page](https://docs.brew.sh/Manpage#update-options) this forces Homebrew to update its caches every time the CI runs. The only downside (aside from time) is it also upgrade Homebrew itself, which may not be fully desirable, but unfortunately I don't think there's a way to tell homebrew to only upgrade formulae (i.e. there is no equivalent to `apt-cache update` or some such)