### PR TITLE
 docs: add configuration compatibility section to README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ mode and editor commands, making the best use of both editors.
 
 -   Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim)
     extension.
--   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.9.0** or greater.
+-   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.9.0** or greater (0.10 recommended,
+    [see below](#neovim-configuration-for-compatibility)).
     -   Set the Neovim path in the extension settings. You must specify the full path to Neovim, like
         "`C:\Neovim\bin\nvim.exe`" or "`/usr/local/bin/nvim`".
     -   The setting id is "`vscode-neovim.neovimExecutablePaths.win32/linux/darwin`", respective to your system.
@@ -99,6 +100,13 @@ To conditionally activate plugins, `vim-plug` has a
 [few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation). `packer.nvim` and `lazy.nvim`
 have built-in support for `cond = vim.g.vscode`. See
 [plugins](https://github.com/vscode-neovim/vscode-neovim/wiki/Plugins) in the wiki for tips on configuring Vim plugins.
+
+#### Neovim configuration for best compatibility
+
+Though the extension strives to be as compatible as possible with older versions of Neovim, some older versions may have
+quirks that are not present anymore. In light of this, certain configuration settings are recommended in some older
+versions for the best experience. These can be found
+[on the wiki](https://github.com/vscode-neovim/vscode-neovim/wiki/Version-Compatibility-Notes).
 
 ### VSCode configuration
 


### PR DESCRIPTION
Clarifies a quirk of neovim output that changed between 0.9.x and 0.10. Thanks to @iansinnott for [pointing it out!](https://github.com/vscode-neovim/vscode-neovim/issues/2046#issuecomment-2155828299)