### PR TITLE
fix: ignore editors without `ViewColumn` in nvim-0.10

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -629,7 +629,13 @@ export class BufferManager implements Disposable {
                     this.excludeEditorsWithoutViewColumn = nvim0_10;
                 }
                 const visibleEditors = this.excludeEditorsWithoutViewColumn
-                    ? [...window.visibleTextEditors].filter((e) => e.viewColumn != null || e === activeEditor)
+                    ? [...window.visibleTextEditors].filter(
+                          (e) =>
+                              e.viewColumn != null ||
+                              e === activeEditor ||
+                              // These two schemes are special cases where we want to sync
+                              ["output", "vscode-notebook-cell"].includes(e.document.uri.scheme),
+                      )
                     : [...window.visibleTextEditors];
 
                 if (token?.isCancellationRequested) continue;

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -619,7 +619,11 @@ export class BufferManager implements Disposable {
 
                 const activeEditor = window.activeTextEditor;
 
-                // NOTE: See #2407
+                // NOTE: Issue #2407 is caused by a current bug in nvim when
+                // handling RPC requests. https://github.com/neovim/neovim/issues/31316
+                // To mitigate it, we exclude editors without a ViewColumn
+                // (e.g., input boxes, chat code blocks) to reduce sync operations.
+                // These editors are usually temporary, so the impact is minimal.
                 if (this.excludeEditorsWithoutViewColumn == null) {
                     const nvim0_10 = (await this.client.call("has", "nvim-0.10")) === 1;
                     this.excludeEditorsWithoutViewColumn = nvim0_10;


### PR DESCRIPTION
Ignore editors without a ViewColumn in Neovim 0.10 and above to avoid issues caused by too many editors leading to RPC problems.

At present, [this](https://github.com/vscode-neovim/vscode-neovim/pull/2394/commits/54bb04ed3e0d5adc65e7589e8d4add91696c03f2) is the simplest and most useful approach. The difference is that keeping the activeEditor synchronized at all times is more accurate.

fix #2407