### PR TITLE
fix: Fix multi-byte character selection in Nvim 0.10 blockwise visual

### DIFF
--- a/runtime/lua/vscode/internal.lua
+++ b/runtime/lua/vscode/internal.lua
@@ -209,8 +209,8 @@ function M.get_selections(win)
         -- ignore
       end
     else
-      local start_col = fn.virtcol2col(win, line_1, start_vcol)
-      local end_col = fn.virtcol2col(win, line_1, end_vcol)
+      local start_col = util.virtcol2col(win, line_1, start_vcol)
+      local end_col = util.virtcol2col(win, line_1, end_vcol)
       local start_col_offset = fn.strlen(util.get_char_at(line_1, start_col, buf) or "")
       local end_col_offset = fn.strlen(util.get_char_at(line_1, end_col, buf) or "")
       local range = vim.lsp.util.make_given_range_params(

--- a/src/test/integ/visual-modes.test.ts
+++ b/src/test/integ/visual-modes.test.ts
@@ -512,6 +512,52 @@ describe("Visual modes test", () => {
         );
     });
 
+    it("Visual block mode - multi-width chars - `virtcol` is within a multibyte character", async () => {
+        await openTextDocument({ content: ["hello", "-你好", "hello"].join("\n") });
+
+        await sendNeovimKeys(client, "<C-v>");
+        await sendVSCodeKeys("jl");
+        await assertContent(
+            {
+                vsCodeSelections: [new vscode.Selection(1, 0, 1, 2), new vscode.Selection(0, 0, 0, 3)],
+            },
+            client,
+        );
+        await sendVSCodeKeys("j");
+        await assertContent(
+            {
+                vsCodeSelections: [
+                    new vscode.Selection(2, 0, 2, 2),
+                    new vscode.Selection(1, 0, 1, 2),
+                    new vscode.Selection(0, 0, 0, 2),
+                ],
+            },
+            client,
+        );
+        await sendVSCodeKeys("l");
+        await assertContent(
+            {
+                vsCodeSelections: [
+                    new vscode.Selection(2, 0, 2, 3),
+                    new vscode.Selection(1, 0, 1, 2),
+                    new vscode.Selection(0, 0, 0, 3),
+                ],
+            },
+            client,
+        );
+        await sendVSCodeKeys("l");
+        await assertContent(
+            {
+                vsCodeSelections: [
+                    new vscode.Selection(2, 0, 2, 4),
+                    new vscode.Selection(1, 0, 1, 3),
+                    new vscode.Selection(0, 0, 0, 4),
+                ],
+            },
+            client,
+        );
+    });
+
     it("Visual mode - $ is ok for upward selection", async () => {
         await openTextDocument({ content: ["blah1 abc", "blah2 abc", "blah3 abc"].join("\n") });
 


### PR DESCRIPTION
Since Nvim 0.10.0, `virtcol2col` changed from returning the last byte of a multi-byte character to returning the first byte. However, we need the column of the last byte, which is consistent with the selected region in Nvim.

Close #2166