### PR TITLE
refactor: follow nvim ui-messages protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mode and editor commands, making the best use of both editors.
 
 Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) extension.
 
-Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.9.0** or greater (0.10 recommended).
+Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.10.0** or greater.
 
 > **Note:** Though the extension strives to be as compatible as possible with older versions of Neovim, some older
 > versions may have quirks that are not present anymore. In light of this, certain configuration settings are

--- a/runtime/lua/vscode/default-options.lua
+++ b/runtime/lua/vscode/default-options.lua
@@ -7,7 +7,7 @@ local function setup()
   vim.g.loaded_matchparen = 1
 
   -- When enable `ext_messages`, `cmdheight` will be set to 0 by default.
-  vim.opt.cmdheight = 1
+  vim.opt.cmdheight = 2
 end
 
 return { setup = setup }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const NVIM_MIN_VERSION = "0.9.0";
+export const NVIM_MIN_VERSION = "0.10.0";
 
 export const GlyphChars = {
     COMMAND: "\u2318",

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -103,6 +103,7 @@ type RedrawEventArgs =
       >
     // ["msg_history_show", entries]
     | IRedrawEventArg<"msg_history_show", [string, [number, string][]][][]>
+    | IRedrawEventArg<"msg_history_clear">
     | IRedrawEventArg<"msg_clear">
     | IRedrawEventArg<"mode_change", [mode: string, mode_idx: number]>
     | IRedrawEventArg<

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -24,6 +24,8 @@ interface IRedrawEventArg<N, A extends unknown[] = []> {
     args: A["length"] extends 0 ? undefined : A[];
 }
 
+type MsgShowContent = [attr_id: number, text_chunk: string][];
+
 type RedrawEventArgs =
     | IRedrawEventArg<"win_close", [grid: number]>
     | IRedrawEventArg<"win_external_pos", [grid: number, win: neovim.Window]>
@@ -87,13 +89,13 @@ type RedrawEventArgs =
                   | "quickfix"
                   | "search_count"
                   | "wmsg",
-              content: [number, string][],
+              content: MsgShowContent,
               replace_last: boolean,
           ]
       >
-    | IRedrawEventArg<"msg_showcmd", [content: [number, string][]]>
-    | IRedrawEventArg<"msg_showmode", [content: [number, string][]]>
-    | IRedrawEventArg<"msg_ruler", [content: [number, string][]]>
+    | IRedrawEventArg<"msg_showcmd", [content: MsgShowContent]>
+    | IRedrawEventArg<"msg_showmode", [content: MsgShowContent]>
+    | IRedrawEventArg<"msg_ruler", [content: MsgShowContent]>
     | IRedrawEventArg<
           "mode_info_set",
           [
@@ -101,8 +103,7 @@ type RedrawEventArgs =
               mode_info: { name: string; cursor_shape: "block" | "horizontal" | "vertical" }[],
           ]
       >
-    // ["msg_history_show", entries]
-    | IRedrawEventArg<"msg_history_show", [string, [number, string][]][][]>
+    | IRedrawEventArg<"msg_history_show", [entries: [kind: string, MsgShowContent][]]>
     | IRedrawEventArg<"msg_history_clear">
     | IRedrawEventArg<"msg_clear">
     | IRedrawEventArg<"mode_change", [mode: string, mode_idx: number]>

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -46,7 +46,6 @@ export class MessagesManager implements Disposable {
         switch (name) {
             case "msg_show": {
                 let lineCount = 0;
-
                 for (const [type, content, replaceLast] of args) {
                     // Ignore return_prompt
                     //
@@ -82,16 +81,14 @@ export class MessagesManager implements Disposable {
             }
 
             case "msg_history_show": {
-                for (const arg of args) {
-                    for (const list of arg) {
-                        for (const [commandName, content] of list) {
-                            const cmdContent = content.map(([_attrId, chunk]) => chunk).join("");
+                for (const [entries] of args) {
+                    for (const [commandName, content] of entries) {
+                        const cmdContent = content.map(([_attrId, chunk]) => chunk).join("");
 
-                            if (commandName.length === 0) {
-                                this.historyBuffer.push(cmdContent);
-                            } else {
-                                this.historyBuffer.push(`${commandName}: ${cmdContent}`);
-                            }
+                        if (commandName.length === 0) {
+                            this.historyBuffer.push(cmdContent);
+                        } else {
+                            this.historyBuffer.push(`${commandName}: ${cmdContent}`);
                         }
                     }
                 }

--- a/src/test/integ/messages.test.ts
+++ b/src/test/integ/messages.test.ts
@@ -1,0 +1,123 @@
+import { strict as assert } from "assert";
+
+import { NeovimClient } from "neovim";
+import { TextEditor, window } from "vscode";
+
+import { EXT_ID } from "../../constants";
+
+import {
+    attachTestNvimClient,
+    closeAllActiveEditors,
+    closeNvimClient,
+    openTextDocument,
+    sendNeovimKeys,
+    sendVSCodeCommand,
+    sendVSCodeKeys,
+    wait,
+} from "./integrationUtils";
+
+function findOutputChannel(): TextEditor | undefined {
+    // There might be a better way to find the right channel than this...
+    return window.visibleTextEditors.find((e) => {
+        const { scheme, path } = e.document.uri;
+        return scheme === "output" && path.includes(EXT_ID) && path.endsWith("messages");
+    });
+}
+
+async function sendCommandLine(command: string) {
+    await sendVSCodeKeys(":");
+    await sendVSCodeCommand("vscode-neovim.test-cmdline", command);
+    await sendVSCodeCommand("vscode-neovim.commit-cmdline");
+}
+
+async function hideOutputPanel() {
+    await sendVSCodeCommand("workbench.action.closePanel");
+    await wait();
+}
+
+describe("Message output", () => {
+    let client: NeovimClient;
+
+    before(async () => {
+        client = await attachTestNvimClient();
+        // Just for testing consistency with pre-0.10 versions:
+        await client.setOption("cmdheight", 0);
+        await openTextDocument({ content: "" });
+    });
+
+    after(async () => {
+        await closeNvimClient(client);
+        await closeAllActiveEditors();
+    });
+
+    afterEach(async () => {
+        await client.command("messages clear");
+        await hideOutputPanel();
+    });
+
+    it("should reveal output panel with contents", async () => {
+        await sendCommandLine("echo 1 | echom 2 | echo 3 | echom 4");
+        await wait();
+        let outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "1\n2\n3\n4\n");
+        await hideOutputPanel();
+
+        await sendCommandLine("messages");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "echomsg: 2\nechomsg: 4\n");
+        await hideOutputPanel();
+
+        await sendCommandLine("echo 5 | echo 6 | echo 7");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "5\n6\n7\n");
+    });
+
+    it("should reveal after first line", async () => {
+        await sendCommandLine("echom 1 | sleep 1 | echom 2 | echom 3");
+
+        // only one line written at first, should not be revealed yet
+        let outputEditor = findOutputChannel();
+        assert.equal(outputEditor, undefined);
+
+        await wait(1400);
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "1\n2\n3\n");
+        await hideOutputPanel();
+
+        await sendCommandLine("messages");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "echomsg: 1\nechomsg: 2\nechomsg: 3\n");
+    });
+
+    it("should clear history", async () => {
+        let outputEditor = findOutputChannel();
+        await sendCommandLine("echom 1 | echom 2 | echom 3");
+        await wait();
+        await sendCommandLine("messages");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "echomsg: 1\nechomsg: 2\nechomsg: 3\n");
+
+        await sendCommandLine("messages clear");
+        await wait();
+        await sendCommandLine("messages");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "");
+    });
+
+    it("should reveal for return prompt", async () => {
+        await sendNeovimKeys(client, "/foobar\n");
+        await wait();
+        let outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "/foobar             \nE486: Pattern not found: foobar\n");
+
+        await sendCommandLine("messages");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "emsg: E486: Pattern not found: foobar\n");
+    });
+});

--- a/src/test/integ/messages.test.ts
+++ b/src/test/integ/messages.test.ts
@@ -40,9 +40,11 @@ describe("Message output", () => {
 
     before(async () => {
         client = await attachTestNvimClient();
-        // Just for testing consistency with pre-0.10 versions:
-        await client.setOption("cmdheight", 0);
         await openTextDocument({ content: "" });
+    });
+
+    beforeEach(async () => {
+        await client.setOption("cmdheight", 2);
     });
 
     after(async () => {
@@ -109,11 +111,24 @@ describe("Message output", () => {
         assert.equal(outputEditor?.document.getText(), "");
     });
 
-    it("should reveal for return prompt", async () => {
+    it("should reveal for 'pattern not found' for cmdheight=1", async () => {
+        await client.setOption("cmdheight", 1);
         await sendNeovimKeys(client, "/foobar\n");
         await wait();
         let outputEditor = findOutputChannel();
         assert.equal(outputEditor?.document.getText(), "/foobar             \nE486: Pattern not found: foobar\n");
+
+        await sendCommandLine("messages");
+        await wait();
+        outputEditor = findOutputChannel();
+        assert.equal(outputEditor?.document.getText(), "emsg: E486: Pattern not found: foobar\n");
+    });
+
+    it("should suppress 'pattern not found' with cmdheight=2", async () => {
+        await sendNeovimKeys(client, "/foobar\n");
+        await wait();
+        let outputEditor = findOutputChannel();
+        assert.equal(outputEditor, undefined);
 
         await sendCommandLine("messages");
         await wait();


### PR DESCRIPTION
Closes #2134 

`:help ui-messages` shows a lot more details about how these messages are meant to be handled. This change makes our handling match more closely to the expected behavior and now obeys *_clear types of messages as well.

This changes the behavior of message handling pretty significantly, so it probably deserves some more serious testing before merging into a release — especially given some of the issues that have shown up in the past re: `return_prompt` + `cmdheight`, etc.


Keeping this as a draft for now as I'm still seeing an issue in some case where `:messages` (i.e. `msg_history_show`) gets cleared immediately after writing, resulting in no visible output. Seems to be sent due to https://github.com/neovim/neovim/issues/12929 maybe we should just ignore it, or treat it differently?

- [x] make sure `:messages` works

Feel free to give feedback while this is still in draft though, I would like to check that the approach seems agreeable too.