### PR TITLE
build: add helper to build dev version of extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,15 @@ npm install
 3. Build the VSIX package:
 
 ```sh
-npx vsce package -o vscode-neovim.vsix
+npm run build
+```
+
+If you are developing the extension, and want to install your changes in your VSCode editor, it may be useful to instead
+run the following, so that VSCode does not cache your custom VSIX as the VSIX corresponding to an existing marketplace
+version:
+
+```sh
+npm run build:dev
 ```
 
 4. From VSCode, use the `Extensions: Install from VSIX` command to install the package.

--- a/package.json
+++ b/package.json
@@ -2125,7 +2125,9 @@
         "webpack": "webpack --mode development",
         "webpack-dev": "webpack --mode development --watch",
         "test-compile": "tsc -p ./",
-        "prepare": "husky"
+        "prepare": "husky",
+        "build": "vsce package -o vscode-neovim.vsix",
+        "build:dev": "vsce package --no-update-package-json -o vscode-neovim.vsix $(node -e 'console.log(`${process.env.npm_package_version}-dev`)')"
     },
     "devDependencies": {
         "@johnnymorganz/stylua-bin": "^0.20.0",


### PR DESCRIPTION
One thing I've noticed when building the extension to try out existing PRs is that it's extremely annoying to downgrade back to the "production" version from the marketplace (you either have to rebuild at the old tag, or clear out some VSCode package caches by hand). I added `npm run build:dev`, which should help ease this experience