### PR TITLE
fix: scope list fold keybindings to listFocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 Session.vim
 *.vsix
 *.zip
+.claude/

--- a/package.json
+++ b/package.json
@@ -1604,42 +1604,42 @@
             {
                 "key": "z o",
                 "command": "list.expand",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z shift+o",
                 "command": "list.expand",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z c",
                 "command": "list.collapse",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z shift+c",
                 "command": "list.collapseAllToFocus",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z a",
                 "command": "list.toggleExpand",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z shift+a",
                 "command": "list.toggleExpand",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z m",
                 "command": "list.collapseAll",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "z shift+m",
                 "command": "list.collapseAll",
-                "when": "!editorTextFocus && !inputFocus"
+                "when": "!editorTextFocus && !inputFocus && listFocus"
             },
             {
                 "key": "tab",

--- a/scripts/keybindings/5_widgets.cjs
+++ b/scripts/keybindings/5_widgets.cjs
@@ -107,42 +107,42 @@ const keybinds = [
     {
         key: "z o",
         command: "list.expand",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z shift+o",
         command: "list.expand",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z c",
         command: "list.collapse",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z shift+c",
         command: "list.collapseAllToFocus",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z a",
         command: "list.toggleExpand",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z shift+a",
         command: "list.toggleExpand",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z m",
         command: "list.collapseAll",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "z shift+m",
         command: "list.collapseAll",
-        when: "!editorTextFocus && !inputFocus",
+        when: "!editorTextFocus && !inputFocus && listFocus",
     },
     {
         key: "tab",


### PR DESCRIPTION
## What

Append `&& listFocus` to the `when` clause of the list fold/expand keybindings so they only fire when a list widget is focused, rather than in any non-editor, non-input context.

## Changes

- `package.json` — 8 keybindings updated
- `scripts/keybindings/5_widgets.cjs` — 8 keybindings updated (source generator)
- `.gitignore` — ignore the `.claude/` directory

Affected keys: `z o`, `z shift+o`, `z c`, `z shift+c`, `z a`, `z shift+a`, `z m`, `z shift+m`.