### PR TITLE
Disable escape key to leave insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,13 @@ Set by `editorLangIdExclusions`.
 Disable keybindings defined by this extension in certain filetypes. Please note that this will not affect all
 keybindings.
 
+#### Disable normal mode on escape
+
+Set by `leaveInsertModeOnEscape`.
+
+Do not enter normal mode when Escape key is pressed (or over-typed) while in insert mode. A composite escape keys
+combination (see [Composite escape keys](#composite-escape-keys)) is required to actually use Neovim.
+
 #### Remove other vscode or passthrough keybindings
 
 If the above configuration flags do not provide enough control, you can remove the keybindings by editing your

--- a/package-lock.json
+++ b/package-lock.json
@@ -2224,10 +2224,11 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -5029,12 +5030,13 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,11 @@
                         "w"
                     ]
                 },
+                "vscode-neovim.leaveInsertModeOnEscape": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Escape key will leave insert mode to enter normal mode"
+                },
                 "vscode-neovim.editorLangIdExclusions": {
                     "type": "array",
                     "uniqueItems": true,
@@ -483,7 +488,7 @@
             {
                 "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && editorLangId not in neovim.editorLangIdExclusions && neovim.mode != normal"
+                "when": "editorTextFocus && neovim.init && editorLangId not in neovim.editorLangIdExclusions && neovim.mode != normal && (neovim.mode != insert || neovim.leaveInsertModeOnEscape)"
             },
             {
                 "command": "vscode-neovim.send",

--- a/scripts/keybindings/1_common.cjs
+++ b/scripts/keybindings/1_common.cjs
@@ -51,7 +51,7 @@ const keybinds = [
     {
         command: "vscode-neovim.escape",
         key: "Escape",
-        when: and("neovim.mode != normal"),
+        when: and("neovim.mode != normal", "(neovim.mode != insert || neovim.leaveInsertModeOnEscape)"),
     },
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,7 @@ export class Config implements Disposable {
             VSCodeContext.set(`neovim.ctrlKeysNormal.${k}`, ctrlKeysNormalMode.includes(k));
             VSCodeContext.set(`neovim.ctrlKeysInsert.${k}`, ctrlKeysInsertMode.includes(k));
         });
+        VSCodeContext.set(`neovim.leaveInsertModeOnEscape`, this.leaveInsertModeOnEscape);
 
         if (!e) return;
         const requireRestart = this.requireRestartConfigs.find((c) => e.affectsConfiguration(c));
@@ -96,6 +97,9 @@ export class Config implements Disposable {
     }
     get ctrlKeysInsertMode(): string[] {
         return this.cfg.get<string[]>("ctrlKeysForInsertMode")!;
+    }
+    get leaveInsertModeOnEscape(): boolean {
+        return this.cfg.get<boolean>("leaveInsertModeOnEscape")!;
     }
     get editorLangIdExclusions(): string[] {
         return this.cfg.get<string[]>("editorLangIdExclusions")!;


### PR DESCRIPTION
I find myself hitting Escape multiple times to dismiss an action (ie: search dialog in VSCode): it's bad habit but it assures me that I haven't missed the key press. While I like to use this extension to execute Neovim normal mode commands, I want to be able to explicitly enter normal mode with a dedicated key mapping that cannot be unintentionally used while working in insert mode.
Generally speaking, I like the idea that this extension can be adopted by people who are familiar with VSCode and kinda want to transition gradually into Neovim; so, in the same way it's actually possible to disable Ctrl keys via a config setting, I would suggest to do the same with Escape