### PR TITLE
fix(messages): Limit the minimum value of `cmdheight` to 1

### DIFF
--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -41,7 +41,8 @@ export class MessagesManager implements Disposable {
 
                 const lineCount = outputMsg.split("\n").length;
                 const cmdheight = (await this.main.client.getOption("cmdheight")) as number;
-                if (lineCount > cmdheight) {
+                // Before Nvim 0.10, cmdheight is unchangeable, and it's always 0.
+                if (lineCount > Math.max(1, cmdheight)) {
                     this.channel.show(true);
                 }
 


### PR DESCRIPTION
fix #2109

This version difference does affect maintenance  :(