### PR TITLE
fix: exit visual mode on mouse click or selection cancel

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -369,8 +369,10 @@ export class CursorManager implements Disposable {
             );
 
             if (selection.isEmpty) {
-                // exit visual mode when clicking elsewhere
-                if (this.main.modeManager.isVisualMode && kind === TextEditorSelectionChangeKind.Mouse)
+                // This logic only executes in non-insert mode. In this case, the primary selection is empty,
+                // but other selections are not. This situation usually occurs due to block selection synchronized from neovim.
+                // In this case, we only need to update the cursor position without exiting visual mode.
+                if (this.main.modeManager.isVisualMode && editor.selections.every((s) => s.isEmpty))
                     await this.client.input("<Esc>");
                 await this.updateNeovimCursorPosition(editor, selection.active);
             } else {

--- a/src/test/integ/integrationUtils.ts
+++ b/src/test/integ/integrationUtils.ts
@@ -227,22 +227,14 @@ export async function assertContent(
     if (!editor) {
         throw new Error("No active editor");
     }
+
+    options.vsCodeCursor = options.vsCodeCursor ?? options.cursor;
+    options.neovimCursor = options.neovimCursor ?? options.cursor;
+
     try {
         if (options.content) {
             assert.deepEqual(await getCurrentBufferContents(client), options.content, "Neovim buffer content is wrong");
             assert.deepEqual(getVSCodeContent(), options.content, "VSCode content is wrong");
-        }
-        if (options.cursor) {
-            assert.deepEqual(
-                getVScodeCursor(editor),
-                options.cursor,
-                `Cursor position in vscode - ${options.cursor[0]}:${options.cursor[1]}`,
-            );
-            assert.deepEqual(
-                await getNeovimCursor(client),
-                options.cursor,
-                `Cursor position in neovim - ${options.cursor[0]}:${options.cursor[1]}`,
-            );
         }
         if (options.neovimCursor) {
             assert.deepEqual(

--- a/src/test/integ/visual-modes.test.ts
+++ b/src/test/integ/visual-modes.test.ts
@@ -1,5 +1,5 @@
 import { NeovimClient } from "neovim";
-import vscode from "vscode";
+import vscode, { commands } from "vscode";
 
 import {
     attachTestNvimClient,
@@ -602,6 +602,30 @@ describe("Visual modes test", () => {
         await assertContent(
             {
                 content: [""],
+            },
+            client,
+        );
+    });
+
+    it("Exit visual mode when canceling selection in VSCode", async () => {
+        await openTextDocument({ content: "test" });
+
+        await sendVSCodeKeys("viw");
+        await assertContent(
+            {
+                mode: "v",
+                neovimCursor: [0, 3],
+                vsCodeCursor: [0, 4],
+            },
+            client,
+        );
+
+        commands.executeCommand("cancelSelection");
+        await wait(200);
+        await assertContent(
+            {
+                mode: "n",
+                cursor: [0, 3],
             },
             client,
         );


### PR DESCRIPTION
fix: Fix assertContent cursor position parameter

fix #2299

@theol0403 Previously, the visual model only exited after a mouse click. Was there any special consideration for this?