### PR TITLE
fix(windows): backslashes in path settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,10 +10,8 @@ import {
     workspace,
 } from "vscode";
 
-import { CTRL_KEYS, EXT_ID, EXT_NAME } from "./constants";
-import { VSCodeContext, disposeAll } from "./utils";
-
-const isWindows = process.platform === "win32";
+import { CTRL_KEYS, EXT_ID, EXT_NAME, isWindows } from "./constants";
+import { VSCodeContext, disposeAll, toSlashes } from "./utils";
 
 type SettingPrefix = "neovimExecutablePaths" | "neovimInitVimPaths"; //this needs to be aligned with setting names in package.json
 
@@ -76,15 +74,9 @@ export class Config implements Disposable {
         //https://github.com/microsoft/vscode/blob/master/src/vs/base/common/platform.ts#L63
         let platform = process.platform as "win32" | "darwin" | "linux";
         platform = this.useWsl && platform === "win32" ? "linux" : platform;
-        return this.cfg.get(`${settingPrefix}.${platform}`);
-    }
-
-    private getNeovimPath(): string {
-        return this.getSystemSpecificSetting("neovimExecutablePaths") ?? "nvim";
-    }
-
-    private getNeovimInitPath(): string | undefined {
-        return this.getSystemSpecificSetting("neovimInitVimPaths");
+        const value = this.cfg.get<string>(`${settingPrefix}.${platform}`);
+        const isWinPath = platform === "win32";
+        return value === undefined ? value : toSlashes(value, isWinPath);
     }
 
     get highlights(): { [key: string]: ThemableDecorationRenderOptions } {
@@ -121,10 +113,10 @@ export class Config implements Disposable {
         return this.cfg.get("neovimViewportHeightExtend", 1);
     }
     get neovimPath() {
-        return this.getNeovimPath();
+        return this.getSystemSpecificSetting("neovimExecutablePaths") || "nvim";
     }
     get neovimInitPath() {
-        return this.getNeovimInitPath() ?? "";
+        return this.getSystemSpecificSetting("neovimInitVimPaths") ?? "";
     }
     get clean() {
         return this.cfg.get("neovimClean", false);
@@ -133,7 +125,7 @@ export class Config implements Disposable {
         return this.cfg.get("NVIM_APPNAME", "");
     }
     get logPath() {
-        return this.cfg.get("logPath", "");
+        return toSlashes(this.cfg.get("logPath", ""), isWindows);
     }
     get outputToConsole() {
         return this.cfg.get("logOutputToConsole", false);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export const NVIM_MIN_VERSION = "0.10.0";
 
+export const isWindows = process.platform === "win32";
+
 export const GlyphChars = {
     COMMAND: "\u2318",
     SEARCH_FORWARD: "\u27f3",

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -11,7 +11,7 @@ import { BufferManager } from "./buffer_manager";
 import { CommandLineManager } from "./cmdline_manager";
 import { CommandsController } from "./commands_controller";
 import { config } from "./config";
-import { NVIM_MIN_VERSION } from "./constants";
+import { isWindows, NVIM_MIN_VERSION } from "./constants";
 import { CursorManager } from "./cursor_manager";
 import { DocumentChangeManager } from "./document_change_manager";
 import { eventBus } from "./eventBus";
@@ -20,7 +20,7 @@ import { createLogger } from "./logger";
 import { MessagesManager } from "./messages_manager";
 import { ModeManager } from "./mode_manager";
 import { TypingManager } from "./typing_manager";
-import { disposeAll, findLastEvent, VSCodeContext, wslpath } from "./utils";
+import { disposeAll, findLastEvent, toSlashes, VSCodeContext, wslExe, wslpath } from "./utils";
 import { ViewportManager } from "./viewport_manager";
 
 interface RequestResponse {
@@ -165,7 +165,10 @@ export class MainController implements vscode.Disposable {
     }
 
     private buildSpawnArgs(): [string, string[]] {
-        let extensionPath = this.extContext.extensionPath.replace(/\\/g, "\\\\");
+        let extensionPath = toSlashes(
+            this.extContext.extensionPath,
+            isWindows, // Always a Windows path on win32 (regardless of WSL).
+        );
         if (config.useWsl) {
             extensionPath = wslpath(extensionPath);
         }
@@ -176,7 +179,7 @@ export class MainController implements vscode.Disposable {
         const args = [];
 
         if (config.useWsl) {
-            args.push("C:\\Windows\\system32\\wsl.exe");
+            args.push(wslExe);
             if (config.wslDistribution.length) {
                 args.push("-d", config.wslDistribution);
             }
@@ -201,7 +204,7 @@ export class MainController implements vscode.Disposable {
             "--embed",
             // Initialize vscode neovim modules
             "--cmd",
-            `source ${neovimPreScriptPath}`,
+            `execute 'source' fnameescape('${neovimPreScriptPath.replace(/'/g, "''")}')`,
         );
 
         if (parseInt(process.env.NEOVIM_DEBUG || "", 10) === 1) {
@@ -215,9 +218,7 @@ export class MainController implements vscode.Disposable {
 
         if (config.clean) {
             args.push("--clean");
-        }
-        // #1162
-        if (!config.clean && config.neovimInitPath) {
+        } else if (config.neovimInitPath) {
             args.push("-u", config.neovimInitPath);
         }
         if (config.NVIM_APPNAME) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -11,3 +11,22 @@ export async function fileExists(uri: Uri): Promise<boolean> {
     }
     return true;
 }
+
+/**
+ * The `\\?\` prefix that opts a Win32 path out of normalization. Forward slashes are not
+ * recognized inside such a path, so it must be left alone.
+ */
+const verbatimPrefix = "\\\\?\\";
+
+/**
+ * Rewrites a Windows path to use "/" separators. Both Win32 and Nvim accept "/", which works with Nvim features without
+ * needing to escape "\" slashes.
+ *
+ * @param isWinPath `path` is a Windows path (as opposed to e.g. a WSL setting, which is a Linux path even on win32).
+ */
+export function toSlashes(path: string, isWinPath: boolean): string {
+    if (!isWinPath || path.startsWith(verbatimPrefix)) {
+        return path;
+    }
+    return path.replace(/\\/g, "/");
+}

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -21,6 +21,9 @@ import { config } from "../config";
 import { convertByteNumToCharNum, convertCharNumToByteNum } from "./text";
 import { ManualPromise } from "./async";
 
+/** Full path, because "wsl.exe" may not be on PATH in the extension host's environment. */
+export const wslExe = "C:/Windows/system32/wsl.exe";
+
 /**
  * Stores last changes information for dot repeat
  */
@@ -237,7 +240,7 @@ export function rangesToSelections(
  */
 export const wslpath = (path: string) => {
     const distroArgs = config.wslDistribution.length ? ["-d", config.wslDistribution] : [];
-    const result = spawnSync("C:\\Windows\\system32\\wsl.exe", [...distroArgs, "wslpath", path], {
+    const result = spawnSync(wslExe, [...distroArgs, "wslpath", path], {
         encoding: "utf-8",
     });
     if (result.error) {


### PR DESCRIPTION
# Problem:
With this setting:

    "vscode-neovim.neovimInitVimPaths.win32": "C:\\Users\\USER\\AppData\\Local\\nvim\\init.lua",
    "vscode-neovim.neovimExecutablePaths.win32": "C:\\Program Files\\Neovim\\bin\\nvim.exe"

The `-u` argument passed to Nvim is not escaped:

    [info] MainController: Starting nvim: …\nvim.exe -N --embed --cmd source c:\\Users\\USER\\… -u C:\Users\USER\AppData\Local\nvim\init.lua

# Solution:
Replace the `\` slashes with `/`. There is zero reason to use `\` slashes on Windows.

fix https://github.com/vscode-neovim/vscode-neovim/issues/2285 (note: the premise of that issue is incorrect)