### PR TITLE
fix: preserve visual line/block mode when scrolling with C-d/C-u

### DIFF
--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -39,7 +39,7 @@ export class CommandsController implements Disposable {
             visualAnchor = editor.selection;
         }
 
-        vscode.commands.executeCommand("editorScroll", { to, by, revealCursor: true });
+        await vscode.commands.executeCommand("editorScroll", { to, by, revealCursor: true });
 
         if (visualAnchor && this.main.modeManager.isVisualMode) {
             const newActive = editor.selection.active;

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -1,4 +1,4 @@
-import vscode, { Disposable, commands } from "vscode";
+import vscode, { Disposable, commands, Selection } from "vscode";
 
 import { config } from "./config";
 import { eventBus } from "./eventBus";
@@ -29,8 +29,22 @@ export class CommandsController implements Disposable {
     }
 
     /// SCROLL COMMANDS ///
-    private scrollPage = (by: "page" | "halfPage", to: "up" | "down"): void => {
+    private scrollPage = async (by: "page" | "halfPage", to: "up" | "down"): Promise<void> => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+
+        const wasVisualMode = this.main.modeManager.isVisualMode;
+        let visualAnchor: Selection | undefined;
+        if (wasVisualMode) {
+            visualAnchor = editor.selection;
+        }
+
         vscode.commands.executeCommand("editorScroll", { to, by, revealCursor: true });
+
+        if (visualAnchor && this.main.modeManager.isVisualMode) {
+            const newActive = editor.selection.active;
+            editor.selections = [new Selection(visualAnchor.anchor, newActive)];
+        }
     };
 
     private scrollLine = (to: "up" | "down"): void => {


### PR DESCRIPTION
Fixes #2434

When scrolling with C-d/C-u in visual line/block mode, the visual mode was being exited because the cursor position changed after VS Code's scroll command reset the selection.

This fix:
1. Captures the visual mode state and anchor position before scrolling
2. Executes the VS Code scroll command
3. Restores the visual selection with the new cursor position but same anchor