### PR TITLE
fix: remove maximum debounce time for normal selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
                 "vscode-neovim.normalSelectionDebounceTime": {
                     "type": "integer",
                     "minimum": 20,
-                    "maximum": 100,
+                    "maximum": 200,
                     "default": 50,
                     "description": "Debounce time used to synchronize selection from VSCode to Nvim, typically referring to cursor movement"
                 },

--- a/package.json
+++ b/package.json
@@ -320,7 +320,6 @@
                 "vscode-neovim.normalSelectionDebounceTime": {
                     "type": "integer",
                     "minimum": 20,
-                    "maximum": 200,
                     "default": 50,
                     "description": "Debounce time used to synchronize selection from VSCode to Nvim, typically referring to cursor movement"
                 },


### PR DESCRIPTION
I found `"vscode-neovim.normalSelectionDebounceTime": 100` is not enough for completely getting rid of https://github.com/vscode-neovim/vscode-neovim/issues/1752.
`200` is the max limit for `vscode-neovim.mouseSelectionDebounceTime` too, might be sufficient.