### PR TITLE
feat: show output when return_prompt is sent

### DIFF
--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -23,6 +23,7 @@ export class MessagesManager implements Disposable {
                 const lines: string[] = [];
                 for (const [type, content, clear] of args) {
                     if (type === "return_prompt") {
+                        this.channel.show(true);
                         continue;
                     }
 


### PR DESCRIPTION
Just a small QoL change in face of #2024. If nvim is sending us a `return_prompt` event, the output we have is probably meaningful enough to show to a user, so we should pop out the output channel. This is useful for things like `!`, which might only have one line of output (and thus wouldn't normally display)