### PR TITLE
fix: do not reset cmdline state unless we are going to show a dialog

### DIFF
--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -116,13 +116,18 @@ export class CommandLineManager implements Disposable {
 
         this.state.redrawExpected = false;
         const title = prompt || this.getTitle(firstc);
+        const initialInputValue = this.input.value;
         const visibilityChanged = this.showInput(level, title, content);
 
         // We only need to proceed if text has been entered. In both of these cases, they haven't.
         //
-        // 1. The dialog box is being shown for the first time, and there is no content. No one has typed anything!
+        // 1. The dialog box is being shown for the first time, and the content is the same as it was before we set
+        //    the initial value. This is basically trying to get ahead of an onChange event.
         // 2. The dialog box was already visible, but the content is identical. No one has typed anything!
-        if ((visibilityChanged && content === "") || (!visibilityChanged && this.input.value === content)) {
+        if (
+            (visibilityChanged && initialInputValue === content) ||
+            (!visibilityChanged && this.input.value === content)
+        ) {
             logger.debug("dropping cmdline_show as the content is unchanged");
             return;
         }

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -128,6 +128,12 @@ export class CommandLineManager implements Disposable {
             (visibilityChanged && initialInputValue === content) ||
             (!visibilityChanged && this.input.value === content)
         ) {
+            // A change event will be fired for the new content in this box, given we have to show the box
+            // before we set the value
+            if (visibilityChanged && content.length > 0) {
+                this.state.pendingNvimUpdates++;
+            }
+
             logger.debug("dropping cmdline_show as the content is unchanged");
             return;
         }
@@ -254,13 +260,16 @@ export class CommandLineManager implements Disposable {
             this.state = new CmdlineState();
             this.input.items = [];
             this.input.activeItems = [];
+            // Show MUST be called before we set the value, hence this branching
+            this.input.show();
             this.input.value = initialValue;
             visibilityChanged = true;
+        } else {
+            this.input.show();
         }
 
         this.state.level = level;
         this.input.title = title;
-        this.input.show();
 
         return visibilityChanged;
     }

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -114,6 +114,7 @@ export class CommandLineManager implements Disposable {
             return;
         }
 
+        this.state.redrawExpected = false;
         const title = prompt || this.getTitle(firstc);
         const visibilityChanged = this.showInput(level, title, content);
 

--- a/src/test/integ/command-line.test.ts
+++ b/src/test/integ/command-line.test.ts
@@ -170,8 +170,23 @@ describe("Command line", () => {
         );
     });
 
+    it("Showing the command line again very quickly should not auto-hide it", async () => {
+        await openTextDocument({ content: "some text" });
+
+        // We do this with sendNeovimKeys so everything is done quickly
+        // A bad implementation will close the command line too early before the commit-cmdline takes effect
+        await sendNeovimKeys(client, String.raw`:call feedkeys(":call setline(1, 'hello, world')")<CR>`);
+        await sendVSCodeCommand("vscode-neovim.commit-cmdline");
+        await assertContent(
+            {
+                content: ["hello, world"],
+            },
+            client,
+        );
+    });
+
     it("Should allow finishing a command that was set up via neovim inputs", async () => {
-        await openTextDocument({ content: "a" });
+        await openTextDocument({ content: "some text" });
 
         // Set up the command. This could be done by something like a plugin or a mapped key
         await sendNeovimKeys(client, String.raw`:call setline(1, 'hello, world'`);
@@ -187,7 +202,7 @@ describe("Command line", () => {
     });
 
     it("Should allow finishing a command that was set up via neovim inputs, even if it was aborted", async () => {
-        await openTextDocument({ content: "a" });
+        await openTextDocument({ content: "some text" });
         // Set up the command. This could be done by something like a plugin or a mapped key
         // Put in the command and press esc, so that it's the "last" command, even though we abort
         await sendNeovimKeys(client, String.raw`:call setline(1, 'hello, world'`);

--- a/src/test/integ/command-line.test.ts
+++ b/src/test/integ/command-line.test.ts
@@ -170,7 +170,7 @@ describe("Command line", () => {
         );
     });
 
-    it("Showing the command line again very quickly should not auto-hide it", async () => {
+    it("Should not hide the input for an incomplete command if nvim sends two :s very quickly", async () => {
         await openTextDocument({ content: "some text" });
 
         // We do this with sendNeovimKeys so everything is done quickly


### PR DESCRIPTION
Fixes #2079 

This one is a bit of a doozy. When using the sandwich plugin and running `sd"` on `master`, these are the logs from the CmdLine logger

```
[~/Documents/code/vscode-neovim] nick@scooty-puff-jr$ tail -f /tmp/vscode-neovim.log |grep CmdLine
2024-06-06T02:18:46.502Z CmdLine: cmdline_hide
2024-06-06T02:18:46.502Z CmdLine: visible level is undefined, hiding
2024-06-06T02:18:46.548Z CmdLine: cmdline_hide
2024-06-06T02:18:46.548Z CmdLine: visible level is undefined, hiding
2024-06-06T02:18:46.753Z CmdLine: cmdline_show: "0,call setpos('.', a:tail)"
2024-06-06T02:18:46.753Z CmdLine: cmdline_show: setting input value: "call setpos('.', a:tail)"
2024-06-06T02:18:46.755Z CmdLine: onChange: skip updating cmdline because change originates from nvim: ""
2024-06-06T02:18:46.755Z CmdLine: cmdline_hide
2024-06-06T02:18:46.755Z CmdLine: visible level is 1, hiding
2024-06-06T02:18:46.755Z CmdLine: cmdline_show: "0,call setpos('.', a:tail)"
2024-06-06T02:18:46.756Z CmdLine: cmdline_show: setting input value: "call setpos('.', a:tail)"
2024-06-06T02:18:46.759Z CmdLine: cmdline_hide
2024-06-06T02:18:46.759Z CmdLine: visible level is 1, hiding
2024-06-06T02:18:46.767Z CmdLine: onChange: skip updating cmdline because change originates from nvim: "call setpos('.', a:tail)"
2024-06-06T02:18:46.771Z CmdLine: onHide: skipping event
2024-06-06T02:18:46.771Z CmdLine: onChange: sending cmdline to nvim: "call setpos('.', a:tail)" + "<C-u>" -> ""
2024-06-06T02:18:46.775Z CmdLine: onChange: sending cmdline to nvim: "" + "<C-u>call setpos('.', a:tail)" -> "call setpos('.', a:tail)"
```

It seems that because the `onChange` events are not executing until after we process our events (which is fine, we have no guarantees there). Then, because the state was reset on every `msg_show`, the `pendingUpdatesFromNvim` count was reset, meaning that any text destined for the commandline was sent to the editor. This would happen even on events we would drop due to their content being unchanged

After the change, this looks something like this

```
2024-06-06T02:43:56.416Z CmdLine: cmdline_hide
2024-06-06T02:43:56.416Z CmdLine: visible level is undefined, hiding
2024-06-06T02:43:56.416Z CmdLine: cmdline_hide
2024-06-06T02:43:56.416Z CmdLine: visible level is undefined, hiding
2024-06-06T02:43:56.622Z CmdLine: cmdline_show: "0,call setpos('.', a:tail)"
2024-06-06T02:43:56.623Z CmdLine: cmdline_show: setting input value: "call setpos('.', a:tail)"
2024-06-06T02:43:56.630Z CmdLine: cmdline_hide
2024-06-06T02:43:56.630Z CmdLine: visible level is 1, hiding
2024-06-06T02:43:56.631Z CmdLine: cmdline_show: "0,call setpos('.', a:tail)"
2024-06-06T02:43:56.631Z CmdLine: dropping cmdline_show as the content is unchanged
2024-06-06T02:43:56.632Z CmdLine: cmdline_hide
2024-06-06T02:43:56.632Z CmdLine: visible level is 1, hiding
2024-06-06T02:43:56.651Z CmdLine: onChange: skip updating cmdline because change originates from nvim: "call setpos('.', a:tail)"
2024-06-06T02:43:56.654Z CmdLine: onHide: skipping event
```

The old code actually called `reset()` when the dialog itself hid, but that is also racy. By resetting right before we show a new dialog, we ensure we have no stale state due to out of order event processing.

~~I'd love to add a test for this, but if I'm honest, I'm not sure how to trigger this bug without this plugin (which seems to be emulating some fast typing). I'll need to think on it~~