### PR TITLE
feat(startup): improve Nvim version check

### DIFF
--- a/runtime/vscode-neovim.vim
+++ b/runtime/vscode-neovim.vim
@@ -20,40 +20,6 @@ end
 vim.opt.rtp:prepend(vim.g.vscode_neovim_runtime)
 EOF
 
-" Check version
-lua << EOF
-local MIN_VERSION = vim.g.vscode_nvim_min_version
-
-local cmp = -1 ---@type -1|0|1
-local prerelease = false
-if vim.version and vim.version.parse then
-  local v = vim.version()
-  local curr = { v.major, v.minor, v.patch }
-  local min = vim.version.parse(MIN_VERSION)
-  cmp = vim.version.cmp(curr, min)
-  prerelease = not not v.prerelease
-end
-
-local warn = true
-local msgs = {
-  ("vscode-neovim requires nvim version %s or higher."):format(MIN_VERSION),
-  "Install the [latest stable version](https://github.com/neovim/neovim/releases/latest).",
-}
-if cmp < 0 then
-  -- nothing
-elseif cmp == 0 and prerelease then
-  table.insert(msgs, 2, ("Current version is a **prerelease** of %s.").format(MIN_VERSION))
-else
-  warn = false
-end
-
-if warn then
-  vim.rpcnotify(vim.g.vscode_channel, "vscode-action", "eval", {
-    args = { "vscode.window.showErrorMessage(args)", table.concat(msgs, " ") },
-  })
-end
-EOF
-
 " Load altercmd
 " {{{
 " altercmd - Alter built-in Ex commands by your own ones

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,10 +47,20 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
         await plugin.init();
     } catch (e) {
         vscode.window
-            .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart")
+            .showErrorMessage(
+                `[Failed to start nvim] ${e instanceof Error ? e.message : e}`,
+                "Update Nvim",
+                "View Logs",
+                "Restart",
+            )
             .then((value) => {
-                if (value === "Restart") {
-                    vscode.commands.executeCommand("vscode-neovim.restart");
+                if (value === "Update Nvim") {
+                    void vscode.env.openExternal(vscode.Uri.parse("https://github.com/neovim/neovim/releases/latest"));
+                } else if (value === "View Logs") {
+                    void vscode.commands.executeCommand("workbench.panel.output.focus");
+                    logger.outputChannel()?.show();
+                } else if (value === "Restart") {
+                    void vscode.commands.executeCommand("vscode-neovim.restart");
                 }
             });
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,6 +8,7 @@ import { disposeAll } from "./utils";
 import { EXT_NAME } from "./constants";
 
 export interface ILogger {
+    outputChannel(): vscode.LogOutputChannel | undefined;
     trace(...args: any[]): void;
     debug(...args: any[]): void;
     info(...args: any[]): void;
@@ -37,7 +38,7 @@ export class Logger implements Disposable {
     private filePath: string | undefined;
     private level!: vscode.LogLevel;
     private logToConsole!: boolean;
-    private outputChannel!: vscode.LogOutputChannel;
+    private outputChannel?: vscode.LogOutputChannel;
 
     /**
      * Setup logging for the extension.
@@ -160,6 +161,7 @@ export class Logger implements Disposable {
         const logger = this.loggers.has(scope)
             ? this.loggers.get(scope)!
             : {
+                  outputChannel: () => this.outputChannel,
                   trace: (...args: any[]) => {
                       if (this.level <= vscode.LogLevel.Trace) {
                           this.log(vscode.LogLevel.Trace, scope, logToOutputChannel, args);


### PR DESCRIPTION
## Problem:
Version check is spread out across two different parts of the codebase. https://github.com/vscode-neovim/vscode-neovim/issues/2234

## Solution:
- Use the new `paths` feature of `findNvim()` and use that to check the Nvim version, even when the user has configured a specific Nvim path.
- Improve the message wording.
- Show a `View Logs` button.

![image](https://github.com/user-attachments/assets/fb8fa5b7-6a6b-44e6-91bd-c97eb918c3c3)

![image](https://github.com/user-attachments/assets/5cd17e89-af91-4810-b019-ce499be27b68)


