### PR TITLE
add: word wrap files, pending maintainer direction

### DIFF
--- a/runtime/vscode/word_wrap/keymaps-vscode.lua
+++ b/runtime/vscode/word_wrap/keymaps-vscode.lua
@@ -1,0 +1,302 @@
+--[[
+NOTES ABOUT KEYMAPS... it gets confusing
+  -- ignore "o" in j/k that gets complex usually u want to 3yj according to relative lines not screen lines
+  -- check vim.fn.mode() to avoid issues with visual block mode
+  -- we can add v:count == 0 ? check to keep 3j function the same as without wrap? need to ask manintainer about this. for now i just include it in my personal remapping of j.
+  -- is_macro_executing to fix keymap issues when executing macros. plays back keys as if theres no word wrap.
+  -- i learned after re-writing these keymaps 20 times that for proper functionality in macros we need to use expr in mappings
+  -- i prefer to remap I/A to be wrap aware. but these could be changed to something else to prevent user confusion.
+  -- same with D/C/Y
+
+  KNOWN ISSUES:
+  -- currently using these keymaps in a ":norm" without bang will cause issues. recommend toggleing off wrap before using command.
+
+--]]
+
+local utils = require("vscode.word_wrap.utils")
+local vscode = require("vscode")
+
+M = {
+  {
+    "n",
+    "gj",
+    function()
+      if utils.is_macro_executing() then
+        return "j"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "down", by = "wrappedLine", value = vim.v.count },
+      })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "cursor N lines downward (include 'wrap')" },
+  },
+
+  {
+    "v",
+    "gj",
+    function()
+      if utils.is_macro_executing() or vim.fn.mode() ~= "v" then
+        return "j"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "down", by = "wrappedLine", select = true, value = vim.v.count },
+      })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "cursor N lines downward (include 'wrap')" },
+  },
+
+  {
+    "n",
+    "gk",
+    function()
+      if utils.is_macro_executing() then
+        return "k"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "up", by = "wrappedLine", value = vim.v.count },
+      })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "cursor N lines up (include 'wrap')" },
+  },
+
+  {
+    "v",
+    "gk",
+    function()
+      if utils.is_macro_executing() or vim.fn.mode() ~= "v" then
+        return "k"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "up", by = "wrappedLine", select = true, value = vim.v.count },
+      })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "cursor N lines up (include 'wrap')" },
+  },
+  {
+    "n",
+    "g0",
+    function()
+      if utils.is_macro_executing() then
+        return "0"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineStart" },
+      })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "first char of wrapped line (wrap-aware)" },
+  },
+  {
+    "v",
+    "g0",
+    function()
+      if utils.is_macro_executing() or vim.fn.mode() ~= "v" then
+        return "0"
+      end
+      vscode.call("cursorRight") -- vscode doesnt include char under cursor in visual selection, neovim does. Move right to compensate. neither includes char under crsor in operator pending mode, so undo in "o" mapping below
+      vscode.call("cursorMove", { args = { to = "wrappedLineStart", select = true } })
+      vscode.call("cursorRight", { args = { select = true } }) -- HACK: ya idk without this operator pending doesnt work. spent days figuring this out. fml.
+      return ""
+    end,
+    { expr = true, silent = true, desc = "first non-blank character of the line (include 'wrap')" },
+  },
+
+  {
+    { "o" },
+    "g0",
+    function()
+      if utils.is_macro_executing() then
+        return "0"
+      end
+      vscode.call("cursorLeft") -- undoing the conpensating right from visual mode
+      return ":<C-U>normal hvg0<CR>"
+    end,
+    { expr = true, silent = true, desc = "first non-blank character of the line (include 'wrap')" },
+  },
+  {
+    "n",
+    "g^",
+    function()
+      if utils.is_macro_executing() then
+        return "^"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineFirstNonWhitespaceCharacter" },
+      })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "first non-blank character of the line (include 'wrap')" },
+  },
+  {
+    "v",
+    "g^",
+    function()
+      if utils.is_macro_executing() or vim.fn.mode() ~= "v" then
+        return "^"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineFirstNonWhitespaceCharacter", select = true },
+      })
+      -- VSCode selections don’t include char under cursor, Neovim does
+      vscode.call("cursorRight", { args = { select = true } })
+      return ""
+    end,
+    { expr = true, silent = true, desc = "first non-blank character of the line (include 'wrap')" },
+  },
+  {
+    { "o" },
+    "g^",
+    function()
+      if utils.is_macro_executing() then
+        return "^"
+      end
+      return ":<C-U>normal vg^<CR>"
+    end,
+    { expr = true, silent = true, desc = "first non-blank character of the line (include 'wrap')" },
+  },
+  {
+    "n",
+    "g$",
+    function()
+      if utils.is_macro_executing() then
+        return "$"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineLastNonWhitespaceCharacter" },
+      })
+      if not (vim.o.virtualedit:find("all") or vim.o.virtualedit:find("onemore")) then
+        vscode.call("cursorLeft")
+      end
+      return vim.api.nvim_replace_termcodes("<Ignore>", true, true, true) -- without this cursor is desynced after motion,
+    end,
+    { expr = true, silent = true, desc = "end of the line (include 'wrap')" },
+  },
+  {
+    "v",
+    "g$",
+    function()
+      if utils.is_macro_executing() or vim.fn.mode() ~= "v" then
+        return "$"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineEnd", select = true },
+      })
+      vscode.call("cursorLeft") -- adjust like Neovim’s visual mode
+      return ""
+    end,
+    { expr = true, silent = true, desc = "end of the line (include 'wrap')" },
+  },
+  {
+    { "o" },
+    "g$",
+    function()
+      if utils.is_macro_executing() then
+        return "$"
+      end
+      return ":<C-U>normal vg$<CR>"
+    end,
+    { expr = true, silent = true, desc = "end of the line (include 'wrap')" },
+  },
+  {
+    "n",
+    "I",
+    function()
+      if utils.is_macro_executing() then
+        return "I"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineFirstNonWhitespaceCharacter" },
+      })
+      return "i"
+    end,
+    { expr = true, silent = true, desc = "I (include 'wrap')" },
+  },
+  {
+    "n",
+    "A",
+    function()
+      if utils.is_macro_executing() then
+        return "A"
+      end
+      vscode.call("cursorMove", {
+        args = { to = "wrappedLineLastNonWhitespaceCharacter" },
+      })
+      return "i" -- 'i' because cursor is already past the end (virtualedit)
+    end,
+    { expr = true, silent = true, desc = "A (include 'wrap')" },
+  },
+  -- NOTE: below changes behavior of Y,D,C to respect line wrap. see note at top of file.
+  {
+    "n",
+    "D",
+    function()
+      if utils.is_macro_executing() then
+        return "D"
+      else
+        return "dg$"
+      end
+    end,
+    { expr = true, remap = true, desc = "[D]elete to end of line (include 'wrap')" },
+  },
+  {
+    "n",
+    "C",
+    function()
+      if utils.is_macro_executing() then
+        return "C"
+      else
+        return "cg$"
+      end
+    end,
+    { expr = true, remap = true, desc = "[C]hange to end of line (include 'wrap')" },
+  },
+  {
+    "n",
+    "Y",
+    function()
+      if utils.is_macro_executing() then
+        return "Y"
+      else
+        return "yg$"
+      end
+    end,
+    { expr = true, remap = true, desc = "[Y]ank to end of line (include 'wrap')" },
+  },
+  -- all keymaps user would put in their config for proper word wrap behavior
+  {
+    { "n", "v" },
+    "j",
+    "v:count == 0 ? 'gj' : 'j'",
+    { expr = true, remap = true, desc = "cursor N lines downward (include 'wrap')" },
+  },
+  {
+    { "n", "v" },
+    "k",
+    "v:count == 0 ? 'gk' : 'k'",
+    { expr = true, remap = true, desc = "cursor N lines up (include 'wrap')" },
+  },
+  {
+    { "n", "v", "o" },
+    "0",
+    "g0",
+    { remap = true, desc = "first char of the line (include 'wrap')" },
+  },
+  {
+    { "n", "v", "o" },
+    "^",
+    "g^",
+    { remap = true, desc = "first non-blank character of the line (include 'wrap')" },
+  },
+  {
+    { "n", "v", "o" },
+    "$",
+    "g$",
+    { remap = true, desc = "end of the line (include 'wrap')" },
+  },
+}
+
+return M

--- a/runtime/vscode/word_wrap/togglewrap.lua
+++ b/runtime/vscode/word_wrap/togglewrap.lua
@@ -1,0 +1,181 @@
+--[[
+INIT CODE
+    will prob have to move this to a file when making the plugin
+--]]
+
+local utils = require("vscode.word_wrap.utils")
+local vscode
+local keymaps
+
+if vim.g.vscode then
+  vscode = require("vscode")
+  vim.notify = vscode.notify
+  keymaps = require("vscode.word_wrap.keymaps-vscode")
+  -- else
+  -- 	keymaps = require("utils.keymaps-neovim")
+end
+
+vim.keymap.set("n", "<leader>uw", function()
+  if utils.is_macro_recording() or utils.is_macro_executing() then
+    vim.notify("ToggleWrap disabled during macro execution", vim.log.levels.WARN)
+    return
+  end
+
+  if vim.g.vscode then
+    local new_wrap = not utils.get_vscode_wrap().enabled
+    vim.cmd("ToggleWrap " .. tostring(new_wrap))
+    return
+  end
+
+  vim.cmd("ToggleWrap")
+end, { desc = "[u]i toggle line [w]rap and movement" })
+
+--[[
+MAIN USERCMD FOR TOGGLE WRAP
+    neovim & vscode compatible
+--]]
+
+vim.api.nvim_create_user_command("ToggleWrap", function(ctx)
+  local arg = ctx.args
+
+  ---Toggle or explicitly set word wrap and related editor options.
+  ---@param enabled boolean? If true, enable wrap; if false, disable wrap; if nil, toggle current state.
+  ---@return boolean The resulting state of wrap (true = enabled, false = disabled)
+  local function ToggleWrap(enabled)
+    ---@type boolean
+    if enabled == nil then
+      local current = vim.g.vscode and utils.get_vscode_wrap().enabled or vim.wo.wrap
+      enabled = not current
+    end
+
+    if vim.g.vscode then
+      local new_wrap_mode = enabled and "bounded" or "off"
+      vscode.update_config("editor.wordWrap", new_wrap_mode, "global")
+      if not enabled then
+        utils.unset_wrap_keymaps(keymaps)
+        return enabled
+      end
+      utils.set_wrap_keymaps(keymaps)
+      return enabled
+    end
+
+    -- capture exact current location
+    local cur_tab = vim.api.nvim_get_current_tabpage()
+    local cur_win = vim.api.nvim_get_current_win()
+
+    -- set global defaults so future windows/buffers inherit
+    vim.opt_global.wrap = enabled
+    vim.opt_global.linebreak = enabled
+    if enabled then
+      vim.opt_global.formatoptions:remove("l")
+      utils.set_wrap_keymaps(keymaps)
+    else
+      vim.opt_global.formatoptions:append("l")
+      utils.unset_wrap_keymaps(keymaps)
+    end
+
+    -- apply to all existing windows in all tabs without stealing focus
+    for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tab)) do
+        pcall(vim.api.nvim_win_call, win, function()
+          vim.opt_local.wrap = enabled
+          vim.opt_local.linebreak = enabled
+          if enabled then
+            vim.opt_local.formatoptions:remove("l")
+          else
+            vim.opt_local.formatoptions:append("l")
+          end
+        end)
+      end
+    end
+
+    -- restore exact original tab and window
+    pcall(vim.api.nvim_set_current_tabpage, cur_tab)
+    pcall(vim.api.nvim_set_current_win, cur_win)
+
+    if not ctx.smods.silent then
+      vim.notify(enabled and "✅ Wrap enabled" or "❌ Wrap disabled")
+    end
+
+    return enabled
+  end
+
+  if arg == nil or arg == "" then
+    ToggleWrap()
+    return
+  end
+
+  local s = arg:lower()
+  local bool
+  if s == "true" or s == "on" or s == "1" then
+    bool = true
+  elseif s == "false" or s == "off" or s == "0" then
+    bool = false
+  else
+    if not ctx.smods.silent then
+      vim.notify("ToggleWrap: invalid argument. Use 'on'/'off' or no arg to toggle.", vim.log.levels.WARN)
+    end
+    return
+  end
+
+  ToggleWrap(bool)
+end, {
+  complete = function()
+    return { "on", "off" }
+  end,
+  nargs = "?",
+  desc = "Toggle or set wrap (use 'on'/'off' or no arg to toggle)",
+})
+
+--[[
+AUTOCMD's FOR TOGGLE WRAP
+    couldnt figure out how to make wordwrap keymaps to work with recording macros and in vscode so just disable wrap and keymaps when recording
+    i was however able to get the keymaps to work WHILE executing macros
+--]]
+
+-- ToggleWrap off upon RecordingEnter
+local my_group = vim.api.nvim_create_augroup("ToggleWrap", { clear = true })
+vim.api.nvim_create_autocmd({ "RecordingEnter" }, {
+  group = my_group,
+  callback = function()
+    local ok, err = pcall(vim.cmd, "ToggleWrap off")
+    if not ok then
+      vim.notify("Error disabling wrap: " .. err, vim.log.levels.ERROR)
+      return
+    end
+    vim.notify("Macro detected, wordWrap & keymaps disabled...", vim.log.levels.INFO)
+  end,
+})
+
+-- -- NOTE: below autocmd interfered with keymaps and just general usage so disabled it. keeping just incase though.
+-- -- ToggleWrap off upon CmdlineLeave if using :norm command
+-- vim.api.nvim_create_autocmd("CmdlineLeave", {
+-- 	group = my_group,
+-- 	callback = function()
+-- 		local cmd = vim.fn.getcmdline() or ""
+
+-- 		if cmd:match("^%s*norm%a*") then
+-- 			local ok, err = pcall(vim.cmd, "ToggleWrap off")
+-- 			if not ok then
+-- 				vim.notify("Error disabling wrap: " .. err, vim.log.levels.ERROR)
+-- 				return
+-- 			end
+-- 			vim.notify("Command detected, wordWrap & keymaps disabled...", vim.log.levels.INFO)
+-- 		end
+-- 	end,
+-- })
+
+-- Keep vscode wrap state in sync
+if vim.g.vscode then
+  vim.api.nvim_create_autocmd({ "CursorHold", "VimEnter" }, {
+    group = my_group,
+    callback = function()
+      local enabled = utils.get_vscode_wrap().enabled
+      local cmd = enabled and "ToggleWrap on" or "ToggleWrap off"
+      -- use a delay to avoid startup errors
+      vim.defer_fn(function()
+        pcall(vim.cmd, "silent " .. cmd)
+      end, 300)
+    end,
+  })
+end

--- a/runtime/vscode/word_wrap/utils.lua
+++ b/runtime/vscode/word_wrap/utils.lua
@@ -1,0 +1,51 @@
+-- TODO: add feat: capture previous keymap state to restore later after unsetting. aka my <leaderY/C/D keymaps
+local M = {}
+
+--- Register a list of keymaps.
+-- @param km table list of mappings (each entry: {mode, lhs, rhs, opts})
+function M.set_wrap_keymaps(km)
+  if type(km) ~= "table" then
+    vim.notify("set_wrap_keymaps: expected table, got " .. type(km), vim.log.levels.WARN)
+    return
+  end
+  for _, m in ipairs(km) do
+    local mode, lhs, rhs, opts = m[1], m[2], m[3], m[4]
+    vim.keymap.set(mode, lhs, rhs, opts)
+  end
+end
+
+--- Remove a list of keymaps. legacy since using vim.g.my_is_wrap to track state
+-- @param km table list of mappings (each entry: {mode, lhs, rhs, opts})
+function M.unset_wrap_keymaps(km)
+  if type(km) ~= "table" then
+    vim.notify("unset_wrap_keymaps: expected table, got " .. type(km), vim.log.levels.WARN)
+    return
+  end
+  for _, m in ipairs(km) do
+    local mode, lhs = m[1], m[2]
+    pcall(vim.keymap.del, mode, lhs)
+  end
+end
+
+---Word wrap modes.
+---@alias WordWrapMode '"off"'|'"on"'|'"bounded"'|'"wordWrapColumn"'
+
+---Get VSCode word wrap setting with info on whether wrapping is active.
+---@return { mode: WordWrapMode|nil, enabled: boolean }
+function M.get_vscode_wrap()
+  local vscode = require("vscode")
+  local mode = vscode.get_config("editor.wordWrap")
+  local enabled = mode == "on" or mode == "bounded" or mode == "wordWrapColumn"
+  return { mode = mode, enabled = enabled }
+end
+
+--- Return true when a macro is currently executing.
+function M.is_macro_executing()
+  return vim.fn.reg_executing() ~= ""
+end
+
+function M.is_macro_recording()
+  return vim.fn.reg_recording() ~= ""
+end
+
+return M


### PR DESCRIPTION
## Overview
extension didnt function well with vscode when wordWrap was enabled. i spent a lot of time configuring my own neovim keymaps to work in vscode one-to-one to how neovim handles keymaps with wordWrap on. I believe I have it as best as it can get. 

looking over the contributing.md file, figured that this "Delegates as much as possible to nvim" and could potentially be a PR to this project rather than a plugin/wiki in itself. Hoping you agree.

This first draft is to get you opinion on where the files and code should go. as of now i just copied over my neovim files into runtime/vscode/word_wrap pending your review.

## My proposal
looking over the codebase i believe the best place to put this code is as follows:

utils.lua -> runtime/lua/vscode/util.lua (not sure if this is the right place for it though)
keymaps-vscode.lua & togglewrap.lua -> combine into 1 file into runtime/vscode/word_wrap.lua or replace existing motions override vim file.

let me know what you think and i can go from there.

## Features
ToggleWrap Command: Adds a :ToggleWrap user command to enable, disable, or toggle word wrap globally.
Keymap Integration: ~~Sets up <leader>uw to toggle wrap and adjust movement keymaps for wrapped lines.~~ just an example of how to use it. wont be included in final draft.
Macro Safety: Automatically disables wrap and related keymaps during macro recording to avoid conflicts.
VSCode Sync: Keeps VSCode’s editor.wordWrap setting in sync with Neovim’s wrap state.