### PR TITLE
Autofix: bug: visual mode remains after canceling vscode search

### DIFF
--- a/src/mode_manager.ts
+++ b/src/mode_manager.ts
@@ -104,6 +104,7 @@ export class ModeManager implements Disposable {
 
     private handleModeChanged([mode]: EventBusData<"mode-changed">) {
         logger.debug(`Changing mode to ${mode}`);
+        const prevMode = this.mode;
         this.mode = new Mode(mode);
         if (!this.isInsertMode && this.isRecording) {
             this.isRecording = false;
@@ -111,6 +112,13 @@ export class ModeManager implements Disposable {
         }
         VSCodeContext.set("neovim.mode", this.mode.name);
         logger.debug(`Setting mode context to ${this.mode.name}`);
+
+        // Handle transition from visual to normal mode
+        if (prevMode.isVisual && this.mode.isNormal) {
+            logger.debug("Exiting visual mode");
+            VSCodeContext.set("neovim.isVisualMode", false);
+        }
+
         this.eventEmitter.fire(null);
     }
 


### PR DESCRIPTION
I have updated the `handleModeChanged` method in the `ModeManager` class to properly handle the transition from visual mode to normal mode when the VSCode search is canceled. This change ensures that the Neovim visual mode is correctly exited when the user cancels the VSCode search. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission