### PR TITLE
fix(cmdline): support nested cmdline

### DIFF
--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -103,6 +103,9 @@ export class CommandLineManager implements Disposable {
             }
             case "cmdline_hide": {
                 logger.debug(`cmdline_hide`);
+                // in the case of rapid cmdline_hide and cmdline_show, we want to rush the behavior of onHide
+                this.input.value = "";
+                this.state.redrawExpected = true;
                 if (this.state.isDisplayed) {
                     this.state.ignoreHideEvent = true;
                     this.input.hide();
@@ -115,13 +118,13 @@ export class CommandLineManager implements Disposable {
 
     private cmdlineShow = (content: string, firstc: string, prompt: string): void => {
         this.input.title = prompt || this.getTitle(firstc);
+        this.input.show();
+        this.state.isDisplayed = true;
         // only redraw if triggered from a known keybinding. Otherwise, delayed nvim cmdline_show could replace fast typing.
         if (!this.state.redrawExpected) {
             logger.debug(`cmdline_show: ignoring cmdline_show because no redraw expected: "${content}"`);
             return;
         }
-        this.input.show();
-        this.state.isDisplayed = true;
         this.state.redrawExpected = false;
         if (this.input.value !== content) {
             logger.debug(`cmdline_show: setting input value: "${content}"`);
@@ -163,8 +166,9 @@ export class CommandLineManager implements Disposable {
         if (!this.state.ignoreHideEvent) {
             logger.debug("onHide, entering <ESC>");
             await this.main.client.input("<Esc>");
+            this.reset();
         }
-        this.reset();
+        this.state.ignoreHideEvent = false;
     };
 
     private onSelection = async (e: readonly QuickPickItem[]): Promise<void> => {

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -114,7 +114,6 @@ export class CommandLineManager implements Disposable {
     }
 
     private cmdlineShow = (content: string, firstc: string, prompt: string): void => {
-        this.state.lastTypedText = content;
         this.input.title = prompt || this.getTitle(firstc);
         if (!this.state.isDisplayed) {
             this.input.show();
@@ -127,7 +126,9 @@ export class CommandLineManager implements Disposable {
         }
         this.state.redrawExpected = false;
         if (this.input.value !== content) {
+            logger.debug(`cmdline_show: setting input value: "${content}"`);
             this.state.pendingNvimUpdates++;
+            this.state.lastTypedText = content;
             const activeItems = this.input.activeItems; // backup selections
             this.input.value = content; // update content
             this.input.activeItems = activeItems; // restore selections
@@ -150,9 +151,7 @@ export class CommandLineManager implements Disposable {
     private onChange = async (text: string): Promise<void> => {
         if (this.state.pendingNvimUpdates) {
             this.state.pendingNvimUpdates = Math.max(0, this.state.pendingNvimUpdates - 1);
-            logger.debug(
-                `onChange: skip updating cmdline because change originates from nvim: "${this.state.lastTypedText}"`,
-            );
+            logger.debug(`onChange: skip updating cmdline because change originates from nvim: "${text}"`);
             return;
         }
         const toType = calculateInputAfterTextChange(this.state.lastTypedText, text);

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -162,13 +162,14 @@ export class CommandLineManager implements Disposable {
     };
 
     private onHide = async (): Promise<void> => {
-        logger.debug("onHide, resetting cmdline");
-        if (!this.state.ignoreHideEvent) {
-            logger.debug("onHide, entering <ESC>");
+        if (this.state.ignoreHideEvent) {
+            logger.debug("onHide: skipping event");
+            this.state.ignoreHideEvent = false;
+        } else {
+            logger.debug("onHide: entering <ESC> and resetting cmdline");
             await this.main.client.input("<Esc>");
             this.reset();
         }
-        this.state.ignoreHideEvent = false;
     };
 
     private onSelection = async (e: readonly QuickPickItem[]): Promise<void> => {

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -115,15 +115,13 @@ export class CommandLineManager implements Disposable {
 
     private cmdlineShow = (content: string, firstc: string, prompt: string): void => {
         this.input.title = prompt || this.getTitle(firstc);
-        if (!this.state.isDisplayed) {
-            this.input.show();
-        }
-        this.state.isDisplayed = true;
         // only redraw if triggered from a known keybinding. Otherwise, delayed nvim cmdline_show could replace fast typing.
         if (!this.state.redrawExpected) {
             logger.debug(`cmdline_show: ignoring cmdline_show because no redraw expected: "${content}"`);
             return;
         }
+        this.input.show();
+        this.state.isDisplayed = true;
         this.state.redrawExpected = false;
         if (this.input.value !== content) {
             logger.debug(`cmdline_show: setting input value: "${content}"`);


### PR DESCRIPTION
Fix https://github.com/vscode-neovim/vscode-neovim/issues/2028

`ignoreHideEvent` wasn't actually having any effect. But, when it did, it would cause issues with opening and closing the cmdline, because `cmdline_hide` would trigger after the cmdline is already hidden, setting `ignoreHideEvent` to true, and then not properly exiting the next cmdline.

This adds another state variable to make sure we know exactly when `onHide` will actually trigger (so we can be guaranteed that it clears the flag). 

Finally, the macro issue in #2028 might only be solvable with a timer (like in the old impl).  