### PR TITLE
refactor(prototype): integrate BufWriteCmd for basic writing

### DIFF
--- a/runtime/lua/vscode.lua
+++ b/runtime/lua/vscode.lua
@@ -6,6 +6,7 @@ local sync_options = require("vscode.sync-options")
 local cursor = require("vscode.cursor")
 local highlight = require("vscode.highlight")
 local viewport = require("vscode.viewport")
+local files = require("vscode.files")
 
 default_optons.setup()
 force_options.setup()
@@ -13,6 +14,7 @@ sync_options.setup()
 cursor.setup()
 highlight.setup()
 viewport.setup()
+files.setup()
 
 local vscode = {
   -- actions

--- a/runtime/lua/vscode/files.lua
+++ b/runtime/lua/vscode/files.lua
@@ -1,0 +1,23 @@
+local api = vim.api
+local vscode = require("vscode.api")
+
+local M = {}
+
+function collect_file_info(event)
+  return {
+    buf = event.buf,
+    path = event.file,
+  }
+end
+
+function M.setup()
+  api.nvim_create_autocmd({ "BufWriteCmd" }, {
+    pattern = "*",
+    callback = function(event)
+      local info = collect_file_info(event)
+      vscode.action("save_buf", { args = { info.buf, info.path } })
+    end,
+  })
+end
+
+return M

--- a/runtime/lua/vscode/internal.lua
+++ b/runtime/lua/vscode/internal.lua
@@ -280,4 +280,10 @@ function M.wslpath(path)
   return vim.trim(ret)
 end
 
+-- Get the current Neovim CWD
+-- @return string
+function M.cwd()
+  return fn.getcwd()
+end
+
 return M

--- a/runtime/vscode/overrides/vscode-file-commands.vim
+++ b/runtime/vscode/overrides/vscode-file-commands.vim
@@ -49,10 +49,11 @@ AlterCommand e[dit] Edit
 AlterCommand ex Ex
 AlterCommand ene[w] Enew
 AlterCommand fin[d] Find
-AlterCommand w[rite] Write
 AlterCommand sav[eas] Saveas
 AlterCommand wa[ll] Wall
 AlterCommand q[uit] Quit
+" TODO: Wq/Wqall need to be handled with the autocmd
+" Just putting "write" in saveAndClose doesn't work, because the writecmd is asynchronous
 AlterCommand wq Wq
 AlterCommand x[it] Xit
 AlterCommand qa[ll] Qall

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -137,6 +137,7 @@ type EventsMapping = {
     ];
     ["visual-changed"]: [number];
     ["statusline"]: [string];
+    ["save-buf"]: [number, string?];
 };
 
 export interface Event<T extends keyof EventsMapping = keyof EventsMapping> {


### PR DESCRIPTION
This is a bit of a prototype. I may make some minor changes but the goal of this PR is to be a first pass (based on [this discussion](https://github.com/vscode-neovim/vscode-neovim/issues/1260#issuecomment-2148351054) that handles the most basic `:w` cases (and also solves #521), which will have value when merged as-is.

I left some comments below about things I'm thinking about, but this is the bulk of the changes.


