### PR TITLE
refactor: remove Altercmd for "write"

### DIFF
--- a/runtime/vscode/overrides/vscode-file-commands.vim
+++ b/runtime/vscode/overrides/vscode-file-commands.vim
@@ -1,3 +1,12 @@
+function! s:write()
+    if v:cmdbang
+        call VSCodeNotify('workbench.action.files.saveAs')
+    else
+        call VSCodeNotify('workbench.action.files.save')
+    endif
+
+    set nomod
+endfunction
 
 function! s:editOrNew(...)
     let file = a:1
@@ -31,7 +40,6 @@ command! -bang -nargs=? Ex call <SID>editOrNew(<q-args>, <q-bang>)
 command! -bang Enew call <SID>editOrNew('__vscode_new__', <q-bang>)
 command! -bang Find call VSCodeNotify('workbench.action.quickOpen')
 
-command! -complete=file -bang -nargs=? Write if <q-bang> ==# '!' | call VSCodeNotify('workbench.action.files.saveAs') | else | call VSCodeNotify('workbench.action.files.save') | endif
 command! -bang Saveas call VSCodeNotify('workbench.action.files.saveAs')
 
 command! -bang Wall call VSCodeNotify('workbench.action.files.saveAll')
@@ -45,12 +53,14 @@ command! -bang Qall call VSCodeNotify('workbench.action.closeAllEditors')
 command! -bang Wqall call <SID>saveAllAndClose()
 command! -bang Xall call <SID>saveAllAndClose()
 
+augroup vscode.file-commands
+    autocmd BufWriteCmd * call s:write()
+augroup END
+
 AlterCommand e[dit] Edit
 AlterCommand ex Ex
 AlterCommand ene[w] Enew
 AlterCommand fin[d] Find
-AlterCommand w[rite] Write
-AlterCommand sav[eas] Saveas
 AlterCommand wa[ll] Wall
 AlterCommand q[uit] Quit
 AlterCommand wq Wq

--- a/runtime/vscode/overrides/vscode-file-commands.vim
+++ b/runtime/vscode/overrides/vscode-file-commands.vim
@@ -61,6 +61,7 @@ AlterCommand e[dit] Edit
 AlterCommand ex Ex
 AlterCommand ene[w] Enew
 AlterCommand fin[d] Find
+AlterCommand sav[eas] Saveas
 AlterCommand wa[ll] Wall
 AlterCommand q[uit] Quit
 AlterCommand wq Wq

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -614,8 +614,8 @@ export class BufferManager implements Disposable {
             vim.api.nvim_buf_set_var(bufId, "vscode_uri_data", docUriJson)
             vim.api.nvim_buf_set_name(bufId, bufname)
             vim.api.nvim_buf_set_option(bufId, "modifiable", not isExternalDoc)
-            -- force nofile, just in case if the buffer was created externally
-            vim.api.nvim_buf_set_option(bufId, "buftype", "nofile")
+            -- force acwrite, which is similar to nofile, but will only be written via the BufWriteCmd autocommand.
+            vim.api.nvim_buf_set_option(bufId, "buftype", "acwrite")
             vim.api.nvim_buf_set_option(bufId, "buflisted", true)
         `,
             [


### PR DESCRIPTION
~~This is definitely _not_ fully tested, but is something I was playing around with~~ I wanted to throw out this there to see if there was any something I hadn't considered here :) It's a pretty fundamental change, so I'd love eyes from those who know more than me :D

Should also address #521. I was able to run `w !wc -c` on an unsaved buffer and get the output, without kicking up a save dialog

I've been running this for a bit with no major issues, but would love some soak testing help