### PR TITLE
feat: revamp messages output channel

### DIFF
--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -67,7 +67,11 @@ export class MessagesManager implements Disposable {
     }
 
     private writeMessage(msg: string) {
+        if (msg.length === 0) {
+            return;
+        }
+
         logger.info(msg);
-        this.channel.append(msg);
+        this.channel.replace(msg);
     }
 }

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -54,7 +54,11 @@ export class MessagesManager implements Disposable {
                         for (const [commandName, content] of list) {
                             const cmdContent = content.map((c) => c[1]).join("");
 
-                            lines.push(`${commandName}: ${cmdContent}`);
+                            if (commandName.length === 0) {
+                                lines.push(cmdContent);
+                            } else {
+                                lines.push(`${commandName}: ${cmdContent}`);
+                            }
                         }
                     }
                 }

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -76,11 +76,11 @@ export class MessagesManager implements Disposable {
         }
 
         logger.info(msg);
-        const outputMsg = this.endInNewline(msg);
+        const outputMsg = this.ensureEOL(msg);
         this.channel.replace(outputMsg);
     }
 
-    private endInNewline(msg: string): string {
+    private ensureEOL(msg: string): string {
         if (msg.length === 0 || msg[msg.length - 1] === "\n") {
             return msg;
         }

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -20,58 +20,67 @@ export class MessagesManager implements Disposable {
     private handleRedraw({ name, args }: EventBusData<"redraw">): void {
         switch (name) {
             case "msg_show": {
-                let str = "";
+                const lines: string[] = [];
                 for (const [type, content, clear] of args) {
                     if (type === "return_prompt") {
                         continue;
                     }
+
                     if (clear) {
-                        this.channel.clear();
-                        str = "";
+                        // Remove all stored lines, we will clear the output console on the way out.
+                        lines.splice(0, lines.length);
                     }
-                    let contentStr = "";
-                    for (const c of content) {
-                        contentStr += c[1];
+
+                    const segments = content.map((c) => c[1]);
+                    if (segments.length > 0) {
+                        segments[0] = segments[0].replace(/^\n+/, "");
                     }
-                    // sometimes neovim sends linebreaks, sometimes not ¯\_(ツ)_/¯
-                    str += (contentStr[0] === "\n" ? "" : "\n") + contentStr;
+
+                    lines.push(...segments);
                 }
-                // remove empty last line (since we always put \n at the end)
-                const lines = str.split("\n").slice(1);
-                if (lines.length > 2) {
+
+                if (lines.length >= 2) {
                     this.channel.show(true);
                 }
 
-                this.writeMessage(str);
+                this.writeMessage(lines.join("\n"));
                 break;
             }
+
             case "msg_history_show": {
-                let str = "\n";
+                const lines = [];
                 for (const arg of args) {
                     for (const list of arg) {
                         for (const [commandName, content] of list) {
-                            let cmdContent = "";
-                            for (const c of content) {
-                                cmdContent += c[1];
-                            }
-                            str += `${commandName}: ${cmdContent}\n`;
+                            const cmdContent = content.map((c) => c[1]).join("");
+
+                            lines.push(`${commandName}: ${cmdContent}`);
                         }
                     }
                 }
 
                 this.channel.show(true);
-                this.writeMessage(str);
+                this.writeMessage(lines.join("\n"));
                 break;
             }
         }
     }
 
-    private writeMessage(msg: string) {
+    private writeMessage(msg: string): void {
         if (msg.length === 0) {
             return;
         }
 
         logger.info(msg);
-        this.channel.replace(msg);
+        const outputMsg = this.endInNewline(msg);
+        this.channel.replace(outputMsg);
+    }
+
+    private endInNewline(msg: string): string {
+        if (msg.length === 0 || msg[msg.length - 1] === "\n") {
+            return msg;
+        }
+
+        return msg + "\n";
     }
 }


### PR DESCRIPTION
This PR builds on #2022 ~(sorry for the redundant commits... couldn't find a good way to stack the PRs).~

The idea here is that the output channel can be used to emulate the bottom split window in nvim after calling `messages`, or a statusline. 


A video's worth a thousand words: 

https://github.com/vscode-neovim/vscode-neovim/assets/977151/de2b7376-1de5-4dc6-b8c5-c3416b3e6756

A few notes on what you're watching here

1. If the output panel is open, a `msg_show` will be the only thing shown
2. If the output panel is closed, single-line output will not open the panel
3. multi-line output or command history will show the output panel 

Of course, you can still view historical outputs in the logs channel.
![image](https://github.com/vscode-neovim/vscode-neovim/assets/977151/0c2635d4-37f1-454b-b30e-82016c3d6bbc)
