### PR TITLE
docs: mention `Neovim: Restart Extension` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ tab.
 
 ### Troubleshooting
 
+- To fix intermittent problems, you can run the `Neovim: Restart Extension` command to restart the extension.
 - View the logs via `Output: Focus on Output View` and select `vscode-neovim logs`.
     - **To enable debug logs,** click the "gear" icon and select `Debug`, then click it again and choose
       `Set As Default`.


### PR DESCRIPTION
Although we mention how to find all commands, users often don't know about this particular command which will unblock many of them.

We definitely don't want to repeat every command in our docs, but this one is important enough and is appropriate for the "Troubleshooting" section.