### PR TITLE
refactor: Improve explanation of Ctrl+key in settings menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
                 "vscode-neovim.ctrlKeysForNormalMode": {
                     "type": "array",
                     "uniqueItems": true,
+                    "markdownDescription": "Enabled Ctrl+key combinations for all modes except insert mode.\n\nIf a key is in the below list, then `Ctrl+key` will be handled by Neovim. Otherwise it will be handled by VS Code.",
                     "items": {
                         "type": "string",
                         "enum": [
@@ -178,12 +179,12 @@
                         "down",
                         "backspace",
                         "delete"
-                    ],
-                    "description": "Enabled Ctrl keys in normal/visual/etc...(except insert) modes"
+                    ]
                 },
                 "vscode-neovim.ctrlKeysForInsertMode": {
                     "type": "array",
                     "uniqueItems": true,
+                    "markdownDescription": "Enabled Ctrl+key combinations for insert mode.\n\nIf a key is in the below list, then `Ctrl+key` will be handled by Neovim while in insert mode. Otherwise it will be handled by VS Code.",
                     "items": {
                         "type": "string",
                         "enum": [
@@ -235,8 +236,7 @@
                         "t",
                         "u",
                         "w"
-                    ],
-                    "description": "Enabled Ctrl keys in insert mode"
+                    ]
                 },
                 "vscode-neovim.editorLangIdExclusions": {
                     "type": "array",


### PR DESCRIPTION
The settings currently look like this:
![image](https://github.com/user-attachments/assets/ce72bb6b-c49b-402b-b518-3967b7aa04c9)

I didn't know whether enabled Ctrl keys meant for Neovim or for VS Code. This commit changes the settings to now look like this, which would have been a better explanation when I started using the extension:
![image](https://github.com/user-attachments/assets/096246d7-9d0e-4f2e-93b3-913284e0ba9c)
