### PR TITLE
fix: don't show output panel after return_prompt, reverts #2029

### DIFF
--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -26,7 +26,11 @@ export class MessagesManager implements Disposable {
                 const lines: string[] = [];
                 for (const [type, content, clear] of args) {
                     if (type === "return_prompt") {
-                        this.channel.show(true);
+                        // Ignore return_prompt
+                        //
+                        // A note to future readers: return_prompt is sent much more often with ui_messages. It may
+                        // not do what you expect from what :help ui says, so be careful about using these events.
+                        // See: https://github.com/vscode-neovim/vscode-neovim/issues/2046#issuecomment-2144175058
                         continue;
                     }
 


### PR DESCRIPTION
Closes #2046 