### PR TITLE
style: enable `no-unsafe-assignment`, `no-unsafe-return`, and `no-unsafe-member-access`

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -77,7 +77,8 @@ module.exports = tseslint.config(
             "@typescript-eslint/no-floating-promises": "off", // jumpy; would be nice to turn on, but we have a lot of these
             "@typescript-eslint/unbound-method": "off", // jumpy, given how vscode's API binds this. Would be good to remove.
 
-            // This codebase interacts with `any` a lot, so for now, all no-unsafe-* we violate are currently disabled
+            // I would love to disable this rule, but unfortunately it forbids spreading any[] types, which is
+            // quite useful for forwarding. I think it's a bit overzealous
             "@typescript-eslint/no-unsafe-argument": "off",
         },
     },

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -79,7 +79,6 @@ module.exports = tseslint.config(
 
             // This codebase interacts with `any` a lot, so for now, all no-unsafe-* we violate are currently disabled
             "@typescript-eslint/no-unsafe-argument": "off",
-            "@typescript-eslint/no-unsafe-member-access": "off",
         },
     },
     {
@@ -88,6 +87,7 @@ module.exports = tseslint.config(
             // Good for production code to avoid unsafe type leaks, potentially very frustrating and of little value for tests
             "@typescript-eslint/no-unsafe-assignment": "off",
             "@typescript-eslint/no-unsafe-return": "off",
+            "@typescript-eslint/no-unsafe-member-access": "off",
         },
     },
     {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -80,7 +80,6 @@ module.exports = tseslint.config(
             // This codebase interacts with `any` a lot, so for now, all no-unsafe-* we violate are currently disabled
             "@typescript-eslint/no-unsafe-argument": "off",
             "@typescript-eslint/no-unsafe-member-access": "off",
-            "@typescript-eslint/no-unsafe-return": "off",
         },
     },
     {
@@ -88,6 +87,7 @@ module.exports = tseslint.config(
         rules: {
             // Good for production code to avoid unsafe type leaks, potentially very frustrating and of little value for tests
             "@typescript-eslint/no-unsafe-assignment": "off",
+            "@typescript-eslint/no-unsafe-return": "off",
         },
     },
     {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -79,9 +79,15 @@ module.exports = tseslint.config(
 
             // This codebase interacts with `any` a lot, so for now, all no-unsafe-* we violate are currently disabled
             "@typescript-eslint/no-unsafe-argument": "off",
-            "@typescript-eslint/no-unsafe-assignment": "off",
             "@typescript-eslint/no-unsafe-member-access": "off",
             "@typescript-eslint/no-unsafe-return": "off",
+        },
+    },
+    {
+        files: ["src/test/**/*.ts"],
+        rules: {
+            // Good for production code to avoid unsafe type leaks, potentially very frustrating and of little value for tests
+            "@typescript-eslint/no-unsafe-assignment": "off",
         },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "ts-loader": "^9.5.1",
                 "typescript": "^5.4.4",
                 "typescript-eslint": "^7.8.0",
+                "vscode-languageserver-types": "^3.17.5",
                 "webpack": "^5.91.0",
                 "webpack-cli": "^5.1.4"
             },
@@ -6206,6 +6207,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+            "dev": true
         },
         "node_modules/watchpack": {
             "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -2167,6 +2167,7 @@
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.4",
         "typescript-eslint": "^7.8.0",
+        "vscode-languageserver-types": "^3.17.5",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4"
     },

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -85,14 +85,16 @@ class ActionManager implements Disposable {
                 return config.has(names);
             }
         });
-        this.add("get_config", (names: string | string[]) => {
+        this.add("get_config", ((names: string | string[]) => {
             const config = workspace.getConfiguration();
             if (Array.isArray(names)) {
                 return names.map((name) => config.get(name));
             } else {
+                // We can't know the type of this configuration value until runtime.
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
                 return config.get(names);
             }
-        });
+        }) as ((names: string) => any) & ((names: string[]) => any[]));
         this.add("update_config", async (names: string | string[], values: any, target?: "global" | "workspace") => {
             const config = workspace.getConfiguration();
             let targetConfig = null;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -101,12 +101,11 @@ class ActionManager implements Disposable {
             if (target) {
                 targetConfig = target === "global" ? ConfigurationTarget.Global : ConfigurationTarget.Workspace;
             }
-            if (!Array.isArray(names)) {
-                names = [names];
-                values = [values];
-            }
-            for (const [idx, name] of names.entries()) {
-                await config.update(name, values[idx], targetConfig);
+
+            const namesArr = ensureArray(names);
+            const valuesArr = ensureArray(values);
+            for (const [idx, name] of namesArr.entries()) {
+                await config.update(name, valuesArr[idx], targetConfig);
             }
         });
         this.add("start-multiple-cursors", (ranges: Range[]) => {
@@ -124,6 +123,14 @@ class ActionManager implements Disposable {
                 this.client.command(`doautocmd ${e.focused ? "FocusGained" : "FocusLost"}`),
             ),
         );
+    }
+}
+
+function ensureArray<T>(x: T | T[]): T[] {
+    if (Array.isArray(x)) {
+        return x;
+    } else {
+        return [x];
     }
 }
 

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -27,6 +27,7 @@ export async function eval_for_client(code: string, args: any): Promise<any> {
     // We can tell statically this will return a Promise<any>, and this is user provided code,
     // so, we can't know its type.
     /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-disable @typescript-eslint/no-unsafe-return */
     const func: () => Promise<any> = eval("async () => {" + code + "}");
     const result = await func();
 
@@ -38,5 +39,5 @@ export async function eval_for_client(code: string, args: any): Promise<any> {
     }
 
     return data ? JSON.parse(data) : data;
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-enable */
 }

--- a/src/actions_eval.ts
+++ b/src/actions_eval.ts
@@ -24,6 +24,9 @@ void logger;
 export async function eval_for_client(code: string, args: any): Promise<any> {
     void args;
 
+    // We can tell statically this will return a Promise<any>, and this is user provided code,
+    // so, we can't know its type.
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     const func: () => Promise<any> = eval("async () => {" + code + "}");
     const result = await func();
 
@@ -35,4 +38,5 @@ export async function eval_for_client(code: string, args: any): Promise<any> {
     }
 
     return data ? JSON.parse(data) : data;
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
 }

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -43,6 +43,8 @@ export class CommandLineManager implements Disposable {
     public constructor(private main: MainController) {
         eventBus.on("redraw", this.handleRedraw, this, this.disposables);
         this.input = window.createQuickPick();
+        // https://github.com/microsoft/vscode/issues/73904
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         (this.input as any).sortByLabel = false;
         this.input.ignoreFocusOut = true;
         this.input.buttons = [

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -117,7 +117,9 @@ export class CursorManager implements Disposable {
                         .split("-")
                         .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
                         .join("");
-                    const style = TextEditorCursorStyle[styleName as any] as any as TextEditorCursorStyle;
+                    const style = TextEditorCursorStyle[
+                        styleName as keyof typeof TextEditorCursorStyle
+                    ] as any as TextEditorCursorStyle;
                     window.visibleTextEditors.forEach((e) => (e.options.cursorStyle = style));
                 },
             },

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -12,6 +12,7 @@ import {
     window,
     workspace,
 } from "vscode";
+import type * as lsp from "vscode-languageserver-types";
 
 import actions from "./actions";
 import { config } from "./config";
@@ -255,7 +256,7 @@ export class CursorManager implements Disposable {
                 return;
             }
             try {
-                const ranges = await actions.lua("get_selections", win);
+                const ranges = await actions.lua<lsp.Range[]>("get_selections", win);
                 selections = rangesToSelections(ranges, editor.document);
             } catch (e) {
                 logger.error(e);

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -390,12 +390,7 @@ export class DocumentChangeManager implements Disposable {
             changeArgs.push([start.line, startBytes, end.line, endBytes, text.split(eol)]);
         }
 
-        const bufTick: number = await this.client.request("nvim_buf_get_changedtick", [bufId]);
-        if (!bufTick) {
-            logger.log(doc.uri, LogLevel.Warning, `Can't get changed tick for bufId: ${bufId}, deleted?`);
-            return;
-        }
-
+        const bufTick = (await this.client.request("nvim_buf_get_changedtick", [bufId])) as number;
         this.bufferSkipTicks.set(bufId, bufTick + changeArgs.length);
 
         logger.log(doc.uri, LogLevel.Debug, `Setting wantInsertCursorUpdate to false`);

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -2,12 +2,7 @@ import neovim from "neovim";
 import { Disposable, EventEmitter } from "vscode";
 
 // #region RedrawEventArgs
-interface IRedrawEventArg<N, A extends unknown[] = []> {
-    name: N;
-    args: A["length"] extends 0 ? undefined : A[];
-}
-
-type RedrawEventArgs =
+export type RedrawEventArgs =
     | IRedrawEventArg<"win_close", [number]> // ["win_close", grid]
     // ["win_external_pos", grid, win]
     | IRedrawEventArg<"win_external_pos", [number, neovim.Window]>
@@ -98,6 +93,11 @@ type RedrawEventArgs =
     | IRedrawEventArg<"popupmenu_select", [number]>
     | IRedrawEventArg<"popupmenu_hide">;
 // #endregion
+//
+interface IRedrawEventArg<N, A extends unknown[] = []> {
+    name: N;
+    args: A["length"] extends 0 ? undefined : A[];
+}
 
 interface BufferInfo {
     bufnr: number;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -102,7 +102,7 @@ export class Logger implements Disposable {
     }
 
     private log(level: vscode.LogLevel, scope: string, logToOutputChannel: boolean, args: any[]): void {
-        const msg = args.reduce((p, c, i) => {
+        const msg = args.reduce((p: string, c: any, i: number) => {
             if (typeof c === "object") {
                 try {
                     c = inspect(c, false, 2, false);

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -14,7 +14,7 @@ import { config } from "./config";
 import { NVIM_MIN_VERSION } from "./constants";
 import { CursorManager } from "./cursor_manager";
 import { DocumentChangeManager } from "./document_change_manager";
-import { eventBus } from "./eventBus";
+import { eventBus, RedrawEventArgs } from "./eventBus";
 import { HighlightManager } from "./highlight_manager";
 import { createLogger } from "./logger";
 import { MessagesManager } from "./messages_manager";
@@ -257,6 +257,8 @@ export class MainController implements vscode.Disposable {
             }
             targetRange = doc.validateRange(targetRange);
             editor.selections = [new vscode.Selection(targetRange.start, targetRange.end)];
+            // This is an arbitrary action from VSCode, we can't know the return type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const res = await actions.run(action, ...(options.args || []));
             if (options.restore_selection !== false) {
                 editor.selections = prevSelections;
@@ -295,6 +297,7 @@ export class MainController implements vscode.Disposable {
                 break;
             }
             case "vscode-neovim": {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 const [command, args] = events;
                 eventBus.fire(command as any, args);
                 break;
@@ -320,7 +323,7 @@ export class MainController implements vscode.Disposable {
                         const eventData = {
                             name: batchItem[0],
                             args: batchItem.slice(1),
-                        } as any;
+                        } as RedrawEventArgs;
 
                         eventBus.fire("redraw", eventData);
                     });
@@ -347,6 +350,8 @@ export class MainController implements vscode.Disposable {
                 if (Array.isArray(options)) options = {}; // empty lua table
 
                 try {
+                    // This is an arbitrary action from neovim, we can't know the return type
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     const res = await this.runAction(action, options);
                     response.send(res);
                 } catch (err) {

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -263,6 +263,9 @@ export class MainController implements vscode.Disposable {
             if (options.restore_selection !== false) {
                 editor.selections = prevSelections;
             }
+
+            // This is an arbitrary action from VSCode, we can't know the return type
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return res;
         }
         return actions.run(action, ...(options.args || []));

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -368,6 +368,8 @@ export class MainController implements vscode.Disposable {
     };
 
     private setClientInfo() {
+        // We know version will be present in package.json...
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const versionString = this.extContext.extension.packageJSON.version as string;
         const [major, minor, patch] = [...versionString.split(".").map((n) => +n), 0, 0, 0];
         logger.debug(`Setting client info: vscode-neovim ${major}.${minor}.${patch}`);

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -12,6 +12,7 @@ import {
     TextEditor,
     commands,
 } from "vscode";
+import type * as lsp from "vscode-languageserver-types";
 
 import { config } from "../config";
 
@@ -207,13 +208,7 @@ export function isChangeSubsequentToChange(
  * @param document The document used to validate the range.
  * @returns The converted selections.
  */
-export function rangesToSelections(
-    ranges: {
-        start: { line: number; character: number };
-        end: { line: number; character: number };
-    }[],
-    document?: TextDocument,
-): Selection[] {
+export function rangesToSelections(ranges: lsp.Range[], document?: TextDocument): Selection[] {
     return ranges.map((r) => {
         const start = new Position(r.start.line, r.start.character);
         const end = new Position(r.end.line, r.end.character);


### PR DESCRIPTION
I passed over these when adding the type-checked rules, but I wanted to revisit them. There are some times where it is correct to disable it (as we can't know the types until runtime), but there are a few where we actually do know the types, and we should just take the time to type everything.