### PR TITLE
use package.json node version for setup-node

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v6
               with:
-                  node-version: "18"
+                  node-version-file: package.json
                   cache: "npm"
 
             - name: Install Neovim
@@ -56,7 +56,7 @@ jobs:
             - uses: actions/checkout@v5
             - uses: actions/setup-node@v6
               with:
-                  node-version: "18"
+                  node-version-file: package.json
                   cache: "npm"
             - name: npm install
               run: npm ci --silent
@@ -92,7 +92,7 @@ jobs:
             - uses: actions/setup-node@v6
               if: ${{ steps.release.outputs.release_created }}
               with:
-                  node-version: "18"
+                  node-version-file: package.json
                   cache: "npm"
             - name: npm install
               if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v6
               with:
-                  node-version: "18"
+                  node-version-file: package.json
                   cache: "npm"
 
             - name: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "webpack-cli": "^6.0.1"
             },
             "engines": {
+                "node": "22.x",
                 "vscode": "^1.90.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "email": "devpieron@gmail.com"
     },
     "engines": {
+        "node": "22.x",
         "vscode": "^1.90.0"
     },
     "keywords": [


### PR DESCRIPTION
## Summary

- Add `engines.node` set to `22.x` in `package.json` and `package-lock.json`.
- Update setup-node workflow steps to read the Node version from `package.json`.
- Split this small CI update out from #2618 per review feedback.

## Validation

- Verified `package.json` and `package-lock.json` both declare `engines.node` as `22.x`.
- Confirmed the branch diff against upstream `master` only includes the Node-version workflow and package metadata changes.