### PR TITLE
fix: Fix setting the cwd in remote development

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -170,8 +170,7 @@ export class MainController implements vscode.Disposable {
     private getcwd(): string {
         let cwd = process.cwd();
 
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        const expectedCwd = workspaceFolders?.length ? workspaceFolders[0].uri.fsPath : undefined;
+        const expectedCwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (!expectedCwd) return cwd;
 
         // Remote Development


### PR DESCRIPTION
fixes #2058

**Problem**: We missed the situation where vscode-neovim runs on the remote extension host in remote development.

**Solution**: Set it.