### PR TITLE
chore: remove useless log for viewport change

### DIFF
--- a/src/viewport_manager.ts
+++ b/src/viewport_manager.ts
@@ -12,12 +12,8 @@ import {
 import actions from "./actions";
 import { config } from "./config";
 import { EventBusData, eventBus } from "./eventBus";
-import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
 import { ManualPromise, disposeAll } from "./utils";
-
-const logger = createLogger("ViewportManager");
-
 // all 0-indexed
 export class Viewport {
     line = 0; // current line
@@ -68,10 +64,7 @@ export class ViewportManager implements Disposable {
         this.viewportChangedPromise = undefined;
 
         const gridId = this.main.bufferManager.getGridIdForWinId(winid);
-        if (!gridId) {
-            logger.warn(`Unable to update scrolled view. No grid for winId: ${winid}`);
-            return;
-        }
+        if (!gridId) return;
 
         this.viewportChangedPromise = new ManualPromise();
 


### PR DESCRIPTION

This log is redundant and misleading. When synchronizing the Editor, the grid corresponding to the created window definitely doesn't exist yet.