### PR TITLE
fix(buffer): prevent concurrent syncs and stale data

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -457,7 +457,7 @@ export class BufferManager implements Disposable {
                 await this.syncActiveEditor(activeEditor);
             }
         } catch (e) {
-            logger.error(`Error syncing layout: ${e}`);
+            logger.error("Error syncing layout:", e);
         } finally {
             this.isSyncingLayout = false;
             this.syncLayoutPromise?.resolve();


### PR DESCRIPTION
Synchronous layout operations take some time, and even with debouncing and a CancelToken, it's not guaranteed that only one synchronous operation will run at a time. If multiple synchronous operations are executed simultaneously, conflicts can occur, especially when initializing the buffer, leading to errors when setting the buffer name.