### PR TITLE
fix: prevent loop on OptionSet

### DIFF
--- a/runtime/lua/vscode/sync-options.lua
+++ b/runtime/lua/vscode/sync-options.lua
@@ -31,80 +31,76 @@ end
 ---@param lineNumbers "on"|"off"|"relative"
 local function set_number(win, lineNumbers)
   if lineNumbers == "relative" then
-    vim.wo[win].rnu = true
+    util.win_set_option(win, "relativenumber", true)
   elseif lineNumbers == "on" then
-    vim.wo[win].nu = true
-    vim.wo[win].rnu = false
+    util.win_set_option(win, "number", true)
+    util.win_set_option(win, "relativenumber", false)
   else
-    vim.wo[win].nu = false
-    vim.wo[win].rnu = false
+    util.win_set_option(win, "number", false)
+    util.win_set_option(win, "relativenumber", false)
   end
 end
 
 ---Handle changes from vscode
 ---Set nvim options
 ---@param buf number
----@param new_opts EditorOptions
----@param old_opts EditorOptions
-local function set_options(buf, new_opts, old_opts)
+---@param opts EditorOptions
+local function set_options(buf, opts)
   if not api.nvim_buf_is_valid(buf) then
     return
   end
 
-  api.nvim_buf_set_var(buf, "vscode_editor_options", new_opts)
+  api.nvim_buf_set_var(buf, "vscode_editor_options", opts)
 
-  if new_opts.tabSize ~= old_opts.tabSize then
-    vim.bo[buf].ts = new_opts.tabSize
-    vim.bo[buf].sw = new_opts.tabSize
-  end
-
-  if new_opts.insertSpaces ~= old_opts.insertSpaces then
-    vim.bo[buf].et = new_opts.insertSpaces
-  end
+  util.buf_set_option(buf, "tabstop", opts.tabSize)
+  util.buf_set_option(buf, "shiftwidth", opts.tabSize)
+  util.buf_set_option(buf, "expandtab", opts.insertSpaces)
 
   local win = api.nvim_get_current_win()
-  if api.nvim_win_get_buf(win) == buf and new_opts.lineNumbers ~= old_opts.lineNumbers then
-    set_number(win, new_opts.lineNumbers)
+  if api.nvim_win_get_buf(win) == buf then
+    set_number(win, opts.lineNumbers)
   end
 end
 
 ---Check changes from nvim
 ---Set vscode options
-local function check_options()
-  local opts = vim.b.vscode_editor_options
-  if not opts then -- should not happen
+local function _check_options()
+  local vscode_opts = vim.b.vscode_editor_options
+  if not vscode_opts then -- should not happen
     return
   end
 
   if not vim.b.vscode_editor_options_first_checked then --load the defaults
     vim.b.vscode_editor_options_first_checked = true
-    vim.bo.ts = opts.tabSize
-    vim.bo.sw = opts.tabSize
-    vim.bo.expandtab = opts.insertSpaces
-    set_number(0, opts.lineNumbers)
+    util.buf_set_option(0, "tabstop", vscode_opts.tabSize)
+    util.buf_set_option(0, "shiftwidth", vscode_opts.tabSize)
+    util.buf_set_option(0, "expandtab", vscode_opts.insertSpaces)
+    set_number(0, vscode_opts.lineNumbers)
     return
   end
 
+  local buf = api.nvim_get_current_buf()
   local ts, sw, et = vim.bo.ts, vim.bo.sw, vim.bo.et
+
   if sw ~= ts then
-    vim.bo.sw = ts -- must be the same
+    util.buf_set_option(buf, "shiftwidth", ts) -- must be the same
   end
 
-  local new_opts = {
+  local nvim_opts = {
     tabSize = ts,
     insertSpaces = et,
     lineNumbers = get_number_style(vim.wo.nu, vim.wo.rnu),
   }
 
-  if vim.deep_equal(new_opts, opts) then
+  if vim.deep_equal(nvim_opts, vscode_opts) then
     return
   end
 
-  vim.b.vscode_editor_options = new_opts
-  vscode.action("set_editor_options", { args = { api.nvim_get_current_buf(), new_opts } })
+  vim.b.vscode_editor_options = nvim_opts
+  vscode.action("set_editor_options", { args = { buf, nvim_opts } })
 end
 
-local check_options_debounced = util.debounce(check_options, 20)
+local check_options = util.debounce(_check_options, 20)
 
 local function process_modeline()
   if vim.b.vscode_editor_options_first_checked then
@@ -114,23 +110,20 @@ local function process_modeline()
         vim.bo.modeline = true
       end
       vim.cmd.doautocmd("CursorMoved") -- process modeline
-      check_options_debounced()
+      check_options()
     end
   end
 end
 
 function M.setup()
-  vscode.on("editor_options_changed", function(buf, new_opts)
-    local old_opts = vim.b[buf].vscode_editor_options or {}
-    set_options(buf, new_opts, old_opts)
-  end)
+  vscode.on("editor_options_changed", set_options)
   vscode.on("document_buffer_init", function(buf)
     if not api.nvim_buf_is_valid(buf) then
       return
     end
     local has, opts = pcall(api.nvim_buf_get_var, buf, "vscode_editor_options")
     if has then
-      set_options(buf, opts, {})
+      set_options(buf, opts)
       vim.defer_fn(process_modeline, 100)
     end
   end)
@@ -139,12 +132,12 @@ function M.setup()
   -- options
   api.nvim_create_autocmd({ "OptionSet" }, {
     group = group,
-    callback = check_options_debounced,
+    callback = check_options,
     pattern = { "tabstop", "shiftwidth", "expandtab", "number", "relativenumber" },
   })
   api.nvim_create_autocmd(
     { "CursorMoved", "BufWinEnter", "InsertEnter", "InsertLeave", "FileType" },
-    { group = group, callback = check_options_debounced }
+    { group = group, callback = check_options }
   )
   -- modeline
   api.nvim_create_autocmd({ "BufWinEnter", "WinEnter", "CursorMoved", "FileType" }, {

--- a/runtime/lua/vscode/util.lua
+++ b/runtime/lua/vscode/util.lua
@@ -97,4 +97,23 @@ else
   end
 end
 
+-- Wrapper for nvim_set_option_value that sets the option only if the value differs
+function M.set_option_value(name, value, opts)
+  opts = opts or {}
+  local current = api.nvim_get_option_value(name, opts)
+  if current ~= value then
+    api.nvim_set_option_value(name, value, opts)
+  end
+end
+
+-- Wrapper for set_option_value to set a buffer option
+function M.buf_set_option(buf, name, value)
+  return M.set_option_value(name, value, { buf = buf })
+end
+
+-- Wrapper for set_option_value to set a window option
+function M.win_set_option(win, name, value)
+  return M.set_option_value(name, value, { win = win })
+end
+
 return M


### PR DESCRIPTION
With the config below, entering and exiting Insert mode causes the `OptionSet` event to trigger repeatedly, leading to a loop.

```lua
vim.opt.number = true

vim.api.nvim_create_autocmd("InsertEnter", {
  pattern = "*",
  callback = function()
    vim.wo.relativenumber = true
  end,
})

vim.api.nvim_create_autocmd("InsertLeave", {
  pattern = "*",
  callback = function()
    vim.wo.relativenumber = false
  end,
})
```

Demonstration Videos:

## Before
[Link](https://1drv.ms/v/s!AkmEvT_Y9oQ6gcJBEggsXLzWsZJP_g?e=3l06EI)

The `OptionSet` keeps triggering.
## After
[Link](https://1drv.ms/v/s!AkmEvT_Y9oQ6gcJA16bZRkHnPX7qGQ?e=82s8Vb)

Note: This may not fully address #2267(not sure this is the root cause, in my case, vscode-neovim is not locking up in insert mode), but it does fix the looping OptionSet event in this scenario.