### PR TITLE
fix: avoid unnecessary rpcnotify that cause crashs (temporary fix)

### DIFF
--- a/runtime/lua/vscode/viewport.lua
+++ b/runtime/lua/vscode/viewport.lua
@@ -41,6 +41,20 @@ local function setup_viewport_changed()
         return
       end
       view_cache[view.winid] = view
+
+      --#region XXX: Temporary fix for #2165
+      -- Avoid unnecessary notifications
+      -- For highlighting #1976
+      local leftcol_changed = cache and cache.leftcol ~= view.leftcol
+      -- For cursor position #1971
+      local cursor_changed = cache
+        and (cache.lnum ~= view.lnum or cache.col ~= cache.col)
+        and api.nvim_get_mode().mode == "c"
+      if not leftcol_changed and not cursor_changed then
+        return
+      end
+      --#endregion
+
       fn.VSCodeExtensionNotify("viewport-changed", view)
     end,
   })


### PR DESCRIPTION
Temporary fix for #2165

It may not be completely avoided, but it can reduce the problem