### PR TITLE
perf(build): migrate from webpack to rspack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
             },
             "devDependencies": {
                 "@johnnymorganz/stylua-bin": "^2.0.2",
+                "@rspack/cli": "^1.4.10",
+                "@rspack/core": "^1.4.10",
                 "@sinonjs/fake-timers": "^14.0.0",
                 "@types/lodash": "^4.17.16",
                 "@types/mocha": "^10.0.7",
@@ -37,9 +39,7 @@
                 "source-map-support": "^0.5.19",
                 "ts-loader": "^9.5.2",
                 "typescript": "^5.8.2",
-                "typescript-eslint": "^7.18.0",
-                "webpack": "^5.98.0",
-                "webpack-cli": "^6.0.1"
+                "typescript-eslint": "^7.18.0"
             },
             "engines": {
                 "vscode": "^1.90.0"
@@ -271,14 +271,38 @@
                 "kuler": "^2.0.0"
             }
         },
-        "node_modules/@discoveryjs/json-ext": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-            "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+        "node_modules/@emnapi/core": {
+            "version": "1.4.5",
+            "resolved": "http://bnpm.byted.org/@emnapi/core/-/core-1.4.5.tgz",
+            "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=14.17.0"
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.0.4",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.4.5",
+            "resolved": "http://bnpm.byted.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+            "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.0.4",
+            "resolved": "http://bnpm.byted.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+            "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -512,6 +536,7 @@
             "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -527,6 +552,7 @@
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -537,6 +563,7 @@
             "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -547,6 +574,7 @@
             "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -557,7 +585,8 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
@@ -565,9 +594,133 @@
             "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "http://bnpm.byted.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.2.0",
+            "resolved": "http://bnpm.byted.org/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz",
+            "integrity": "sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.1",
+                "@jsonjoy.com/util": "^1.1.2",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^1.20.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util": {
+            "version": "1.8.0",
+            "resolved": "http://bnpm.byted.org/@jsonjoy.com/util/-/util-1.8.0.tgz",
+            "integrity": "sha512-HeR0JQNEdBozt+FrfyM5T0X3R+fIN0D+BRDkxPP5o41fTWzHfeZEqtK16aTW8haU+h+SG7XYq9PP5kobvOmkSA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@leichtgewicht/ip-codec": {
+            "version": "2.0.5",
+            "resolved": "http://bnpm.byted.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+            "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/error-codes": {
+            "version": "0.17.0",
+            "resolved": "http://bnpm.byted.org/@module-federation/error-codes/-/error-codes-0.17.0.tgz",
+            "integrity": "sha512-+pZ12frhaDqh4Xs/MQj4Vu4CAjnJTiEb8Z6fqPfn/TLHh4YLWMOzpzxGuMFDHqXwMb3o8FRAUhNB0eX2ZmhwTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/runtime": {
+            "version": "0.17.0",
+            "resolved": "http://bnpm.byted.org/@module-federation/runtime/-/runtime-0.17.0.tgz",
+            "integrity": "sha512-eMtrtCSSV6neJpMmQ8WdFpYv93raSgsG5RiAPsKUuSCXfZ5D+yzvleZ+gPcEpFT9HokmloxAn0jep50/1upTQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.17.0",
+                "@module-federation/runtime-core": "0.17.0",
+                "@module-federation/sdk": "0.17.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-core": {
+            "version": "0.17.0",
+            "resolved": "http://bnpm.byted.org/@module-federation/runtime-core/-/runtime-core-0.17.0.tgz",
+            "integrity": "sha512-MYwDDevYnBB9gXFfNOmJVIX5XZcbCHd0dral7gT7yVmlwOhbuGOLlm2dh2icwwdCYHA9AFDCfU9l1nJR4ex/ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/error-codes": "0.17.0",
+                "@module-federation/sdk": "0.17.0"
+            }
+        },
+        "node_modules/@module-federation/runtime-tools": {
+            "version": "0.17.0",
+            "resolved": "http://bnpm.byted.org/@module-federation/runtime-tools/-/runtime-tools-0.17.0.tgz",
+            "integrity": "sha512-t4QcKfhmwOHedwByDKUlTQVw4+gPotySYPyNa8GFrBSr1F6wcGdGyOhzP+PdgpiJLIM03cB6V+IKGGHE28SfDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.17.0",
+                "@module-federation/webpack-bundler-runtime": "0.17.0"
+            }
+        },
+        "node_modules/@module-federation/sdk": {
+            "version": "0.17.0",
+            "resolved": "http://bnpm.byted.org/@module-federation/sdk/-/sdk-0.17.0.tgz",
+            "integrity": "sha512-tjrNaYdDocHZsWu5iXlm83lwEK8A64r4PQB3/kY1cW1iOvggR2RESLAWPxRJXC2cLF8fg8LDKOBdgERZW1HPFA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@module-federation/webpack-bundler-runtime": {
+            "version": "0.17.0",
+            "resolved": "http://bnpm.byted.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.17.0.tgz",
+            "integrity": "sha512-o8XtXwqTDlqLgcALOfObcCbqXvUcSDHIEXrkcb4W+I8GJY7IqV0+x6rX4mJ3f59tca9qOF8zsZsOA6BU93Pvgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime": "0.17.0",
+                "@module-federation/sdk": "0.17.0"
             }
         },
         "node_modules/@msgpack/msgpack": {
@@ -576,6 +729,19 @@
             "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.0.1",
+            "resolved": "http://bnpm.byted.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.1.tgz",
+            "integrity": "sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.5",
+                "@emnapi/runtime": "^1.4.5",
+                "@tybys/wasm-util": "^0.10.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -636,6 +802,258 @@
                 "url": "https://opencollective.com/unts"
             }
         },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.29",
+            "resolved": "http://bnpm.byted.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rspack/binding": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding/-/binding-1.4.10.tgz",
+            "integrity": "sha512-awiXN7qTTTLWFThbJFL+M4k1if4sb17xKA5TaHbbxs0qKSlpe3adwNrNHaNU2WOQz+PbuF++OMyd+4gUusKuVg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "@rspack/binding-darwin-arm64": "1.4.10",
+                "@rspack/binding-darwin-x64": "1.4.10",
+                "@rspack/binding-linux-arm64-gnu": "1.4.10",
+                "@rspack/binding-linux-arm64-musl": "1.4.10",
+                "@rspack/binding-linux-x64-gnu": "1.4.10",
+                "@rspack/binding-linux-x64-musl": "1.4.10",
+                "@rspack/binding-wasm32-wasi": "1.4.10",
+                "@rspack/binding-win32-arm64-msvc": "1.4.10",
+                "@rspack/binding-win32-ia32-msvc": "1.4.10",
+                "@rspack/binding-win32-x64-msvc": "1.4.10"
+            }
+        },
+        "node_modules/@rspack/binding-darwin-arm64": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.4.10.tgz",
+            "integrity": "sha512-PraYGuVSzvEwdoYC8T70qI/8j1QeUe2sysiWmjSdxUpxJsDfw35hK9TfxULeAJULlAUAiiXs03hdZk29DBc3ow==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-darwin-x64": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.4.10.tgz",
+            "integrity": "sha512-rWTSJ08TE0uqUjqAHkTmWqJu+FLSJ70A199Fk9k/FLZTS8UtHjuzZW7rv4qIN2nwJJLherxFUnP6y69cHuaGNw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-gnu": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.4.10.tgz",
+            "integrity": "sha512-cs6yu250FzRU1hl+02VLoJRdzbAveTOqvREeHgqL5AiTc6q1dQo1IZ16/Qt4+g0DMjnvM66pELRIO2nphXL8aA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-arm64-musl": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.4.10.tgz",
+            "integrity": "sha512-NnOAoWkpZvOa+xM7NAJg25O+tSKt6xCXoga+gOw5XPni1NxHDc3PNh5bU6fAmc2Z29YLLdxeVqPmIDfdk1EkDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-gnu": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.4.10.tgz",
+            "integrity": "sha512-FcaBqMclADWiqX+Mez15kggwaVYZkoEqDiQwYRpYDbBMsiJEtfp41GnNRstTWxYxFbcmuWoZl2cYy+LepR21ag==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-linux-x64-musl": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.4.10.tgz",
+            "integrity": "sha512-vgRQhCw+C/Nxv6MZVNUkPzSXs6kIWHIrGKUvOM1ceeAkT+jNFEQdukkQ5LsYgEqEwP9ezWubxN3IGrMxyimlPw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rspack/binding-wasm32-wasi": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.4.10.tgz",
+            "integrity": "sha512-lk647+Ob3yvVS2FgW0vCfo/gz9h0Q7v9HGBFcsD1uW0/tSqXMa2s9ZvIn+B7S9tRgIoosXEAuq8NeCXKGWVj5Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.0.1"
+            }
+        },
+        "node_modules/@rspack/binding-win32-arm64-msvc": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.4.10.tgz",
+            "integrity": "sha512-9mB3kh4pKaY4wFosZwuxb5EUtt7vv/uKW3OF4TJDC35bH7r54s+YYpHyXROT304r6URl4b6HNHlysL2m7BLihg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-ia32-msvc": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.4.10.tgz",
+            "integrity": "sha512-DPlyLZDUWkNcFI7zp1BQVVnihd4j/hCIbxqvIKvUt7whIVYMP52i8lCsa52uNGBSj7BcbcKAFElXC9dHVvoQGA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/binding-win32-x64-msvc": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.4.10.tgz",
+            "integrity": "sha512-FEE6OM0Wh7nj90+1ARXojT0Dnqox9UlIUIj7MQmX09yeMtckR+HITeq75F8y0l7HUvKOl2zQovmenk1KgyJV8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rspack/cli": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/cli/-/cli-1.4.10.tgz",
+            "integrity": "sha512-qWnBEN1pthP8wlgR6qOw+L8wXXUo3/B9EgD+XDavK6bKxwWlUvc02u2ERKvyaVyBctus708/M4dj9uxNH5xUDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@discoveryjs/json-ext": "^0.5.7",
+                "@rspack/dev-server": "~1.1.3",
+                "colorette": "2.0.20",
+                "exit-hook": "^4.0.0",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
+                "webpack-bundle-analyzer": "4.10.2",
+                "yargs": "17.7.2"
+            },
+            "bin": {
+                "rspack": "bin/rspack.js"
+            },
+            "peerDependencies": {
+                "@rspack/core": "^1.0.0-alpha || ^1.x"
+            }
+        },
+        "node_modules/@rspack/cli/node_modules/@discoveryjs/json-ext": {
+            "version": "0.5.7",
+            "resolved": "http://bnpm.byted.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@rspack/core": {
+            "version": "1.4.10",
+            "resolved": "http://bnpm.byted.org/@rspack/core/-/core-1.4.10.tgz",
+            "integrity": "sha512-eK3H328pihiM1323OlaClKJ9WlqgGBZpcR5AqFoWsG0KD01tKCJOeZEgtCY6paRLrsQrEJwBrLntkG0fE7WNGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@module-federation/runtime-tools": "0.17.0",
+                "@rspack/binding": "1.4.10",
+                "@rspack/lite-tapable": "1.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@swc/helpers": ">=0.5.1"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rspack/dev-server": {
+            "version": "1.1.3",
+            "resolved": "http://bnpm.byted.org/@rspack/dev-server/-/dev-server-1.1.3.tgz",
+            "integrity": "sha512-jWPeyiZiGpbLYGhwHvwxhaa4rsr8CQvsWkWslqeMLb2uXwmyy3UWjUR1q+AhAPnf0gs3lZoFZ1hjBQVecHKUvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^3.6.0",
+                "http-proxy-middleware": "^2.0.9",
+                "p-retry": "^6.2.0",
+                "webpack-dev-server": "5.2.2",
+                "ws": "^8.18.0"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "peerDependencies": {
+                "@rspack/core": "*"
+            }
+        },
+        "node_modules/@rspack/lite-tapable": {
+            "version": "1.0.1",
+            "resolved": "http://bnpm.byted.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
+            "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -666,11 +1084,65 @@
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
             "dev": true
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.0",
+            "resolved": "http://bnpm.byted.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+            "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.5",
+            "resolved": "http://bnpm.byted.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+            "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/bonjour": {
+            "version": "3.5.13",
+            "resolved": "http://bnpm.byted.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+            "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.38",
+            "resolved": "http://bnpm.byted.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect-history-api-fallback": {
+            "version": "1.5.4",
+            "resolved": "http://bnpm.byted.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+            "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express-serve-static-core": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.6",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
             "integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -681,6 +1153,7 @@
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -690,7 +1163,51 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-            "dev": true
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@types/express": {
+            "version": "4.17.22",
+            "resolved": "http://bnpm.byted.org/@types/express/-/express-4.17.22.tgz",
+            "integrity": "sha512-eZUmSnhRX9YRSkplpz0N+k6NljUUn5l3EWZIKZvYzhvMphEuNiyyy1viH/ejgt66JWgALwC/gtSUAeQKtSwW/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "4.19.6",
+            "resolved": "http://bnpm.byted.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.4",
+            "resolved": "http://bnpm.byted.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+            "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/http-proxy": {
+            "version": "1.17.16",
+            "resolved": "http://bnpm.byted.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+            "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -711,6 +1228,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "http://bnpm.byted.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/mocha": {
             "version": "10.0.7",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
@@ -727,11 +1251,85 @@
                 "undici-types": "~6.20.0"
             }
         },
+        "node_modules/@types/node-forge": {
+            "version": "1.3.13",
+            "resolved": "http://bnpm.byted.org/@types/node-forge/-/node-forge-1.3.13.tgz",
+            "integrity": "sha512-zePQJSW5QkwSHKRApqWCVKeKoSOt4xvEnLENZPjyvm9Ezdf/EyDeJM7jqLzOwjVICQQzvLZ63T55MKdJB5H6ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.14.0",
+            "resolved": "http://bnpm.byted.org/@types/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "http://bnpm.byted.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/retry": {
+            "version": "0.12.2",
+            "resolved": "http://bnpm.byted.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "0.17.4",
+            "resolved": "http://bnpm.byted.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-index": {
+            "version": "1.9.4",
+            "resolved": "http://bnpm.byted.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+            "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "1.15.7",
+            "resolved": "http://bnpm.byted.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+            "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "*"
+            }
+        },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "8.1.5",
             "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
             "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
             "dev": true
+        },
+        "node_modules/@types/sockjs": {
+            "version": "0.3.36",
+            "resolved": "http://bnpm.byted.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+            "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -743,6 +1341,16 @@
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
             "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
             "dev": true
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "http://bnpm.byted.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.18.0",
@@ -1204,6 +1812,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -1213,25 +1822,29 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -1242,13 +1855,15 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -1261,6 +1876,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -1270,6 +1886,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -1278,13 +1895,15 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -1301,6 +1920,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -1314,6 +1934,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -1326,6 +1947,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -1340,69 +1962,49 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@webpack-cli/configtest": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-            "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0",
-                "webpack-cli": "6.x.x"
-            }
-        },
-        "node_modules/@webpack-cli/info": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-            "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0",
-                "webpack-cli": "6.x.x"
-            }
-        },
-        "node_modules/@webpack-cli/serve": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-            "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0",
-                "webpack-cli": "6.x.x"
-            },
-            "peerDependenciesMeta": {
-                "webpack-dev-server": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "http://bnpm.byted.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "http://bnpm.byted.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/acorn": {
             "version": "8.14.0",
@@ -1423,6 +2025,19 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "http://bnpm.byted.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/agent-base": {
@@ -1501,6 +2116,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/ansi-html-community": {
+            "version": "0.0.8",
+            "resolved": "http://bnpm.byted.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+            "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+            "dev": true,
+            "engines": [
+                "node >= 0.8.0"
+            ],
+            "license": "Apache-2.0",
+            "bin": {
+                "ansi-html": "bin/ansi-html"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1556,6 +2184,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/array-flatten": {
+            "version": "1.1.1",
+            "resolved": "http://bnpm.byted.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/array-includes": {
             "version": "3.1.8",
@@ -1766,6 +2401,13 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/batch": {
+            "version": "0.6.1",
+            "resolved": "http://bnpm.byted.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/big-integer": {
             "version": "1.6.52",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -1833,6 +2475,59 @@
             "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
             "dev": true
         },
+        "node_modules/body-parser": {
+            "version": "1.20.3",
+            "resolved": "http://bnpm.byted.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.13.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/body-parser/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "http://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/body-parser/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bonjour-service": {
+            "version": "1.3.0",
+            "resolved": "http://bnpm.byted.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1886,6 +2581,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -1963,6 +2659,32 @@
                 "node": ">=0.2.0"
             }
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "http://bnpm.byted.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "http://bnpm.byted.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -2021,7 +2743,8 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/chainsaw": {
             "version": "0.1.0",
@@ -2088,16 +2811,11 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "version": "3.6.0",
+            "resolved": "http://bnpm.byted.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
+            "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -2109,6 +2827,9 @@
             },
             "engines": {
                 "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -2126,6 +2847,7 @@
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -2170,21 +2892,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/clone-deep": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/cockatiel": {
@@ -2264,11 +2971,152 @@
                 "node": ">=18"
             }
         },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "http://bnpm.byted.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.8.1",
+            "resolved": "http://bnpm.byted.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "http://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/compression/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "http://bnpm.byted.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
+        },
+        "node_modules/connect-history-api-fallback": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+            "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "0.5.4",
+            "resolved": "http://bnpm.byted.org/content-disposition/-/content-disposition-0.5.4.tgz",
+            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-disposition/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "http://bnpm.byted.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "http://bnpm.byted.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.1",
+            "resolved": "http://bnpm.byted.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "http://bnpm.byted.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -2378,6 +3226,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/debounce": {
+            "version": "1.2.1",
+            "resolved": "http://bnpm.byted.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/debug": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -2438,6 +3293,36 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "node_modules/default-browser": {
+            "version": "5.2.1",
+            "resolved": "http://bnpm.byted.org/default-browser/-/default-browser-5.2.1.tgz",
+            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "resolved": "http://bnpm.byted.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -2505,6 +3390,27 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/destroy": {
+            "version": "1.2.0",
+            "resolved": "http://bnpm.byted.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2514,6 +3420,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/detect-node": {
+            "version": "2.1.0",
+            "resolved": "http://bnpm.byted.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/diff": {
             "version": "5.2.0",
@@ -2534,6 +3447,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dns-packet": {
+            "version": "5.6.1",
+            "resolved": "http://bnpm.byted.org/dns-packet/-/dns-packet-5.6.1.tgz",
+            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@leichtgewicht/ip-codec": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/doctrine": {
@@ -2603,6 +3529,13 @@
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "http://bnpm.byted.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/duplexer2": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -2627,11 +3560,19 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "http://bnpm.byted.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.73",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.73.tgz",
             "integrity": "sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -2643,6 +3584,16 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
             "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
@@ -2677,19 +3628,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/envinfo": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-            "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "envinfo": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/es-abstract": {
@@ -2777,7 +3715,8 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
             "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.0.0",
@@ -2839,6 +3778,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "http://bnpm.byted.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
@@ -3092,6 +4038,7 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -3323,6 +4270,7 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3336,6 +4284,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "http://bnpm.byted.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "http://bnpm.byted.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3343,6 +4308,19 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.x"
+            }
+        },
+        "node_modules/exit-hook": {
+            "version": "4.0.0",
+            "resolved": "http://bnpm.byted.org/exit-hook/-/exit-hook-4.0.0.tgz",
+            "integrity": "sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/expand-template": {
@@ -3354,6 +4332,91 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/express": {
+            "version": "4.21.2",
+            "resolved": "http://bnpm.byted.org/express/-/express-4.21.2.tgz",
+            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.8",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.20.3",
+                "content-disposition": "0.5.4",
+                "content-type": "~1.0.4",
+                "cookie": "0.7.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "1.3.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "merge-descriptors": "1.0.3",
+                "methods": "~1.1.2",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.12",
+                "proxy-addr": "~2.0.7",
+                "qs": "6.13.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.2.1",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "http://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/express/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/express/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "http://bnpm.byted.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -3417,15 +4480,6 @@
             ],
             "license": "BSD-3-Clause"
         },
-        "node_modules/fastest-levenshtein": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.9.1"
-            }
-        },
         "node_modules/fastq": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -3433,6 +4487,19 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/faye-websocket": {
+            "version": "0.11.4",
+            "resolved": "http://bnpm.byted.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "websocket-driver": ">=0.5.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/fd-slicer": {
@@ -3495,6 +4562,42 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/finalhandler": {
+            "version": "1.3.1",
+            "resolved": "http://bnpm.byted.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "statuses": "2.0.1",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/finalhandler/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "http://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/finalhandler/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -3627,6 +4730,26 @@
             },
             "engines": {
                 "node": ">=12.20.0"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "http://bnpm.byted.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "http://bnpm.byted.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/fs-constants": {
@@ -3831,7 +4954,8 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/globals": {
             "version": "16.0.0",
@@ -3910,6 +5034,29 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
+        },
+        "node_modules/gzip-size": {
+            "version": "6.0.0",
+            "resolved": "http://bnpm.byted.org/gzip-size/-/gzip-size-6.0.0.tgz",
+            "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/handle-thing": {
+            "version": "2.0.1",
+            "resolved": "http://bnpm.byted.org/handle-thing/-/handle-thing-2.0.1.tgz",
+            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/has-bigints": {
             "version": "1.0.2",
@@ -4013,6 +5160,26 @@
                 "node": ">=10"
             }
         },
+        "node_modules/hpack.js": {
+            "version": "2.1.6",
+            "resolved": "http://bnpm.byted.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "http://bnpm.byted.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/htmlparser2": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -4032,6 +5199,52 @@
                 "entities": "^4.4.0"
             }
         },
+        "node_modules/http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "http://bnpm.byted.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-parser-js": {
+            "version": "0.5.10",
+            "resolved": "http://bnpm.byted.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+            "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/http-proxy": {
+            "version": "1.18.1",
+            "resolved": "http://bnpm.byted.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4043,6 +5256,44 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-middleware": {
+            "version": "2.0.9",
+            "resolved": "http://bnpm.byted.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-proxy": "^1.17.8",
+                "http-proxy": "^1.18.1",
+                "is-glob": "^4.0.1",
+                "is-plain-obj": "^3.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "@types/express": "^4.17.13"
+            },
+            "peerDependenciesMeta": {
+                "@types/express": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
+            "version": "3.0.0",
+            "resolved": "http://bnpm.byted.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -4071,6 +5322,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "http://bnpm.byted.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "http://bnpm.byted.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ieee754": {
@@ -4131,25 +5405,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/import-local": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-            "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
-            "dev": true,
-            "dependencies": {
-                "pkg-dir": "^4.2.0",
-                "resolve-cwd": "^3.0.0"
-            },
-            "bin": {
-                "import-local-fixture": "fixtures/cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/imurmurhash": {
@@ -4217,6 +5472,16 @@
             },
             "engines": {
                 "node": ">= 12"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "2.2.0",
+            "resolved": "http://bnpm.byted.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/is-array-buffer": {
@@ -4382,6 +5647,41 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "http://bnpm.byted.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "http://bnpm.byted.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-interactive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -4404,6 +5704,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.1.0",
+            "resolved": "http://bnpm.byted.org/is-network-error/-/is-network-error-1.1.0.tgz",
+            "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-number": {
@@ -4446,19 +5759,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-plain-object": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isobject": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-regex": {
@@ -4596,16 +5896,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
-        "node_modules/isobject": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/jackspeak": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
@@ -4627,6 +5917,7 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -4642,6 +5933,7 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4652,6 +5944,7 @@
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -4690,7 +5983,8 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -4819,20 +6113,21 @@
                 "json-buffer": "3.0.1"
             }
         },
-        "node_modules/kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/kuler": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
             "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+        },
+        "node_modules/launch-editor": {
+            "version": "2.10.0",
+            "resolved": "http://bnpm.byted.org/launch-editor/-/launch-editor-2.10.0.tgz",
+            "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "shell-quote": "^1.8.1"
+            }
         },
         "node_modules/leven": {
             "version": "3.1.0",
@@ -4885,6 +6180,7 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -5094,12 +6390,53 @@
             "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
             "dev": true
         },
+        "node_modules/media-typer": {
+            "version": "0.3.0",
+            "resolved": "http://bnpm.byted.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/memfs": {
+            "version": "4.20.0",
+            "resolved": "http://bnpm.byted.org/memfs/-/memfs-4.20.0.tgz",
+            "integrity": "sha512-VKta4Y+0CPo0NvYMOE7vvhaNe4K5WTP077G1S4PS0h0joX0f15NosPT6y48rOpKLCh48nnlgY/TdRPwiKCIIkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/json-pack": "^1.0.3",
+                "@jsonjoy.com/util": "^1.3.0",
+                "tree-dump": "^1.0.1",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "1.0.3",
+            "resolved": "http://bnpm.byted.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5108,6 +6445,16 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/methods": {
+            "version": "1.1.2",
+            "resolved": "http://bnpm.byted.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/micromatch": {
@@ -5177,6 +6524,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "http://bnpm.byted.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
@@ -5392,10 +6746,34 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "http://bnpm.byted.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "node_modules/multicast-dns": {
+            "version": "7.2.5",
+            "resolved": "http://bnpm.byted.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dns-packet": "^5.2.2",
+                "thunky": "^1.0.2"
+            },
+            "bin": {
+                "multicast-dns": "cli.js"
+            }
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
@@ -5416,11 +6794,22 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
+        "node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "http://bnpm.byted.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/neovim": {
             "version": "5.3.0",
@@ -5503,11 +6892,22 @@
                 "url": "https://opencollective.com/node-fetch"
             }
         },
+        "node_modules/node-forge": {
+            "version": "1.3.1",
+            "resolved": "http://bnpm.byted.org/node-forge/-/node-forge-1.3.1.tgz",
+            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+            "dev": true,
+            "license": "(BSD-3-Clause OR GPL-2.0)",
+            "engines": {
+                "node": ">= 6.13.0"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
             "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -5615,6 +7015,36 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obuf": {
+            "version": "1.1.2",
+            "resolved": "http://bnpm.byted.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "http://bnpm.byted.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.1.0",
+            "resolved": "http://bnpm.byted.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5662,6 +7092,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/opener": {
+            "version": "1.5.2",
+            "resolved": "http://bnpm.byted.org/opener/-/opener-1.5.2.tgz",
+            "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+            "dev": true,
+            "license": "(WTFPL OR MIT)",
+            "bin": {
+                "opener": "bin/opener-bin.js"
             }
         },
         "node_modules/optionator": {
@@ -5824,13 +7264,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+        "node_modules/p-retry": {
+            "version": "6.2.1",
+            "resolved": "http://bnpm.byted.org/p-retry/-/p-retry-6.2.1.tgz",
+            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
+                "retry": "^0.13.1"
+            },
             "engines": {
-                "node": ">=6"
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/pac-proxy-agent": {
@@ -5932,6 +7381,16 @@
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "http://bnpm.byted.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5990,6 +7449,13 @@
                 "node": "20 || >=22"
             }
         },
+        "node_modules/path-to-regexp": {
+            "version": "0.1.12",
+            "resolved": "http://bnpm.byted.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -6021,70 +7487,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/possible-typed-array-names": {
@@ -6166,6 +7568,30 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "http://bnpm.byted.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "http://bnpm.byted.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/proxy-agent": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -6230,10 +7656,11 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.12.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-            "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+            "version": "6.13.0",
+            "resolved": "http://bnpm.byted.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.0.6"
             },
@@ -6271,6 +7698,32 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "http://bnpm.byted.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "2.5.2",
+            "resolved": "http://bnpm.byted.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/rc": {
@@ -6388,6 +7841,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "http://bnpm.byted.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/resolve": {
             "version": "1.22.8",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -6405,27 +7865,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-            "dev": true,
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/restore-cursor": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -6440,6 +7879,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "http://bnpm.byted.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/reusify": {
@@ -6465,6 +7914,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.0.0",
+            "resolved": "http://bnpm.byted.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -6544,6 +8006,13 @@
                 "node": ">=10"
             }
         },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "http://bnpm.byted.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/sax": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
@@ -6607,6 +8076,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/select-hose": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/selfsigned": {
+            "version": "2.4.1",
+            "resolved": "http://bnpm.byted.org/selfsigned/-/selfsigned-2.4.1.tgz",
+            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node-forge": "^1.3.0",
+                "node-forge": "^1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/semver": {
             "version": "7.6.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -6619,6 +8109,58 @@
                 "node": ">=10"
             }
         },
+        "node_modules/send": {
+            "version": "0.19.0",
+            "resolved": "http://bnpm.byted.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/send/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "http://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/send/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "http://bnpm.byted.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -6626,6 +8168,108 @@
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/serve-index": {
+            "version": "1.9.1",
+            "resolved": "http://bnpm.byted.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/serve-index/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "http://bnpm.byted.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/serve-index/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "http://bnpm.byted.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-index/node_modules/http-errors": {
+            "version": "1.6.3",
+            "resolved": "http://bnpm.byted.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-index/node_modules/inherits": {
+            "version": "2.0.3",
+            "resolved": "http://bnpm.byted.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/serve-index/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "http://bnpm.byted.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/serve-index/node_modules/setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "http://bnpm.byted.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/serve-index/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "http://bnpm.byted.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "1.16.2",
+            "resolved": "http://bnpm.byted.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.19.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/set-function-length": {
@@ -6666,18 +8310,12 @@
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
             "dev": true
         },
-        "node_modules/shallow-clone": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "http://bnpm.byted.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kind-of": "^6.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
+            "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -6698,6 +8336,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "http://bnpm.byted.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/side-channel": {
@@ -6779,6 +8430,21 @@
                 "is-arrayish": "^0.3.1"
             }
         },
+        "node_modules/sirv": {
+            "version": "2.0.4",
+            "resolved": "http://bnpm.byted.org/sirv/-/sirv-2.0.4.tgz",
+            "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6796,6 +8462,18 @@
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/sockjs": {
+            "version": "0.3.24",
+            "resolved": "http://bnpm.byted.org/sockjs/-/sockjs-0.3.24.tgz",
+            "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "faye-websocket": "^0.11.3",
+                "uuid": "^8.3.2",
+                "websocket-driver": "^0.7.4"
             }
         },
         "node_modules/socks": {
@@ -6845,6 +8523,53 @@
                 "source-map": "^0.6.0"
             }
         },
+        "node_modules/spdy": {
+            "version": "4.0.2",
+            "resolved": "http://bnpm.byted.org/spdy/-/spdy-4.0.2.tgz",
+            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "http://bnpm.byted.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            }
+        },
+        "node_modules/spdy-transport/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "http://bnpm.byted.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/sprintf-js": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -6857,6 +8582,16 @@
             "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "http://bnpm.byted.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/stdin-discarder": {
@@ -7166,6 +8901,7 @@
             "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -7185,6 +8921,7 @@
             "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
@@ -7219,7 +8956,8 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/text-hex": {
             "version": "1.0.0",
@@ -7231,6 +8969,26 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "node_modules/thingies": {
+            "version": "1.21.0",
+            "resolved": "http://bnpm.byted.org/thingies/-/thingies-1.21.0.tgz",
+            "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+            "dev": true,
+            "license": "Unlicense",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
+        "node_modules/thunky": {
+            "version": "1.1.0",
+            "resolved": "http://bnpm.byted.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tmp": {
             "version": "0.2.3",
@@ -7253,6 +9011,26 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "http://bnpm.byted.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "http://bnpm.byted.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -7260,6 +9038,23 @@
             "dev": true,
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/tree-dump": {
+            "version": "1.0.3",
+            "resolved": "http://bnpm.byted.org/tree-dump/-/tree-dump-1.0.3.tgz",
+            "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
             }
         },
         "node_modules/triple-beam": {
@@ -7463,6 +9258,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "http://bnpm.byted.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/typed-array-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
@@ -7620,6 +9429,16 @@
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "dev": true
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "http://bnpm.byted.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/unzipper": {
             "version": "0.10.14",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
@@ -7657,6 +9476,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.0"
@@ -7688,6 +9508,16 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
+        "node_modules/utils-merge": {
+            "version": "1.0.1",
+            "resolved": "http://bnpm.byted.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -7697,17 +9527,38 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "http://bnpm.byted.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/watchpack": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
             "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/wbuf": {
+            "version": "1.7.3",
+            "resolved": "http://bnpm.byted.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "node_modules/web-streams-polyfill": {
@@ -7725,6 +9576,7 @@
             "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.6",
@@ -7766,62 +9618,206 @@
                 }
             }
         },
-        "node_modules/webpack-cli": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-            "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+        "node_modules/webpack-bundle-analyzer": {
+            "version": "4.10.2",
+            "resolved": "http://bnpm.byted.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+            "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@discoveryjs/json-ext": "^0.6.1",
-                "@webpack-cli/configtest": "^3.0.1",
-                "@webpack-cli/info": "^3.0.1",
-                "@webpack-cli/serve": "^3.0.1",
-                "colorette": "^2.0.14",
-                "commander": "^12.1.0",
-                "cross-spawn": "^7.0.3",
-                "envinfo": "^7.14.0",
-                "fastest-levenshtein": "^1.0.12",
-                "import-local": "^3.0.2",
-                "interpret": "^3.1.1",
-                "rechoir": "^0.8.0",
-                "webpack-merge": "^6.0.1"
+                "@discoveryjs/json-ext": "0.5.7",
+                "acorn": "^8.0.4",
+                "acorn-walk": "^8.0.0",
+                "commander": "^7.2.0",
+                "debounce": "^1.2.1",
+                "escape-string-regexp": "^4.0.0",
+                "gzip-size": "^6.0.0",
+                "html-escaper": "^2.0.2",
+                "opener": "^1.5.2",
+                "picocolors": "^1.0.0",
+                "sirv": "^2.0.3",
+                "ws": "^7.3.1"
             },
             "bin": {
-                "webpack-cli": "bin/cli.js"
+                "webpack-bundle-analyzer": "lib/bin/analyzer.js"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/@discoveryjs/json-ext": {
+            "version": "0.5.7",
+            "resolved": "http://bnpm.byted.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "http://bnpm.byted.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "http://bnpm.byted.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "http://bnpm.byted.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-dev-middleware": {
+            "version": "7.4.2",
+            "resolved": "http://bnpm.byted.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
+            "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.10",
+                "memfs": "^4.6.0",
+                "mime-types": "^2.1.31",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "schema-utils": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.82.0"
+                "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
-                "webpack-bundle-analyzer": {
-                    "optional": true
-                },
-                "webpack-dev-server": {
+                "webpack": {
                     "optional": true
                 }
             }
         },
-        "node_modules/webpack-merge": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-            "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+        "node_modules/webpack-dev-server": {
+            "version": "5.2.2",
+            "resolved": "http://bnpm.byted.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.1"
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.21",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
+                "ansi-html-community": "^0.0.8",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
+                "colorette": "^2.0.10",
+                "compression": "^1.7.4",
+                "connect-history-api-fallback": "^2.0.0",
+                "express": "^4.21.2",
+                "graceful-fs": "^4.2.6",
+                "http-proxy-middleware": "^2.0.9",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.6.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^2.4.1",
+                "serve-index": "^1.9.1",
+                "sockjs": "^0.3.24",
+                "spdy": "^4.0.2",
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
+            },
+            "bin": {
+                "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                },
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "http://bnpm.byted.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "http://bnpm.byted.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/webpack-sources": {
@@ -7829,8 +9825,34 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/websocket-driver": {
+            "version": "0.7.4",
+            "resolved": "http://bnpm.byted.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/websocket-extensions": {
+            "version": "0.1.4",
+            "resolved": "http://bnpm.byted.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/which": {
@@ -7882,13 +9904,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/wildcard": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
-            "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/winston": {
             "version": "3.14.1",
@@ -8075,6 +10090,60 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "http://bnpm.byted.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "http://bnpm.byted.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.0",
+            "resolved": "http://bnpm.byted.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/xml2js": {
             "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -2165,9 +2165,9 @@
         "test:integration": "node ./out/test/runIntegrationTest.js",
         "pretest:unit": "npm run test-compile",
         "pretest:integration": "npm run test-compile",
-        "vscode:prepublish": "webpack --mode production",
-        "webpack": "webpack --mode development",
-        "webpack-dev": "webpack --mode development --watch",
+        "vscode:prepublish": "rspack --mode production",
+        "webpack": "rspack --mode development",
+        "webpack-dev": "rspack --mode development --watch",
         "test-compile": "tsc -p ./",
         "prepare": "husky",
         "build": "vsce package -o vscode-neovim.vsix",
@@ -2175,6 +2175,8 @@
     },
     "devDependencies": {
         "@johnnymorganz/stylua-bin": "^2.0.2",
+        "@rspack/cli": "^1.4.10",
+        "@rspack/core": "^1.4.10",
         "@sinonjs/fake-timers": "^14.0.0",
         "@types/lodash": "^4.17.16",
         "@types/mocha": "^10.0.7",
@@ -2194,9 +2196,7 @@
         "source-map-support": "^0.5.19",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.2",
-        "typescript-eslint": "^7.18.0",
-        "webpack": "^5.98.0",
-        "webpack-cli": "^6.0.1"
+        "typescript-eslint": "^7.18.0"
     },
     "dependencies": {
         "@jpwilliams/waitgroup": "^2.1.1",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -4,10 +4,10 @@
 
 const path = require("path");
 
-const webpack = require("webpack");
+const { rspack } = require("@rspack/core");
+const { defineConfig } = require("@rspack/cli");
 
-/**@type {import('webpack').Configuration}*/
-const config = {
+const config = defineConfig({
     target: "node", // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
 
     entry: "./src/extension.ts", // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
@@ -48,11 +48,11 @@ const config = {
         level: "log",
     },
     plugins: [
-        new webpack.EnvironmentPlugin({
+        new rspack.DefinePlugin({
             // stop neovim winston spam
             NVIM_NODE_LOG_LEVEL: "error",
             ALLOW_CONSOLE: true,
         }),
     ],
-};
+});
 module.exports = config;


### PR DESCRIPTION

rspack is pretty much a superset of webpack that's many times faster.

On this project it's over 3x faster:

```sh
$ hyperfine --warmup=3 'node node_modules/webpack-cli/bin/cli.js --mode production' 'node node_modules/@rspack/cli/bin/rspack.js --mode production'
Benchmark 1: node node_modules/webpack-cli/bin/cli.js --mode production
  Time (mean ± σ):      5.371 s ±  0.270 s    [User: 8.241 s, System: 0.402 s]
  Range (min … max):    4.962 s …  5.816 s    10 runs

Benchmark 2: node node_modules/@rspack/cli/bin/rspack.js --mode production
  Time (mean ± σ):      1.624 s ±  0.145 s    [User: 2.741 s, System: 0.289 s]
  Range (min … max):    1.481 s …  1.815 s    10 runs

Summary
  node node_modules/@rspack/cli/bin/rspack.js --mode production ran
    3.31 ± 0.34 times faster than node node_modules/webpack-cli/bin/cli.js --mode production
```
