### PR TITLE
fix(buffers): don't await window/buffer cleanup

### DIFF
--- a/runtime/lua/vscode/internal.lua
+++ b/runtime/lua/vscode/internal.lua
@@ -27,18 +27,19 @@ function M.scroll_viewport(vscode_topline, vscode_endline)
   end
 end
 
----Close windows
----@param wins number[]
-function M.close_windows(wins)
-  for _, win in ipairs(wins) do
+---@class CleanupOpts
+---@field windows number[]
+---@field buffers number[]
+
+---Close windows and buffers. This is done together in one call to reduce RPC
+---overhead, but still ensures buffer cleanup happens after window cleanup.
+---@param opts CleanupOpts
+function M.cleanup_windows_and_buffers(opts)
+  for _, win in ipairs(opts.windows) do
     pcall(vim.api.nvim_win_close, win, true)
   end
-end
 
----Delete buffers
----@param bufs number[]
-function M.delete_buffers(bufs)
-  for _, buf in ipairs(bufs) do
+  for _, buf in ipairs(opts.buffers) do
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
   end
 end

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -34,7 +34,7 @@ export class MessagesManager implements Disposable {
             this.redrawing = this.redrawing.then(() => this.handleFlush());
         });
 
-        this.disposables.push(redrawHandler, flushHandler);
+        this.disposables.push(redrawHandler, flushHandler, this.channel);
     }
 
     public dispose(): void {


### PR DESCRIPTION
Workaround for #2136

This isn't really fixing the problem, since I haven't been able to figure out the root cause yet, but this should at least allow the cleanup handler to move on and restore control to the user after a few seconds.

Also got rid of the lua layer for the window cleanup, since we can just call the nvim APIs directly without an extra indirection (I had hoped that itself might fix the issue but alas did not).

Also ensure messages output channel is cleaned up by registering its `dipsose()` call. I think I broke this in #2177 (oops!)

----

Edit: for testing, I've been driving this a version of this change to see if it helped the UX and it did in fact help! My editor remained usable after the timeout, instead of forcing me to restart the extension like I usually do:
```
2024-09-07 12:39:06.197 [warning] BufferManager: [Error: nvim_win_close timed out after 5000ms
	at /Users/ianchamberlain/.vscode/extensions/asvetliakov.vscode-neovim-1.18.10-dev/dist/extension.js:2:334915]
2024-09-07 12:39:06.198 [debug] BufferManager: Visible editor, viewColumn: 2, doc: file:///Users/ianchamberlain/Documents/Development/lix/build/subprojects/rnix-0.11.0/meson.build
2024-09-07 12:39:06.198 [debug] BufferManager: Visible editor, viewColumn: 1, doc: file:///Users/ianchamberlain/Documents/Development/lix/doc/manual/src/release-notes/rl-2.90.md
2024-09-07 12:39:06.198 [debug] BufferManager: Document not known, init in neovim
2024-09-07 12:39:06.199 [debug] BufferManager: Init buffer for 90, doc: file:///Users/ianchamberlain/Documents/Development/lix/doc/manual/src/release-notes/rl-2.90.md
```