### PR TITLE
Fix #2368: Exclude editors without view columns to avoid random nvim crashes

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -252,7 +252,7 @@ export class BufferManager implements Disposable {
     }
 
     public isExternalTextDocument(textDoc: TextDocument): boolean {
-        if (textDoc.uri.scheme !== "file") {
+        if (textDoc.uri.scheme === "output") {
             return true;
         }
         return this.externalTextDocuments.has(textDoc);
@@ -764,9 +764,10 @@ export class BufferManager implements Disposable {
         const bufname = await this.bufnameForTextDocument(document);
 
         const modifiable = !this.isExternalTextDocument(document);
-        const dirty = this.isExternalTextDocument(document) ? false : document.isDirty;
-        const uri_str = modifiable ? document.uri.toString() : undefined;
-        const uri_data = modifiable ? document.uri.toJSON() : undefined;
+        const isFile = document.uri.scheme === "file";
+        const dirty = isFile ? document.isDirty : false;
+        const uri_str = isFile ? document.uri.toString() : undefined;
+        const uri_data = isFile ? document.uri.toJSON() : undefined;
 
         await actions.lua("init_document_buffer", {
             buf: bufId,

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { randomUUID } from "crypto";
 
 import { debounce } from "lodash";
 import { Buffer, NeovimClient } from "neovim";
@@ -796,7 +797,8 @@ export class BufferManager implements Disposable {
             return config.useWsl ? actions.lua<string>("wslpath", uri.fsPath) : uri.fsPath;
         }
         // We don't care about the name of the buffer if it's not a file
-        return uri.toString();
+        // use UUID instead of using uri which could be very long for uri's from editors like github copilot.
+        return randomUUID().toString();
     }
 
     /**

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -765,13 +765,15 @@ export class BufferManager implements Disposable {
 
         const modifiable = !this.isExternalTextDocument(document);
         const dirty = this.isExternalTextDocument(document) ? false : document.isDirty;
+        const uri_str = modifiable ? document.uri.toString() : undefined;
+        const uri_data = modifiable ? document.uri.toJSON() : undefined;
 
         await actions.lua("init_document_buffer", {
             buf: bufId,
             bufname: bufname,
             lines: lines,
-            uri: document.uri.toString(),
-            uri_data: document.uri.toJSON(),
+            uri: uri_str,
+            uri_data: uri_data,
             editor_options: makeEditorOptionsVariable(editor?.options),
             modifiable: modifiable,
             modified: dirty,

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -576,7 +576,7 @@ export class BufferManager implements Disposable {
                 this.isLayoutOutdated = false;
                 const token = this.syncLayoutSource?.token;
 
-                const visibleEditors = [...window.visibleTextEditors];
+                const visibleEditors = [...window.visibleTextEditors].filter((e) => e.viewColumn !== undefined);
                 const activeEditor = window.activeTextEditor;
 
                 if (token?.isCancellationRequested) continue;

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -678,7 +678,7 @@ export class BufferManager implements Disposable {
     }
 
     private async syncActiveEditor(activeEditor?: TextEditor): Promise<void> {
-        if (!activeEditor) return;
+        if (!activeEditor || !activeEditor.viewColumn) return;
         const winId = this.textEditorToWinId.get(activeEditor);
         const uri = activeEditor.document.uri;
         if (!winId) {


### PR DESCRIPTION
### Description
This changes avoid starting nvim for editors which lacks a view column, for editors such as 

- Github Copilot code suggestions in chat and edits
- Diff editors

cause random crashes as described in #2368, It seems one common pattern in such editors are lack of a view column. So this change tries to avoid starting nvim for such code editors

### Testing
I have run this patch for a week in my daily driver machine and ensured that with this patch I have not come across any random nvim crashes as before.