### PR TITLE
fix: do not open the file automatically after writing

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -545,9 +545,12 @@ export class BufferManager implements Disposable {
 
         const text = document.getText();
         const bytes = new TextEncoder().encode(text);
-        await workspace.fs.writeFile(saveUri, bytes);
-        const doc = await workspace.openTextDocument(saveUri);
-        await window.showTextDocument(doc);
+        try {
+            await workspace.fs.writeFile(saveUri, bytes);
+            window.setStatusBarMessage(`Saved ${saveUri.fsPath}`, 3000);
+        } catch (error) {
+            window.showErrorMessage(`Failed to save ${saveUri.fsPath}: ${error}`);
+        }
     }
 
     // #region Sync layout


### PR DESCRIPTION
Neovim doesn't auto-open saved files; providing a save confirmation would better meet most users' needs.

- close #2384
