### PR TITLE
fix: account for level when handling cmdline_hide events

### DIFF
--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -122,7 +122,6 @@ export class CommandLineManager implements Disposable {
         }
 
         this.state.level = level;
-        this.state.lastTypedText = content;
         this.input.title = prompt || this.getTitle(firstc);
         // only redraw if triggered from a known keybinding. Otherwise, delayed nvim cmdline_show could replace fast typing.
         if (!this.state.redrawExpected) {
@@ -132,6 +131,7 @@ export class CommandLineManager implements Disposable {
         this.state.redrawExpected = false;
         this.showInput();
         if (this.input.value !== content) {
+            this.state.lastTypedText = content;
             this.state.pendingNvimUpdates++;
             const activeItems = this.input.activeItems; // backup selections
             this.input.value = content; // update content

--- a/src/test/integ/command-line.test.ts
+++ b/src/test/integ/command-line.test.ts
@@ -9,6 +9,7 @@ import {
     closeAllActiveEditors,
     closeNvimClient,
     openTextDocument,
+    assertContent,
 } from "./integrationUtils";
 
 describe("Command line", () => {
@@ -133,5 +134,22 @@ describe("Command line", () => {
         // await sendVSCodeCommand("vscode-neovim.test-cmdline", "/abc/g");
         // await sendVSCodeCommand("vscode-neovim.commit-cmdline");
         // assert.equal(await client.commandOutput("echo getreg('/')"), "xyz");
+    });
+
+    it("Supports multiple levels of the command line", async () => {
+        await openTextDocument({ content: "" });
+        await sendVSCodeKeys(":");
+        await sendVSCodeCommand("vscode-neovim.test-cmdline", "normal i");
+        await sendVSCodeCommand("vscode-neovim.send-cmdline", "<C-r>=");
+        await sendVSCodeCommand("vscode-neovim.test-cmdline", "'hello, ' . 'world!'");
+        // Commit both levels of the cmdline
+        await sendVSCodeCommand("vscode-neovim.commit-cmdline");
+        await sendVSCodeCommand("vscode-neovim.commit-cmdline");
+        await assertContent(
+            {
+                content: ["hello, world!"],
+            },
+            client,
+        );
     });
 });


### PR DESCRIPTION
Replaces #2030 
Fixes #2028

When we get cmdline_show events, we're informed of how "deep" our commandline is. Using this is a little more robust than trying to toy our way around what events to ignore. As a result, handling nested command lines is much easier :)

Also, I guess my branch name is wrong, but oh well :)