### PR TITLE
fix: force `winborder` to `none`

### DIFF
--- a/runtime/lua/vscode/force-options.lua
+++ b/runtime/lua/vscode/force-options.lua
@@ -39,6 +39,10 @@ local function force_global_options()
   vim.opt.ruler = false
   vim.opt.colorcolumn = nil
 
+  if vim.fn.exists("&winborder") == 1 then
+    vim.opt.winborder = ""
+  end
+
   forceoptions(vim.opt)
 end
 


### PR DESCRIPTION
fix #2441 

This option interferes with highlighting, and we don’t need it.