### PR TITLE
fix: handle `topline` in the `viewport-changed` event

### DIFF
--- a/runtime/lua/vscode/viewport.lua
+++ b/runtime/lua/vscode/viewport.lua
@@ -46,11 +46,13 @@ local function setup_viewport_changed()
       -- Avoid unnecessary notifications
       -- For highlighting #1976
       local leftcol_changed = cache and cache.leftcol ~= view.leftcol
+      -- For highlighting #2194
+      local topline_changed = cache and cache.topline ~= view.topline
       -- For cursor position #1971
       local cursor_changed = cache
         and (cache.lnum ~= view.lnum or cache.col ~= cache.col)
         and api.nvim_get_mode().mode == "c"
-      if not leftcol_changed and not cursor_changed then
+      if not leftcol_changed and not cursor_changed and not topline_changed then
         return
       end
       --#endregion


### PR DESCRIPTION
Fixes #2194 

**Problem:**
Our highlight manager needs the correct offset of the current viewport. When scrolling with the mouse during `incsearch`, the offset sometimes becomes outdated. This happens because the `viewport-changed` event isn't triggered, and the 'win_viewport' event occurs after the `grid-line` event. As a result, `this.lineCells` becomes incorrect. This is problematic because we rely on accurate `this.lineCells` data when computing line highlights.

https://github.com/vscode-neovim/vscode-neovim/blob/160d7aa03cd72c59ab1a1cfa6e40a591298a549a/src/highlights/grid_line_handler.ts#L87

https://github.com/vscode-neovim/vscode-neovim/blob/160d7aa03cd72c59ab1a1cfa6e40a591298a549a/src/highlight_manager.ts#L105

**Solution:**
Trigger `viewport-changed` to get a up-to-date viewport