### PR TITLE
fix(defaults): keybindings for ctrl+[BracketLeft], ctrl+[BracketRight] as alternatives for ctrl+[ and ctrl+].

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ tab.
   this open Terminal and execute the following command:
   `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`.
 - To fix the remapped escape key not working in Linux, set `"keyboard.dispatch": "keyCode"`.
+- Two VSCode developer commands are useful for keybindings debugging:
+    - `Developer: Toggle Keyboard Shortcuts Troubleshooting` for tracing VSCode emitted keypresses and their processing
+      via defined keybindings.
+    - `Developer: Inspect Key Mapping` for getting the recognized mappings for the current keyboard layout inside
+      VSCode.
 
 ### Performance
 

--- a/package.json
+++ b/package.json
@@ -467,6 +467,11 @@
             },
             {
                 "command": "vscode-neovim.escape",
+                "key": "ctrl+[BracketLeft]",
+                "when": "editorTextFocus && neovim.init && editorLangId not in neovim.editorLangIdExclusions"
+            },
+            {
+                "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
                 "when": "editorTextFocus && neovim.init && editorLangId not in neovim.editorLangIdExclusions && neovim.mode == normal && neovim.ctrlKeysNormal.c && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused && !findWidgetVisible && !notificationCenterVisible"
             },
@@ -739,6 +744,12 @@
             },
             {
                 "command": "vscode-neovim.send",
+                "key": "ctrl+[BracketRight]",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal.[BracketRight] && editorLangId not in neovim.editorLangIdExclusions",
+                "args": "<C-]>"
+            },
+            {
+                "command": "vscode-neovim.send",
                 "key": "ctrl+right",
                 "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal.right && editorLangId not in neovim.editorLangIdExclusions",
                 "args": "<C-right>"
@@ -933,6 +944,12 @@
                 "command": "vscode-neovim.send",
                 "key": "ctrl+]",
                 "when": "editorTextFocus && neovim.init && neovim.mode == insert && neovim.ctrlKeysInsert.] && editorLangId not in neovim.editorLangIdExclusions",
+                "args": "<C-]>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+[BracketRight]",
+                "when": "editorTextFocus && neovim.init && neovim.mode == insert && neovim.ctrlKeysInsert.[BracketRight] && editorLangId not in neovim.editorLangIdExclusions",
                 "args": "<C-]>"
             },
             {
@@ -1424,6 +1441,12 @@
             {
                 "command": "vscode-neovim.send-cmdline",
                 "key": "ctrl+r ctrl+]",
+                "when": "neovim.init && neovim.mode == cmdline",
+                "args": "<C-r><C-]>"
+            },
+            {
+                "command": "vscode-neovim.send-cmdline",
+                "key": "ctrl+r ctrl+[BracketRight]",
                 "when": "neovim.init && neovim.mode == cmdline",
                 "args": "<C-r><C-]>"
             },

--- a/scripts/keybindings/1_common.cjs
+++ b/scripts/keybindings/1_common.cjs
@@ -9,6 +9,11 @@ const keybinds = [
     },
     {
         command: "vscode-neovim.escape",
+        key: "ctrl+[BracketLeft]", // fix ctrl+[ mapping on macOS non-US keyboard layout
+        when: and(),
+    },
+    {
+        command: "vscode-neovim.escape",
         key: "ctrl+c",
         when: and(
             "neovim.mode == normal",

--- a/scripts/keybindings/2_normal_mode.cjs
+++ b/scripts/keybindings/2_normal_mode.cjs
@@ -27,7 +27,16 @@ const when =
 // Generate Ctrl keys
 // const defaults = "abdefhijklortuvwxyz/]";
 // ! ctrl+c is special and is defined in common
-const ctrlKeys = [..."abdefghijklmnopqrstuvwxyz/]", "right", "left", "up", "down", "backspace", "delete"];
+const ctrlKeys = [
+    ..."abdefghijklmnopqrstuvwxyz/]",
+    "[BracketRight]",
+    "right",
+    "left",
+    "up",
+    "down",
+    "backspace",
+    "delete",
+];
 
 ctrlKeys.forEach((k) => {
     let cmd = "vscode-neovim.send";

--- a/scripts/keybindings/3_insert_mode.cjs
+++ b/scripts/keybindings/3_insert_mode.cjs
@@ -5,28 +5,30 @@ const [add, keybinds] = addKeybinds();
 // Generate Ctrl keys
 // const defaults = "adhjortuw";
 // ! ctrl+c is special and is defined in common
-[..."abdefghijklmnopqrstuvwxyz/]", "right", "left", "up", "down", "backspace", "delete"].forEach((k) => {
-    let cmd = "vscode-neovim.send";
-    let key = `ctrl+${k}`;
-    let args = key2arg(key);
-    let when = [
-        "editorTextFocus",
-        "neovim.init",
-        "neovim.mode == insert",
-        `neovim.ctrlKeysInsert.${k}`,
-        "editorLangId not in neovim.editorLangIdExclusions",
-    ].join(" && ");
+[..."abdefghijklmnopqrstuvwxyz/]", "[BracketRight]", "right", "left", "up", "down", "backspace", "delete"].forEach(
+    (k) => {
+        let cmd = "vscode-neovim.send";
+        let key = `ctrl+${k}`;
+        let args = key2arg(key);
+        let when = [
+            "editorTextFocus",
+            "neovim.init",
+            "neovim.mode == insert",
+            `neovim.ctrlKeysInsert.${k}`,
+            "editorLangId not in neovim.editorLangIdExclusions",
+        ].join(" && ");
 
-    switch (k) {
-        case "o":
-            cmd = "vscode-neovim.escape";
-            break;
-        case "r":
-            cmd = "vscode-neovim.send-blocking";
-            break;
-    }
+        switch (k) {
+            case "o":
+                cmd = "vscode-neovim.escape";
+                break;
+            case "r":
+                cmd = "vscode-neovim.send-blocking";
+                break;
+        }
 
-    add(key, when, args, cmd);
-});
+        add(key, when, args, cmd);
+    },
+);
 
 module.exports = keybinds;

--- a/scripts/keybindings/4_cmdline.cjs
+++ b/scripts/keybindings/4_cmdline.cjs
@@ -63,7 +63,7 @@ for (const key in shifts) {
 }
 
 // ctrl+r {ctrl+key, key}
-[..."abcdefghijklmnopqrstuvwxyz]"].forEach((k) => {
+[..."abcdefghijklmnopqrstuvwxyz]", "[BracketRight]"].forEach((k) => {
     let key = `ctrl+${k}`;
     let args = key2arg(key);
     add(`ctrl+r ${key}`, `<C-r>${args}`);

--- a/scripts/keybindings/util.cjs
+++ b/scripts/keybindings/util.cjs
@@ -3,6 +3,8 @@ const keymap = {
     delete: "Del",
     shift: "S",
     ctrl: "C",
+    "[bracketleft]": "[",
+    "[bracketright]": "]",
 };
 
 /**


### PR DESCRIPTION
TLDR: This fixes an issue on macOS and non-US keyboard layout (e.g. Czech), where the corresponding Ctrl code is not correctly recognized. (discussed in #1875).

Long version:
When pressing `Ctrl+<key right to P>` on a keyboard with non-US layout (e.g. Czech), which would be `Ctrl+[` on US layout, this key maps to `<C-[>` in `vim` and `neovim` on Windows and macOS.

This was not working in `vscode-neovim` on macOS (but did work in Windows) for some reason which most likely stems from internal VSCode implementation and how VSCode does (or does not) handle the localized keyboard layouts in particular OS. The observed difference is noted [here](https://github.com/microsoft/vscode/issues/237533).

It appears that both VSCode versions (on macOS and Windows) maps the aforementioned keypress to `ctrl+[BracketLeft]` but only Windows version is then able to pass it further to the extension as `ctrl+[`.

This patch adds an explicit keybinding for `ctrl+[BracketLeft]` (and following the same logic for `ctrl+[BracketRight]`) to workaround the VSCode discrepancy in the two OSes.