### PR TITLE
fix: set highlight group Subsitute

### DIFF
--- a/package.json
+++ b/package.json
@@ -331,16 +331,16 @@
                     },
                     "default": {
                         "IncSearch": {
-                            "backgroundColor": "theme.editor.findMatchBackground",
-                            "borderColor": "theme.editor.findMatchBorder"
+                            "backgroundColor": "theme.editor.findMatchBackground"
                         },
                         "CurSearch": {
-                            "backgroundColor": "theme.editor.findMatchBackground",
-                            "borderColor": "theme.editor.findMatchBorder"
+                            "backgroundColor": "theme.editor.findMatchBackground"
                         },
                         "Search": {
-                            "backgroundColor": "theme.editor.findMatchHighlightBackground",
-                            "borderColor": "theme.editor.findMatchHighlightBorder"
+                            "backgroundColor": "theme.editor.findMatchHighlightBackground"
+                        },
+                        "Substitute": {
+                            "backgroundColor": "theme.editor.findMatchBackground"
                         }
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -338,9 +338,6 @@
                         },
                         "Search": {
                             "backgroundColor": "theme.editor.findMatchHighlightBackground"
-                        },
-                        "Substitute": {
-                            "backgroundColor": "theme.editor.findMatchBackground"
                         }
                     }
                 },

--- a/runtime/lua/vscode-neovim/highlight.lua
+++ b/runtime/lua/vscode-neovim/highlight.lua
@@ -55,6 +55,11 @@ local function setup_globals()
     Visual       = {},
     VisualNC     = {},
     VisualNOS    = {},
+    -- By default, it's linked to Search.
+    -- But Search highlighting defaults to using VSCode ThemeColor, potentially with some opacity.
+    -- When the decoration is "virtText", having a background color with opacity can
+    -- cause the virtual text to blend with the original content.
+    Substitute   = { fg='#282c34', bg='#98c379' },
     Whitespace   = {},
     LineNr       = {},
     LineNrAbove  = {},

--- a/runtime/lua/vscode-neovim/highlight.lua
+++ b/runtime/lua/vscode-neovim/highlight.lua
@@ -55,7 +55,6 @@ local function setup_globals()
     Visual       = {},
     VisualNC     = {},
     VisualNOS    = {},
-    Substitute   = {},
     Whitespace   = {},
     LineNr       = {},
     LineNrAbove  = {},


### PR DESCRIPTION
chore: remove the border of the custom highlights
      It will be strange when multiple decoration ranges with borders are connected.

- Fix #1979 
