### PR TITLE
docs: fix affinity link

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ function verifyExperimentalAffinity(): void {
 
     vscode.window
         .showWarningMessage(
-            "No affinity assigned to vscode-neovim. It is recommended to assign affinity for major performance improvements. Would you like to set default affinity? [Learn more](https://github.com/vscode-neovim/vscode-neovim#performance)",
+            "No affinity assigned to vscode-neovim. It is recommended to assign affinity for major performance improvements. Would you like to set default affinity? [Learn more](https://github.com/vscode-neovim/vscode-neovim/issues/1051)",
             "Yes",
             "Cancel",
         )


### PR DESCRIPTION
## Problem

According to #2155, the README no longer includes instructions for manually configuring the `extensions.experimental.affinity` setting. The "Learn more" prompt now confuses users as it references outdated documentation.  

## Solution

Remove the redundant "[Learn more](https://github.com/vscode-neovim/vscode-neovim#performance)" link from the warning message in `src/extension.ts`.  

![image](https://github.com/user-attachments/assets/fcc550b1-6ce2-41b2-a380-04d20ad196e2)
