### PR TITLE
ci: dependabot should skip `@types/vscode`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
-          interval: "monthly"
+          interval: "weekly"
+      ignore:
+          # @types/vscode must match our declared `engines.vscode` (in package.json).
+          - dependency-name: "@types/vscode"
       groups:
           dev-deps:
               dependency-type: "development"
@@ -18,4 +21,4 @@ updates:
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-          interval: "monthly"
+          interval: "weekly"


### PR DESCRIPTION
## Problem:
dependabot autoupdates `@types/vscode` as part of the "dev-deps" group, which causes CI to fail unless we bump `engines.vscode`. This would require us to aggressively bump our minimum supported vscode version:

    Error: @types/vscode ^1.95.0 greater than engines.vscode ^1.90.0. Either upgrade engines.vscode or use an older @types/vscode version
    Error: Process completed with exit code 1.

## Solution:
Tell dependabot to ignore `@types/vscode`.

TODO: put it in a separate "group" so that dependabot creates a separate PR for it, which we can merge as needed.