### PR TITLE
Ease engines requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@jpwilliams/waitgroup": "^2.1.1",
                 "async-mutex": "^0.5.0",
+                "core-js": "^3.37.1",
                 "fast-myers-diff": "^3.2.0",
                 "grapheme-splitter": "^1.0.4",
                 "lodash": "^4.17.21",
@@ -2041,6 +2042,17 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
+        },
+        "node_modules/core-js": {
+            "version": "3.37.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+            "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@types/mocha": "^10.0.7",
                 "@types/node": "^20.14.9",
                 "@types/sinonjs__fake-timers": "^8.1.5",
-                "@types/vscode": "^1.90.0",
+                "@types/vscode": "1.89.0",
                 "@vscode/test-electron": "^2.4.0",
                 "@vscode/vsce": "^2.29.0",
                 "eslint": "^8.57.0",
@@ -42,7 +42,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.87.0"
+                "vscode": "^1.89.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -610,9 +610,9 @@
             "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
         },
         "node_modules/@types/vscode": {
-            "version": "1.90.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
-            "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+            "version": "1.89.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.89.0.tgz",
+            "integrity": "sha512-TMfGKLSVxfGfoO8JfIE/neZqv7QLwS4nwPwL/NwMvxtAY2230H2I4Z5xx6836pmJvMAzqooRQ4pmLm7RUicP3A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -2161,6 +2161,7 @@
     "dependencies": {
         "@jpwilliams/waitgroup": "^2.1.1",
         "async-mutex": "^0.5.0",
+        "core-js": "^3.37.1",
         "fast-myers-diff": "^3.2.0",
         "grapheme-splitter": "^1.0.4",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "email": "devpieron@gmail.com"
     },
     "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.89.0"
     },
     "keywords": [
         "keybindings",
@@ -2140,7 +2140,7 @@
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.9",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@types/vscode": "^1.90.0",
+        "@types/vscode": "1.89.0",
         "@vscode/test-electron": "^2.4.0",
         "@vscode/vsce": "^2.29.0",
         "eslint": "^8.57.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import "core-js/actual/array/find-last";
 import * as vscode from "vscode";
 
 import actions from "./actions";


### PR DESCRIPTION
First of all: thank you for your work!

This PR ever so slightly eases the latest VS Code version requirement as the code does not use any of the newer APIs the change is supposed to be fully backward compatible.

The reason I am creating this PR is due to some companies not allowing to update to the most recent VS Code version thus the VS Code marketplace for plugins does not allow to install the most recent version of this plugin and these users miss out on months of new functionality. I hope it is okay to make this change as it does not seem to cause any regression in functionality or add an additional maintenance burden.

The proposed minimum required VS Code version 1.89 is fairly recent [April 2024](https://code.visualstudio.com/updates/v1_89).

I have ran all precommit and `npx tsc` which exits with a 0 exit code. Thus I think this is a safe change.

Thank you