### PR TITLE
refactor: don't hardcode substitute highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -340,7 +340,8 @@
                             "backgroundColor": "theme.editor.findMatchHighlightBackground"
                         },
                         "Substitute": {
-                            "backgroundColor": "theme.editor.findMatchBackground"
+                            "backgroundColor": "theme.editor.foreground",
+                            "color": "theme.editor.background"
                         }
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -338,6 +338,9 @@
                         },
                         "Search": {
                             "backgroundColor": "theme.editor.findMatchHighlightBackground"
+                        },
+                        "Substitute": {
+                            "backgroundColor": "theme.editor.findMatchBackground"
                         }
                     }
                 },

--- a/runtime/lua/vscode-neovim/highlight.lua
+++ b/runtime/lua/vscode-neovim/highlight.lua
@@ -55,11 +55,7 @@ local function setup_globals()
     Visual       = {},
     VisualNC     = {},
     VisualNOS    = {},
-    -- By default, it's linked to Search.
-    -- But Search highlighting defaults to using VSCode ThemeColor, potentially with some opacity.
-    -- When the decoration is "virtText", having a background color with opacity can
-    -- cause the virtual text to blend with the original content.
-    Substitute   = { fg='#282c34', bg='#98c379' },
+    Substitute   = {},
     Whitespace   = {},
     LineNr       = {},
     LineNrAbove  = {},


### PR DESCRIPTION
Edits https://github.com/vscode-neovim/vscode-neovim/pull/1983

* `editor.findMatchBackground`: Color of the current search match.
* `editor.findMatchHighlightBackground`: Color of the other search matches. The color must not be opaque so as not to hide underlying decorations.

I believe most themes will not have transparency for findMatchBackground