### PR TITLE
fix: rapid cmdline_show/cmdline_hides would not be handled logically

### DIFF
--- a/src/cmdline/cmdline_queue.ts
+++ b/src/cmdline/cmdline_queue.ts
@@ -1,0 +1,71 @@
+import { type EventBusData } from "../eventBus";
+
+/**
+ * A queue for "batching" cmdline events.
+ *
+ * In the most simple cases, events will simply be passed through and not queued. However, there is a more complicated=
+ * case we must deal with. There is an inherent "race condition" (NB: it's not really a race condition, rather a result
+ * of how the JS event loop works, but it's easiest to think of it as a race) between quickpick hide events and cmdline_* events from nvim. If there is a
+ * cmdline_hide, followed immediately by a cmdline_show, we may call hide() on the quickpick, but onHide will not
+ * be fired until our event handlers have completed execution, leading to bizarre and confusing states. As such,
+ * we "queue" events until we know for sure that the quickpick has bene hidden, and then allow them to be flushed back
+ * to the cmdline_manager.
+ */
+export class CmdlineQueue {
+    private pendingBatches: EventBusData<"redraw">[][] = [];
+    private needFlush: boolean = false;
+    private level: number | null = null;
+
+    /**
+     * Given a newovim event, checks whether or not the caller should handle
+     * this event. If this returns false, the event is enqueued for later re-emission.
+     *
+     * @param event
+     * @returns
+     */
+    handleNvimRedrawEvent(event: EventBusData<"redraw">): boolean {
+        if (this.needFlush) {
+            this.addToBatch(event);
+            return false;
+        }
+
+        if (event.name === "cmdline_show") {
+            const [_content, _pos, _firstc, _prompt, _indent, level] = event.args[0];
+            this.level = level;
+        } else if (event.name === "cmdline_hide" && this.level === 1) {
+            this.prepareBatch();
+        }
+
+        return true;
+    }
+
+    /**
+     * Flush the currently pending batch, and remove it from the queue
+     *
+     * @returns The next batch of pending events, or null if none are pending
+     */
+    flushBatch(): EventBusData<"redraw">[] | null {
+        const result = this.pendingBatches.shift() ?? null;
+        this.needFlush = false;
+        this.level = null;
+
+        return result;
+    }
+
+    private prepareBatch() {
+        this.pendingBatches.push([]);
+        this.needFlush = true;
+        this.level = null;
+    }
+
+    private addToBatch(event: EventBusData<"redraw">) {
+        if (this.pendingBatches.length === 0) {
+            // No batch to add this to. We can't safely assume we should make a new batch (but this should
+            // never happen)
+            throw new Error("Invalid cmdline state");
+        }
+
+        const batch = this.pendingBatches[this.pendingBatches.length - 1];
+        batch.push(event);
+    }
+}

--- a/src/cmdline/cmdline_queue.ts
+++ b/src/cmdline/cmdline_queue.ts
@@ -24,9 +24,9 @@ export class CmdlineQueue {
      * @returns
      */
     handleNvimRedrawEvent(event: EventBusData<"redraw">): boolean {
+        const shouldProcess = !this.needFlush;
         if (this.needFlush) {
             this.addToBatch(event);
-            return false;
         }
 
         if (event.name === "cmdline_show") {
@@ -36,7 +36,7 @@ export class CmdlineQueue {
             this.prepareBatch();
         }
 
-        return true;
+        return shouldProcess;
     }
 
     /**

--- a/src/cmdline_manager.ts
+++ b/src/cmdline_manager.ts
@@ -214,7 +214,7 @@ export class CommandLineManager implements Disposable {
         if (batch !== null) {
             logger.debug("onHide: flushing events");
             batch.forEach((event) => {
-                // Process the events we were waiting for
+                // Process the events we we're waiting for
                 this.handleRedrawEvent(event);
             });
         }

--- a/src/test/unit/cmdline/cmdline_queue.test.ts
+++ b/src/test/unit/cmdline/cmdline_queue.test.ts
@@ -1,0 +1,151 @@
+import { strict as assert } from "assert";
+
+import { CmdlineQueue } from "../../../cmdline/cmdline_queue";
+import { type EventBusData } from "../../../eventBus";
+
+describe("handleNvimEvent", () => {
+    it("returns true for cmdline_show/cmdline_hide events inserted at first", () => {
+        const queue = new CmdlineQueue();
+
+        const events: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "wq"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        events.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
+        });
+    });
+
+    it("returns false for subsequent cmdline_shows given after a cmdline_hide", () => {
+        const queue = new CmdlineQueue();
+
+        const batch1: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        const batch2: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+        ];
+
+        batch1.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
+        });
+
+        batch2.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), false, `Event ${i} did not return false`);
+        });
+    });
+
+    it("should stage the event for when flushBatch is called", () => {
+        const queue = new CmdlineQueue();
+
+        const batch1: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        const batch2: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+        ];
+
+        batch1.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
+        });
+
+        batch2.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), false, `Event ${i} did not return false`);
+        });
+
+        assert.deepEqual(queue.flushBatch(), batch2);
+    });
+
+    it("does not return false after cmdline_hides for level changes", () => {
+        const queue = new CmdlineQueue();
+
+        const batch1: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, "=", "", 0, 2]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        const batch2: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, "value"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        batch1.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
+        });
+
+        batch2.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
+        });
+    });
+
+    it("should not consider a lone cmdline_hide as a trigger for a queue", () => {
+        const queue = new CmdlineQueue();
+
+        queue.handleNvimRedrawEvent({ name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] });
+        // Flush the batch externally. Would occur w/o a cmdline_hide if someone hid the quickpick from vscode
+        queue.flushBatch();
+
+        queue.handleNvimRedrawEvent({ name: "cmdline_hide" as const, args: undefined });
+        // A defective implementation would return false here, as it would indicate events are now being queued
+        assert.equal(
+            queue.handleNvimRedrawEvent({ name: "cmdline_show" as const, args: [[[[{}, "value"]], 0, ":", "", 0, 1]] }),
+            true,
+        );
+    });
+});
+
+describe("flushBatch", () => {
+    it("returns null when nothing is queued", () => {
+        const queue = new CmdlineQueue();
+        assert.equal(queue.flushBatch(), null);
+    });
+
+    it("returns null after staged events are flushed", () => {
+        const queue = new CmdlineQueue();
+        const events: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+        ];
+
+        events.forEach((event) => {
+            queue.handleNvimRedrawEvent(event);
+        });
+
+        assert.notEqual(queue.flushBatch(), null);
+        assert.equal(queue.flushBatch(), null);
+    });
+
+    it("allows queueing of events once a flush occurs", () => {
+        const queue = new CmdlineQueue();
+        const events: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        events.forEach((event) => {
+            queue.handleNvimRedrawEvent(event);
+        });
+
+        queue.flushBatch();
+
+        events.forEach((event, i) => {
+            assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
+        });
+    });
+});

--- a/src/test/unit/cmdline/cmdline_queue.test.ts
+++ b/src/test/unit/cmdline/cmdline_queue.test.ts
@@ -148,4 +148,28 @@ describe("flushBatch", () => {
             assert.equal(queue.handleNvimRedrawEvent(event), true, `Event ${i} did not return true`);
         });
     });
+
+    it("should flush more than one batch", () => {
+        const queue = new CmdlineQueue();
+        const events: EventBusData<"redraw">[] = [
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+            { name: "cmdline_show" as const, args: [[[[{}, ""]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_show" as const, args: [[[[{}, "w"]], 0, ":", "", 0, 1]] },
+            { name: "cmdline_hide" as const, args: undefined },
+        ];
+
+        events.forEach((event) => {
+            queue.handleNvimRedrawEvent(event);
+        });
+
+        assert.notEqual(queue.flushBatch(), null, "Batch 0 did not flush");
+        assert.notEqual(queue.flushBatch(), null, "Batch 1 did not flush");
+        assert.notEqual(queue.flushBatch(), null, "Batch 2 did not flush");
+        assert.equal(queue.flushBatch(), null, "More than 3 batches");
+    });
 });


### PR DESCRIPTION
Replaces #2081
Fixes #2079 


I came up with [this idea](https://github.com/vscode-neovim/vscode-neovim/pull/2081#issuecomment-2157087672) a little while ago, but haven't had the chance to sit down and implement it. Ultimately, most problems with our two-way cmdline sync originats from the fact that a cmdline_hide can be sent before the quickpick actually executes a hide event, or vice versa. Attempting to  manipulate the events to "ignore" is error prone, given this ordering problem. 

To repeat myself a bit from the linked comment, the "idea" is that we can handle cmdline events in batches. Once we receive a cmdline_hide event at level 1 (i.e. no nested command lines), we can consider the current batch "terminated", and begin queueing up events. Then, when we get a VSCode "hide" event, we can flush the batch, and continue processing events. 

A screencast showing some usage of the vim sandwich plugin, and various simple commandline usages


https://github.com/vscode-neovim/vscode-neovim/assets/977151/9fb86d8c-d180-470d-910f-ab18d046c574

