### PR TITLE
feat: move output messages to a separate channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ npm run build:dev
 
 You can view the extension logs in one of three locations
 
-1. Via the `vscode-neovim` Output channel
+1. Via the `vscode-neovim (logs)` Output channel
 
     - Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
       [`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ npm run build:dev
 
 You can view the extension logs in one of three locations
 
-1. Via the `vscode-neovim (logs)` Output channel
+1. Via the `vscode-neovim logs` Output channel
 
     - Note: some messages are not logged to the Output channel, to avoid infinite loop. This is decided by the
       [`logToOutputChannel` parameter](https://github.com/vscode-neovim/vscode-neovim/blob/7337ffd5009067d074af5371171f277cb522aa9b/src/logger.ts#L184).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
     }
 
     const logOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (logs)`, { log: true });
-    const userMessageOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (messages)`);
+    const messageOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (messages)`);
     disposables.push(logOutputChannel);
 
     config.init();
@@ -46,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
     try {
         const plugin = new MainController(context);
         context.subscriptions.push(plugin);
-        await plugin.init(userMessageOutputChannel);
+        await plugin.init(messageOutputChannel);
     } catch (e) {
         vscode.window
             .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,11 +27,12 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
         verifyExperimentalAffinity();
     }
 
-    const outputChannel = vscode.window.createOutputChannel(EXT_NAME, { log: true });
-    disposables.push(outputChannel);
+    const logOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (logs)`, { log: true });
+    const userMessageOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (messages)`);
+    disposables.push(logOutputChannel);
 
     config.init();
-    rootLogger.init(outputChannel.logLevel, config.logPath, config.outputToConsole, outputChannel);
+    rootLogger.init(logOutputChannel.logLevel, config.logPath, config.outputToConsole, logOutputChannel);
     eventBus.init();
     actions.init();
     context.subscriptions.push(
@@ -45,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
     try {
         const plugin = new MainController(context);
         context.subscriptions.push(plugin);
-        await plugin.init(outputChannel);
+        await plugin.init(userMessageOutputChannel);
     } catch (e) {
         vscode.window
             .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
 
     const logOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (logs)`, { log: true });
     const messageOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (messages)`);
-    disposables.push(logOutputChannel);
+    disposables.push(logOutputChannel, messageOutputChannel);
 
     config.init();
     rootLogger.init(logOutputChannel.logLevel, config.logPath, config.outputToConsole, logOutputChannel);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,8 +27,8 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
         verifyExperimentalAffinity();
     }
 
-    const logOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (logs)`, { log: true });
-    const messageOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} (messages)`);
+    const logOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} logs`, { log: true });
+    const messageOutputChannel = vscode.window.createOutputChannel(`${EXT_NAME} messages`);
     disposables.push(logOutputChannel, messageOutputChannel);
 
     config.init();

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -63,7 +63,7 @@ export class MainController implements vscode.Disposable {
 
     public constructor(private extContext: ExtensionContext) {}
 
-    public async init(userMessageOutputChannel: vscode.OutputChannel): Promise<void> {
+    public async init(messageOutputChannel: vscode.OutputChannel): Promise<void> {
         const [cmd, args] = this.buildSpawnArgs();
         logger.info(`starting nvim: ${cmd} ${args.join(" ")}`);
         this.nvimProc = spawn(cmd, args);
@@ -134,7 +134,7 @@ export class MainController implements vscode.Disposable {
             (this.changeManager = new DocumentChangeManager(this)),
             (this.commandLineManager = new CommandLineManager(this)),
             (this.statusLineManager = new StatusLineManager(this)),
-            (this.messagesManager = new MessagesManager(userMessageOutputChannel)),
+            (this.messagesManager = new MessagesManager(messageOutputChannel)),
         );
 
         logger.debug(`UIAttach`);

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -63,7 +63,7 @@ export class MainController implements vscode.Disposable {
 
     public constructor(private extContext: ExtensionContext) {}
 
-    public async init(outputChannel: vscode.LogOutputChannel): Promise<void> {
+    public async init(userMessageOutputChannel: vscode.OutputChannel): Promise<void> {
         const [cmd, args] = this.buildSpawnArgs();
         logger.info(`starting nvim: ${cmd} ${args.join(" ")}`);
         this.nvimProc = spawn(cmd, args);
@@ -134,7 +134,7 @@ export class MainController implements vscode.Disposable {
             (this.changeManager = new DocumentChangeManager(this)),
             (this.commandLineManager = new CommandLineManager(this)),
             (this.statusLineManager = new StatusLineManager(this)),
-            (this.messagesManager = new MessagesManager(outputChannel)),
+            (this.messagesManager = new MessagesManager(userMessageOutputChannel)),
         );
 
         logger.debug(`UIAttach`);

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -1,4 +1,4 @@
-import { Disposable, LogOutputChannel } from "vscode";
+import { Disposable, OutputChannel } from "vscode";
 
 import { EventBusData, eventBus } from "./eventBus";
 import { disposeAll } from "./utils";
@@ -6,7 +6,7 @@ import { disposeAll } from "./utils";
 export class MessagesManager implements Disposable {
     private disposables: Disposable[] = [];
 
-    public constructor(readonly channel: LogOutputChannel) {
+    public constructor(readonly channel: OutputChannel) {
         eventBus.on("redraw", this.handleRedraw, this, this.disposables);
     }
 

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -2,6 +2,9 @@ import { Disposable, OutputChannel } from "vscode";
 
 import { EventBusData, eventBus } from "./eventBus";
 import { disposeAll } from "./utils";
+import { createLogger } from "./logger";
+
+const logger = createLogger("MessagesManager");
 
 export class MessagesManager implements Disposable {
     private disposables: Disposable[] = [];
@@ -38,7 +41,8 @@ export class MessagesManager implements Disposable {
                 if (lines.length > 2) {
                     this.channel.show(true);
                 }
-                this.channel.append(str);
+
+                this.writeMessage(str);
                 break;
             }
             case "msg_history_show": {
@@ -54,10 +58,16 @@ export class MessagesManager implements Disposable {
                         }
                     }
                 }
+
                 this.channel.show(true);
-                this.channel.append(str);
+                this.writeMessage(str);
                 break;
             }
         }
+    }
+
+    private writeMessage(msg: string) {
+        logger.info(msg);
+        this.channel.append(msg);
     }
 }


### PR DESCRIPTION
Fixes #1965. 

I added a second channel, `vscode-neovim (messages)`, and renamed the existing one to `vscode-neovim (logs)`. Messages are sent to both locations, which preserves timestamps. While right now the `vscode-neovim (messages)` channel is a bit barebones, I'm hoping to do some tweaks to make it more useful. Stay tuned on that :) 