### PR TITLE
feat: Add statusLineItems config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,6 +334,21 @@
                     "default": "|",
                     "description": "Separator used by statusline"
                 },
+                "vscode-neovim.statusLineItems": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "pattern": "(statusline|mode|cmd|msg)"
+                    },
+                    "default": [
+                        "statusline",
+                        "mode",
+                        "cmd",
+                        "msg"
+                    ],
+                    "description": "Order of status line items displayed"
+                },
                 "vscode-neovim.compositeTimeout": {
                     "type": "number",
                     "default": 300,

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
                         "cmd",
                         "msg"
                     ],
-                    "description": "Order of status line items displayed"
+                    "description": "Info displayed in the statusbar"
                 },
                 "vscode-neovim.compositeTimeout": {
                     "type": "number",

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,9 @@ export class Config implements Disposable {
     get statusLineSeparator() {
         return this.cfg.get("statusLineSeparator", "|");
     }
+    get statusLineItems(): ("statusline" | "mode" | "cmd" | "msg")[] {
+        return this.cfg.get("statusLineItems", ["statusline","mode","cmd","msg"]);
+    }
 
     get normalSelectionDebounceTime() {
         return this.cfg.get("normalSelectionDebounceTime", 50);

--- a/src/config.ts
+++ b/src/config.ts
@@ -142,7 +142,7 @@ export class Config implements Disposable {
         return this.cfg.get("statusLineSeparator", "|");
     }
     get statusLineItems(): ("statusline" | "mode" | "cmd" | "msg")[] {
-        return this.cfg.get("statusLineItems", ["statusline","mode","cmd","msg"]);
+        return this.cfg.get("statusLineItems", ["statusline", "mode", "cmd", "msg"]);
     }
 
     get normalSelectionDebounceTime() {

--- a/src/status_line_manager.ts
+++ b/src/status_line_manager.ts
@@ -70,7 +70,16 @@ export class StatusLineManager implements Disposable {
     }
 
     private updateStatus() {
-        this.statusBar.text = [this._statusline, this._modeText, this._cmdText, this._msgText]
+        const textItems = config.statusLineItems.map(i => {
+            switch (i) {
+                case "statusline": return this._statusline;
+                case "mode": return this._modeText;
+                case "cmd": return this._cmdText;
+                case "msg": return this._msgText;
+                default: return null;
+            }
+        }).filter(t => t !== null);
+        this.statusBar.text = textItems
             .map((i) => i.replace(/\n/g, " ").trim())
             .filter((i) => i.length)
             .join(config.statusLineSeparator);

--- a/src/status_line_manager.ts
+++ b/src/status_line_manager.ts
@@ -70,15 +70,22 @@ export class StatusLineManager implements Disposable {
     }
 
     private updateStatus() {
-        const textItems = config.statusLineItems.map(i => {
-            switch (i) {
-                case "statusline": return this._statusline;
-                case "mode": return this._modeText;
-                case "cmd": return this._cmdText;
-                case "msg": return this._msgText;
-                default: return null;
-            }
-        }).filter(t => t !== null);
+        const textItems = config.statusLineItems
+            .map((i) => {
+                switch (i) {
+                    case "statusline":
+                        return this._statusline;
+                    case "mode":
+                        return this._modeText;
+                    case "cmd":
+                        return this._cmdText;
+                    case "msg":
+                        return this._msgText;
+                    default:
+                        return null;
+                }
+            })
+            .filter((t) => t !== null);
         this.statusBar.text = textItems
             .map((i) => i.replace(/\n/g, " ").trim())
             .filter((i) => i.length)


### PR DESCRIPTION
Problem:
User can't disable display of msg_show, msg_showcmd and msg_showmode events.

Solution:
Adds a statusLineItems config option that lets the user choose which events (msg_show, msg_showcmd, msg_showmode, and statusline) are rendered, and in which order.

Wrote this tweak to satisfy my customization needs. Should work as before by default.