### PR TITLE
fix: update link to #performance docs from vscode affinity prompt

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ function verifyExperimentalAffinity(): void {
 
     vscode.window
         .showWarningMessage(
-            "No affinity assigned to vscode-neovim. It is recommended to assign affinity for major performance improvements. Would you like to set default affinity? [Learn more](https://github.com/vscode-neovim/vscode-neovim#affinity)",
+            "No affinity assigned to vscode-neovim. It is recommended to assign affinity for major performance improvements. Would you like to set default affinity? [Learn more](https://github.com/vscode-neovim/vscode-neovim#performance)",
             "Yes",
             "Cancel",
         )


### PR DESCRIPTION
Recent improvements to the README.md changed some section titles, which changed the page anchors for deep linking.  This corrects a broken link in verifyExperimentalAffinity() when the default affinity is set.

In preparing this PR, I checked for any other links to "vscode-neovim#" or "README.md" within the codebase and didn't find any other links that might need updating.  