### PR TITLE
style: require eqeqeq in most contexts

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -31,6 +31,7 @@ module.exports = tseslint.config(
             // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
             // e.g. "@typescript-eslint/explicit-function-return-type": "off",
             quotes: ["error", "double", { avoidEscape: true, allowTemplateLiterals: false }],
+            eqeqeq: ["error", "smart"],
             "no-unused-vars": [
                 "error",
                 {

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -146,7 +146,7 @@ export class BufferManager implements Disposable {
             ) => {
                 const [doc] = [...this.textDocumentToBufferId.entries()].find(([_, id]) => id === bufId) || [];
                 if (!doc) return;
-                const editor = window.visibleTextEditors.find((e) => e.document == doc);
+                const editor = window.visibleTextEditors.find((e) => e.document === doc);
                 if (!editor) return;
                 const { tabSize, insertSpaces, lineNumbers: numbers } = options;
                 const lineNumbers =

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ import {
 import { CTRL_KEYS, EXT_ID, EXT_NAME } from "./constants";
 import { VSCodeContext, disposeAll } from "./utils";
 
-const isWindows = process.platform == "win32";
+const isWindows = process.platform === "win32";
 
 type SettingPrefix = "neovimExecutablePaths" | "neovimInitVimPaths"; //this needs to be aligned with setting names in package.json
 

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -174,7 +174,7 @@ export class CursorManager implements Disposable {
             return;
         }
         let style: TextEditorCursorStyle;
-        if (modeName == "visual") {
+        if (modeName === "visual") {
             // in visual mode, we try to hide the cursor because we only use it for selections
             style = TextEditorCursorStyle.LineThin;
         } else if (modeConf.cursorShape === "block") {
@@ -363,11 +363,11 @@ export class CursorManager implements Disposable {
 
             if (selection.isEmpty) {
                 // exit visual mode when clicking elsewhere
-                if (this.main.modeManager.isVisualMode && kind == TextEditorSelectionChangeKind.Mouse)
+                if (this.main.modeManager.isVisualMode && kind === TextEditorSelectionChangeKind.Mouse)
                     await this.client.input("<Esc>");
                 await this.updateNeovimCursorPosition(editor, selection.active);
             } else {
-                if (kind != TextEditorSelectionChangeKind.Mouse || !config.disableMouseSelection)
+                if (kind !== TextEditorSelectionChangeKind.Mouse || !config.disableMouseSelection)
                     await this.updateNeovimVisualSelection(editor, selection);
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
         vscode.window
             .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart")
             .then((value) => {
-                if (value == "Restart") {
+                if (value === "Restart") {
                     vscode.commands.executeCommand("vscode-neovim.restart");
                 }
             });
@@ -101,7 +101,7 @@ function verifyExperimentalAffinity(): void {
             "Cancel",
         )
         .then((value) => {
-            if (value == "Yes") {
+            if (value === "Yes") {
                 setAffinity(defaultAffinity);
                 vscode.window
                     .showInformationMessage(
@@ -109,7 +109,7 @@ function verifyExperimentalAffinity(): void {
                         "Restart",
                     )
                     .then((value) => {
-                        if (value == "Restart") {
+                        if (value === "Restart") {
                             vscode.commands.executeCommand("workbench.action.restartExtensionHost");
                         }
                     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -116,7 +116,7 @@ export class Logger implements Disposable {
         if (this.fd || this.logToConsole) {
             const logMsg = `${getTimestamp()} ${scope}: ${msg}`;
             this.fd && fs.appendFileSync(this.fd, logMsg + "\n");
-            this.logToConsole && console[level == vscode.LogLevel.Error ? "error" : "log"](logMsg);
+            this.logToConsole && console[level === vscode.LogLevel.Error ? "error" : "log"](logMsg);
         }
 
         // Half-baked attempt to avoid infinite loop.

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -163,7 +163,7 @@ export class MainController implements vscode.Disposable {
     private _stop(msg: string) {
         vscode.commands.executeCommand("vscode-neovim.stop");
         vscode.window.showErrorMessage(msg, "Restart").then((value) => {
-            if (value == "Restart") vscode.commands.executeCommand("vscode-neovim.restart");
+            if (value === "Restart") vscode.commands.executeCommand("vscode-neovim.restart");
         });
     }
 
@@ -264,7 +264,7 @@ export class MainController implements vscode.Disposable {
             const range = options.range;
             let targetRange: Range;
             if (Array.isArray(range)) {
-                if (range.length == 2) {
+                if (range.length === 2) {
                     const startLine = Math.max(0, range[0]);
                     const endLine = Math.min(editor.document.lineCount - 1, range[1]);
                     targetRange = new Range(doc.lineAt(startLine).range.start, doc.lineAt(endLine).range.end);

--- a/src/test/integ/actions.test.ts
+++ b/src/test/integ/actions.test.ts
@@ -28,7 +28,7 @@ function pathsEqual(a: string, b: string) {
     if (process.platform === "win32") {
         return a.toLowerCase() === b.toLowerCase();
     } else {
-        return a == b;
+        return a === b;
     }
 }
 

--- a/src/test/integ/highlights.test.ts
+++ b/src/test/integ/highlights.test.ts
@@ -80,8 +80,8 @@ describe("Test highlights", () => {
         const decoration = stubTextEditor.decorationOptionsList[0][0] as DecorationOptions;
 
         assert.ok(decoration.renderOptions); // it should have overlay decoration
-        assert.ok(decoration.renderOptions?.before?.contentText == "j");
-        assert.ok(decoration.renderOptions?.before?.color == "#ff0000");
+        assert.ok(decoration.renderOptions?.before?.contentText === "j");
+        assert.ok(decoration.renderOptions?.before?.color === "#ff0000");
     });
 
     it("forward search / for long line", async () => {

--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -180,7 +180,7 @@ export class ViewportManager implements Disposable {
             return;
         }
         const ranges = editor.visibleRanges;
-        if (!ranges || ranges.length == 0 || ranges[0].end.line - ranges[0].start.line <= 1) {
+        if (!ranges || ranges.length === 0 || ranges[0].end.line - ranges[0].start.line <= 1) {
             return;
         }
         const startLine = ranges[0].start.line - config.neovimViewportHeightExtend;
@@ -193,7 +193,7 @@ export class ViewportManager implements Disposable {
             return;
         }
         const viewport = this.gridViewport.get(gridId);
-        if (viewport && startLine != viewport?.topline && currentLine == viewport?.line) {
+        if (viewport && startLine !== viewport?.topline && currentLine === viewport?.line) {
             actions.lua("scroll_viewport", Math.max(startLine, 0), endLine);
         }
     }


### PR DESCRIPTION
I chose to use the [`smart`](https://eslint.org/docs/latest/rules/eqeqeq#smart) value of the `eqeqeq` rule, as there are some contexts (e.g. `!= null`) where it is desirable to use `eqeq`.

I took a look at these usages, and I don't believe any of them have caused any bugs as-is, but we may as well try to prevent bugs by enforcing this rule.