### PR TITLE
docs: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug/issue
 title: "bug: "
-labels: [bug, triage]
+type: "Bug"
 body:
     - type: markdown
       attributes:
@@ -27,6 +27,12 @@ body:
       attributes:
           label: "Neovim version (nvim -v)"
           placeholder: "0.8.0 commit db1b0ee3b30f"
+      validations:
+          required: true
+    - type: input
+      attributes:
+          label: "VSCode version and flavor (Cursor, vscodium, …)"
+          placeholder: "VSCode 1.x"
       validations:
           required: true
     - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Usage or configuration question
+      url: https://github.com/vscode-neovim/vscode-neovim/discussions
+      about: Ask about configuration and usage of vscode-neovim

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature
 title: "feature: "
-labels: [enhancement, triage]
+type: "Feature"
 body:
     - type: checkboxes
       attributes:


### PR DESCRIPTION
Problem:
Github issues now has a `type` but we are still using the old labels.

Solution:
- Update the issue templates.
- Also ask for VSCode version.