### PR TITLE
chore: remove redundant error message on disconnect

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -160,7 +160,6 @@ export class MainController implements vscode.Disposable {
     }
 
     private _stop(msg: string) {
-        logger.error(msg);
         vscode.commands.executeCommand("vscode-neovim.stop");
         vscode.window.showErrorMessage(msg, "Restart").then((value) => {
             if (value == "Restart") vscode.commands.executeCommand("vscode-neovim.restart");


### PR DESCRIPTION
logger.error also generates error messages, which seems a bit redundant (previously, this confused me as to why there were two error messages). Moreover, this logging is not useful in the logs.