### PR TITLE
Revert "Ease engines requirement"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "dependencies": {
                 "@jpwilliams/waitgroup": "^2.1.1",
                 "async-mutex": "^0.5.0",
-                "core-js": "^3.37.1",
                 "fast-myers-diff": "^3.2.0",
                 "grapheme-splitter": "^1.0.4",
                 "lodash": "^4.17.21",
@@ -24,7 +23,7 @@
                 "@types/mocha": "^10.0.7",
                 "@types/node": "^20.14.9",
                 "@types/sinonjs__fake-timers": "^8.1.5",
-                "@types/vscode": "1.89.0",
+                "@types/vscode": "^1.90.0",
                 "@vscode/test-electron": "^2.4.0",
                 "@vscode/vsce": "^2.29.0",
                 "eslint": "^8.57.0",
@@ -43,7 +42,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.89.0"
+                "vscode": "^1.87.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -611,9 +610,9 @@
             "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
         },
         "node_modules/@types/vscode": {
-            "version": "1.89.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.89.0.tgz",
-            "integrity": "sha512-TMfGKLSVxfGfoO8JfIE/neZqv7QLwS4nwPwL/NwMvxtAY2230H2I4Z5xx6836pmJvMAzqooRQ4pmLm7RUicP3A==",
+            "version": "1.90.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
+            "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2042,17 +2041,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
-        },
-        "node_modules/core-js": {
-            "version": "3.37.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-            "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "email": "devpieron@gmail.com"
     },
     "engines": {
-        "vscode": "^1.89.0"
+        "vscode": "^1.90.0"
     },
     "keywords": [
         "keybindings",
@@ -2157,7 +2157,7 @@
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.9",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@types/vscode": "1.89.0",
+        "@types/vscode": "^1.90.0",
         "@vscode/test-electron": "^2.4.0",
         "@vscode/vsce": "^2.29.0",
         "eslint": "^8.57.0",
@@ -2178,7 +2178,6 @@
     "dependencies": {
         "@jpwilliams/waitgroup": "^2.1.1",
         "async-mutex": "^0.5.0",
-        "core-js": "^3.37.1",
         "fast-myers-diff": "^3.2.0",
         "grapheme-splitter": "^1.0.4",
         "lodash": "^4.17.21",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-import "core-js/actual/array/find-last";
 import * as vscode from "vscode";
 
 import actions from "./actions";


### PR DESCRIPTION
Reverts vscode-neovim/vscode-neovim#2163

The singular support release has been completed, so we can roll back to our higher engine version