### PR TITLE
fix(highlights): wait for doc changes before updating highlights

### DIFF
--- a/src/highlight_manager.ts
+++ b/src/highlight_manager.ts
@@ -30,7 +30,13 @@ export class HighlightManager implements Disposable {
         if (!this.highlightGrids.has(gridId)) {
             this.highlightGrids.set(
                 gridId,
-                new HighlightGrid(gridId, this.groupStore, this.main.bufferManager, this.main.viewportManager),
+                new HighlightGrid(
+                    gridId,
+                    this.groupStore,
+                    this.main.bufferManager,
+                    this.main.viewportManager,
+                    this.main.changeManager,
+                ),
             );
         }
         return this.highlightGrids.get(gridId)!;


### PR DESCRIPTION
fix #2111

We should still wait for the document synchronization to complete before calculating the highlights. Otherwise, there is a possibility of computing incorrect highlights due to inconsistent content. Previously, this logic was mistakenly deleted.