### PR TITLE
refactor: Simplify invoking Treesitter parsing and ensure more timely parsing

### DIFF
--- a/runtime/lua/vscode/sync-options.lua
+++ b/runtime/lua/vscode/sync-options.lua
@@ -11,6 +11,7 @@
 
 local api = vim.api
 local vscode = require("vscode.api")
+local util = require("vscode.util")
 
 local M = {}
 
@@ -106,15 +107,7 @@ local function _check_options()
   end
 end
 
-local check_options = (function()
-  local check_timer
-  return function()
-    if check_timer and check_timer:is_active() then
-      check_timer:close()
-    end
-    check_timer = vim.defer_fn(_check_options, 20)
-  end
-end)()
+local check_options = util.debounce(_check_options, 20)
 
 local function process_modeline()
   if vim.b.vscode_editor_options_first_checked then

--- a/runtime/lua/vscode/util.lua
+++ b/runtime/lua/vscode/util.lua
@@ -62,4 +62,21 @@ function M.compare_position(a, b)
   return -1
 end
 
+---Debounce a function.
+---@param func function function to debounce
+---@param time number trialing time in ms
+---@return function
+function M.debounce(func, time)
+  local timer
+  return function(...)
+    local args = { ... }
+    if timer and timer:is_active() then
+      timer:close()
+    end
+    timer = vim.defer_fn(function()
+      func(unpack(args))
+    end, time)
+  end
+end
+
 return M

--- a/runtime/vscode/treesitter.lua
+++ b/runtime/vscode/treesitter.lua
@@ -1,20 +1,13 @@
 -- TODO: Figure out why Treesitter doesn't parse.
-vim.api.nvim_create_autocmd({ "TextChanged", "InsertLeave" }, {
-  group = vim.api.nvim_create_augroup("vscode.treesitter", {}),
-  callback = (function()
-    local timer
-    return function()
-      if timer and timer:is_active() then
-        timer:close()
-      end
-      timer = vim.defer_fn(function()
-        if vim.b._vscode_last_parse_changedtick ~= vim.b.changedtick then
-          vim.b._vscode_last_parse_changedtick = vim.b.changedtick
-          pcall(function()
-            vim.treesitter.get_parser():parse()
-          end)
-        end
-      end, 300)
-    end
-  end)(),
+
+local api = vim.api
+local util = require("vscode.util")
+
+api.nvim_create_autocmd({ "CursorHold", "TextChanged", "InsertLeave" }, {
+  group = api.nvim_create_augroup("vscode.treesitter", {}),
+  callback = util.debounce(function()
+    pcall(function()
+      vim.treesitter.get_parser():parse()
+    end)
+  end, 100),
 })


### PR DESCRIPTION
- Trigger Treesitter parsing on CursorHold
- Add utility function debounce

It used to be too much consideration, which was unnecessary.