### PR TITLE
fix: drain queued document changes after buffer init

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -159,7 +159,12 @@ export class BufferManager implements Disposable {
         more: boolean,
     ) => void;
 
-    public onBufferInit?: (bufId: number, doc: TextDocument, initDocText: string, initDocVersion: number) => void;
+    public onBufferInit?: (
+        bufId: number,
+        doc: TextDocument,
+        initDocText: string,
+        initDocVersion: number,
+    ) => void | Promise<void>;
 
     private get client() {
         return this.main.client;
@@ -717,10 +722,9 @@ export class BufferManager implements Disposable {
                     logger.error(`Cannot create a buffer, code: ${buf}`);
                     continue;
                 }
-                await this.initBufferForDocument(doc, buf, editor);
-
-                logger.log(doc.uri, LogLevel.Debug, `Document: ${doc.uri}, BufId: ${buf.id}`);
                 this.textDocumentToBufferId.set(doc, buf.id);
+                logger.log(doc.uri, LogLevel.Debug, `Document: ${doc.uri}, BufId: ${buf.id}`);
+                await this.initBufferForDocument(doc, buf, editor);
             }
             if (this.textEditorToWinId.has(editor)) continue;
             const editorBufferId = this.textDocumentToBufferId.get(doc)!;
@@ -849,7 +853,7 @@ export class BufferManager implements Disposable {
         if (!this.isExternalTextDocument(document)) {
             await actions.lua("clear_undo", bufId);
         }
-        this.onBufferInit?.(bufId, document, text, version);
+        await this.onBufferInit?.(bufId, document, text, version);
         buffer.listen("lines", this.receivedBufferEvent);
         actions.fireNvimEvent("document_buffer_init", bufId);
     }
@@ -917,7 +921,7 @@ export class BufferManager implements Disposable {
 
         this.externalTextDocuments.add(doc);
         this.textDocumentToBufferId.set(doc, id);
-        this.onBufferInit?.(id, doc, doc.getText(), doc.version);
+        await this.onBufferInit?.(id, doc, doc.getText(), doc.version);
 
         const windows = await this.client.windows;
         let closeWinId = 0;

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -164,7 +164,7 @@ export class BufferManager implements Disposable {
         doc: TextDocument,
         initDocText: string,
         initDocVersion: number,
-    ) => void | Promise<void>;
+    ) => Promise<void>;
 
     private get client() {
         return this.main.client;

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -373,9 +373,19 @@ export class BufferManager implements Disposable {
                 const buffers = await this.client.buffers;
                 const buf = buffers.find((b) => b.id === bufnr);
                 if (buf) {
-                    await this.initBufferForDocument(doc, buf);
+                    // Set the mapping before init so that queued onChangeTextDocument events
+                    // drained in DocumentChangeManager.onBufferInit can resolve the buffer id.
+                    // Roll back on failure so the document isn't stuck in a half-initialized state.
+                    this.textDocumentToBufferId.set(doc, bufnr);
+                    try {
+                        await this.initBufferForDocument(doc, buf);
+                    } catch (e) {
+                        this.textDocumentToBufferId.delete(doc);
+                        throw e;
+                    }
+                } else {
+                    this.textDocumentToBufferId.set(doc, bufnr);
                 }
-                this.textDocumentToBufferId.set(doc, bufnr);
             }
             if (window.activeTextEditor?.document !== doc) {
                 const editor = await window.showTextDocument(doc, {
@@ -722,9 +732,19 @@ export class BufferManager implements Disposable {
                     logger.error(`Cannot create a buffer, code: ${buf}`);
                     continue;
                 }
+                // Set the mapping before init so that any onChangeTextDocument events fired
+                // during the async init flow can resolve the buffer id when drained in
+                // DocumentChangeManager.onBufferInit. Roll the mapping back on failure so a
+                // future sync can retry init instead of treating this doc as initialized.
                 this.textDocumentToBufferId.set(doc, buf.id);
                 logger.log(doc.uri, LogLevel.Debug, `Document: ${doc.uri}, BufId: ${buf.id}`);
-                await this.initBufferForDocument(doc, buf, editor);
+                try {
+                    await this.initBufferForDocument(doc, buf, editor);
+                } catch (e) {
+                    this.textDocumentToBufferId.delete(doc);
+                    logger.log(doc.uri, LogLevel.Error, (e as Error).message);
+                    continue;
+                }
             }
             if (this.textEditorToWinId.has(editor)) continue;
             const editorBufferId = this.textDocumentToBufferId.get(doc)!;

--- a/src/document_change_manager.ts
+++ b/src/document_change_manager.ts
@@ -172,13 +172,28 @@ export class DocumentChangeManager implements Disposable {
         }
     }
 
-    private onBufferInit: BufferManager["onBufferInit"] = (bufId, doc, initText, initVersion) => {
+    private onBufferInit: BufferManager["onBufferInit"] = async (bufId, doc, initText, initVersion) => {
         logger.log(
             doc.uri,
             LogLevel.Debug,
             `Init buffer content for bufId: ${bufId}, uri: ${doc.uri}, version: ${initVersion}`,
         );
         this.documentContentInNeovim.set(doc, { text: initText, version: initVersion });
+
+        // Drain any queued changes that arrived while the buffer was being initialized.
+        // This handles the case where VS Code fires onChangeTextDocument during the async
+        // initBufferForDocument flow, before documentContentInNeovim is set. Those changes
+        // get queued but never processed because the early return in onChangeTextDocument
+        // exits before reaching the lock. Without this drain, the queued changes are orphaned.
+        const queuedChanges = this.documentChangeQueue.get(doc);
+        if (queuedChanges && queuedChanges.length > 0) {
+            this.documentChangeQueue.set(doc, []);
+            await this.documentChangeLock.runExclusive(async () => {
+                for (const change of queuedChanges) {
+                    await this.processTextDocumentChange(doc, change);
+                }
+            });
+        }
     };
 
     private onNeovimChangeEvent: BufferManager["onBufferEvent"] = (


### PR DESCRIPTION
## Summary

Fixes a race condition where document changes fired during async buffer initialization were silently orphaned, causing the neovim buffer to diverge from VS Code's content.

I first hit this in the **VS Code search editor**. Repro:

1. In a normal editor, visual-select a keyword.
2. Trigger "Open Search Editor" to search for that keyword (the selection is pre-populated into the search editor's query area).
3. Repeat a few times.

After a few iterations, the search editor's cursor lands in the wrong position and subsequent keystrokes behave as if neovim's buffer state doesn't match what's on screen. It's intermittent because it depends on whether VS Code fires its content-population change *during* the async buffer init.

Debugging with an AI assistant, we traced it to this sequence:

1. `BufferManager.syncVisibleEditors` calls `await initBufferForDocument(doc, buf, editor)` — an async flow.
2. While that's running, VS Code fires `onDidChangeTextDocument` for the search editor as its content is populated.
3. `DocumentChangeManager.onChangeTextDocument` pushes the change into `documentChangeQueue`, then early-returns at `if (!this.documentContentInNeovim.has(doc)) return;` because `onBufferInit` hasn't fired yet.
4. When `onBufferInit` eventually fires, it sets `documentContentInNeovim` but never drains the queue. The queued changes are lost, and neovim's view of the buffer is now stale.

Any document type that fires changes during async init can hit this — the search editor is just a reliable reproducer.

## Fix

Three small changes in `src/buffer_manager.ts` and `src/document_change_manager.ts`:

1. **Set `textDocumentToBufferId` before `initBufferForDocument`.** Otherwise, when the drain runs, `processTextDocumentChange` → `getBufferIdForTextDocument(doc)` returns `undefined` and silently drops the change, defeating the drain.
2. **Drain queued changes in `onBufferInit`** after `documentContentInNeovim` is set, under `documentChangeLock` so the drain serializes correctly against any subsequent `onChangeTextDocument` calls.
3. **Make `onBufferInit` async and `await` it at both call sites** (`initBufferForDocument` and the external-buffer path). This ensures the drain completes before `buffer.listen("lines", ...)` subscribes, so neovim's own line events can't interleave with the drain.

The type signature of `onBufferInit` now returns `void | Promise<void>` to reflect this.

## Test plan

- [x] Reproducer: visual-select a keyword, open search editor to search for it, repeat — cursor and edits behave correctly after the fix
- [x] Regular file editing is unaffected (no queued changes → drain is a no-op)
- [x] External buffer path (`handleExtBufferOpen` → `onBufferInit`) still works
- [x] `npm run lint:check`, `npm run format:check`, `npm run test-compile` all pass via pre-commit hook