### PR TITLE
refactor: Improve usability of afterInitConfig option in the settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
                         "type": "string"
                     },
                     "title": "After init config",
-                    "markdownDescription": "Config to be sourced after init config. e.g. : `[\"echo 'hello'\", \"lua << EOF\", \"require'vscode'.notify('world')\", \"EOF\"]`"
+                    "markdownDescription": "Config to be sourced after init config. Each item is a different line of the config. For example:\n\n`set ignorecase`\n\n`echo 'hello'`\n\n`lua << EOF`\n\n`require'vscode'.notify('world')`\n\n`EOF`"
                 },
                 "vscode-neovim.neovimClean": {
                     "type": "boolean",


### PR DESCRIPTION
I spent around 15 minutes wondering why my Vimscript wasn't working to ignore case. Below you can see the settings for the current version of the extension, the top is the correct line and the bottom is the line I was writing:
![image](https://github.com/user-attachments/assets/2c223913-e3f8-4047-8956-485a42cfbff7)

Which maps to this in settings.json
![image](https://github.com/user-attachments/assets/ffc27d1a-8801-4ce8-9e25-640512086010)

I think I would have easily understood what to do immediately if the instructions looked like this instead:
![Screenshot 2024-07-18 143434](https://github.com/user-attachments/assets/7141d828-25d2-4d5f-9d02-1cb822daf524)
