### PR TITLE
fix(messages): output panel misses multi-flush messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@types/node": "^22.13.13",
                 "@types/sinonjs__fake-timers": "^8.1.5",
                 "@types/vscode": "^1.90.0",
-                "@vscode/test-electron": "^2.4.1",
+                "@vscode/test-electron": "^3.1.0",
                 "@vscode/vsce": "^3.3.0",
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^10.1.1",
@@ -961,19 +961,20 @@
             "dev": true
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
-            "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+            "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.5",
                 "jszip": "^3.10.1",
-                "ora": "^7.0.1",
+                "ora": "^8.1.0",
                 "semver": "^7.6.2"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=22"
             }
         },
         "node_modules/@vscode/vsce": {
@@ -1756,7 +1757,8 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "optional": true
         },
         "node_modules/basic-ftp": {
             "version": "5.0.5",
@@ -2132,15 +2134,16 @@
             }
         },
         "node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2151,6 +2154,7 @@
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
             "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -3592,18 +3596,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/foreground-child/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3728,6 +3720,19 @@
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -4092,7 +4097,8 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "optional": true
         },
         "node_modules/ignore": {
             "version": "5.3.1",
@@ -4388,6 +4394,7 @@
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
             "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5157,13 +5164,17 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mimic-response": {
@@ -5634,15 +5645,16 @@
             }
         },
         "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "mimic-fn": "^2.1.0"
+                "mimic-function": "^5.0.0"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5683,33 +5695,35 @@
             }
         },
         "node_modules/ora": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
-            "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^5.3.0",
-                "cli-cursor": "^4.0.0",
-                "cli-spinners": "^2.9.0",
+                "cli-cursor": "^5.0.0",
+                "cli-spinners": "^2.9.2",
                 "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^1.3.0",
-                "log-symbols": "^5.1.0",
-                "stdin-discarder": "^0.1.0",
-                "string-width": "^6.1.0",
+                "is-unicode-supported": "^2.0.0",
+                "log-symbols": "^6.0.0",
+                "stdin-discarder": "^0.2.2",
+                "string-width": "^7.2.0",
                 "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5718,10 +5732,11 @@
             }
         },
         "node_modules/ora/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -5730,32 +5745,48 @@
             }
         },
         "node_modules/ora/node_modules/emoji-regex": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-            "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-            "dev": true
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ora/node_modules/is-unicode-supported": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/log-symbols": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-            "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "chalk": "^5.0.0",
-                "is-unicode-supported": "^1.1.0"
+                "chalk": "^5.3.0",
+                "is-unicode-supported": "^1.3.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5764,29 +5795,31 @@
             }
         },
         "node_modules/ora/node_modules/string-width": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
-            "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^10.2.1",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -6428,16 +6461,17 @@
             }
         },
         "node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6720,10 +6754,17 @@
             }
         },
         "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
@@ -6861,67 +6902,16 @@
             }
         },
         "node_modules/stdin-discarder": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-            "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
             "dev": true,
-            "dependencies": {
-                "bl": "^5.0.0"
-            },
+            "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stdin-discarder/node_modules/bl": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-            "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/stdin-discarder/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/stdin-discarder/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/stoppable": {

--- a/package.json
+++ b/package.json
@@ -2197,7 +2197,7 @@
         "@types/node": "^22.13.13",
         "@types/sinonjs__fake-timers": "^8.1.5",
         "@types/vscode": "^1.90.0",
-        "@vscode/test-electron": "^2.4.1",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.3.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^10.1.1",

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -79,6 +79,7 @@ type RedrawEventArgs =
                   | ""
                   | "confirm"
                   | "confirm_sub"
+                  | "empty"
                   | "emsg"
                   | "echo"
                   | "echomsg"

--- a/src/messages_manager.ts
+++ b/src/messages_manager.ts
@@ -52,6 +52,10 @@ export class MessagesManager implements Disposable {
                     // See: https://github.com/vscode-neovim/vscode-neovim/issues/2046#issuecomment-2144175058
                     if (kind === "return_prompt") continue;
 
+                    // An `empty` message (`:echo ""`) has no content. Skipping it clears the output when it is the only
+                    // message of the batch, and otherwise leaves the other messages alone.
+                    if (kind === "empty") continue;
+
                     // NOTE: we could also potentially handle e.g. `echoerr` differently here,
                     // like logging at error level or displaying a toast etc.
 
@@ -65,6 +69,7 @@ export class MessagesManager implements Disposable {
             }
 
             case "msg_clear": {
+                // Nvim cleared the screen (`CTRL-L`, `:mode`).
                 this.messageBuffer = [];
                 break;
             }
@@ -88,9 +93,15 @@ export class MessagesManager implements Disposable {
             }
 
             case "msg_history_clear":
-                // NOTE: this does not actually correspond to the `:messages clear`
+                // Nvim 0.11 and older: this does not actually correspond to the `:messages clear`
                 // command, but to when neovim wants us to clear our history buffer.
                 this.historyBuffer = [];
+                break;
+
+            case "cmdline_hide":
+                // Leaving the cmdline resets Nvim's message area, so the output must be
+                // rewritten even for a command that emits nothing, e.g. `:messages` with
+                // an empty history.
                 break;
 
             default:
@@ -100,11 +111,9 @@ export class MessagesManager implements Disposable {
         switch (name) {
             case "msg_clear":
             case "msg_history_clear":
-                // These clear messages are often followed by a flush whenever neovim
-                // thinks it's "done" showing those messages, resulting in an empty output
-                // panel instead of the desired display. To avoid flushing the now-empty
-                // buffer, we skip setting didChange so the flush becomes a no-op.
-                // Seems likely caused by/related to https://github.com/neovim/neovim/issues/20416
+                // Dropping staged text is not a change to write. Nvim 0.11 and older emit
+                // these after a message batch as well, where a rewrite would blank the panel
+                // instead of showing the messages.
                 break;
 
             default:
@@ -115,7 +124,13 @@ export class MessagesManager implements Disposable {
     }
 
     private async handleFlush(): Promise<void> {
-        if (!this.didChange) return;
+        if (!this.didChange) {
+            // A redraw without a message means Nvim's message area is idle, so the next msg_show belongs to a new
+            // batch. Nvim does not announce this with msg_clear. The channel still keeps its text.
+            this.messageBuffer = [];
+            this.historyBuffer = [];
+            return;
+        }
 
         const messages = this.displayHistory ? this.historyBuffer : this.messageBuffer;
         logger.trace(`Flushing ${this.displayHistory ? "history" : "message"} buffer: ${inspect(messages)}`);
@@ -134,13 +149,11 @@ export class MessagesManager implements Disposable {
             this.channel.show(true);
         }
 
-        // Reset all the state for the next batch of redraw messages
+        // Reset all the state for the next batch of redraw messages. The staging buffers
+        // are kept, bc a single batch can span several flushes: `:echom 1 | sleep 1 | echom 2`.
         this.didChange = false;
         this.displayHistory = false;
         this.revealOutput = false;
-        // Staging buffers must not persist across flushes or later msg_show events accumulate duplicates.
-        this.messageBuffer = [];
-        this.historyBuffer = [];
     }
 
     private writeMessage(msg: string): void {

--- a/src/test/integ/buffer-write-cmd.test.ts
+++ b/src/test/integ/buffer-write-cmd.test.ts
@@ -10,6 +10,7 @@ import {
     closeAllActiveEditors,
     closeNvimClient,
     sendEscapeKey,
+    sendNeovimKeys,
     sendVSCodeKeys,
     wait,
 } from "./integrationUtils";
@@ -120,7 +121,10 @@ describe("BufWriteCmd integration", () => {
         assert.equal(doc.isDirty, true);
         assert.equal(doc.getText(), "aaa");
 
-        await client.command(`silent w !${command}`);
+        // `:w !cmd` triggers the hit-enter prompt, send <CR> to continue.
+        const write = client.command(`silent w !${command}`);
+        await sendNeovimKeys(client, "<CR>");
+        await write;
         await wait(200);
         await commands.executeCommand("workbench.action.closePanel");
         assert.equal(doc.isDirty, true);

--- a/src/test/integ/integrationUtils.ts
+++ b/src/test/integ/integrationUtils.ts
@@ -40,6 +40,29 @@ export async function wait(timeout = 400): Promise<void> {
     await new Promise((res) => setTimeout(res, timeout));
 }
 
+/**
+ * Waits for an expected state, until `assertion` does not throw an error.
+ * Rethrows the last failure on `timeout`.
+ */
+export async function waitForCondition(
+    assertion: () => void | Promise<void>,
+    timeout = 3000,
+    interval = 50,
+): Promise<void> {
+    const deadline = Date.now() + timeout;
+    for (;;) {
+        try {
+            await assertion();
+            return;
+        } catch (e) {
+            if (Date.now() >= deadline) {
+                throw e;
+            }
+        }
+        await wait(interval);
+    }
+}
+
 export async function attachTestNvimClient(): Promise<NeovimClient> {
     const NV_HOST = process.env.NEOVIM_DEBUG_HOST || "127.0.0.1";
     const NV_PORT = process.env.NEOVIM_DEBUG_PORT || 4000;
@@ -167,17 +190,13 @@ export async function sendNeovimKeys(client: NeovimClient, keys: string, waitTim
 
 export async function sendEscapeKey(timeout = 250): Promise<void> {
     await commands.executeCommand("vscode-neovim.escape");
-    while (!hasVSCodeCursorStyle("block")) {
-        await wait(50);
-    }
+    await waitForCondition(() => assert.ok(hasVSCodeCursorStyle("block"), "escape should give a block cursor"), 10000);
     await wait(timeout);
 }
 
 export async function sendInsertKey(key = "i", timeout = 250): Promise<void> {
     await sendVSCodeKeys(key, 0);
-    while (!hasVSCodeCursorStyle("line")) {
-        await wait(50);
-    }
+    await waitForCondition(() => assert.ok(hasVSCodeCursorStyle("line"), `"${key}" should give a line cursor`), 10000);
     await wait(timeout);
 }
 

--- a/src/test/integ/messages.test.ts
+++ b/src/test/integ/messages.test.ts
@@ -14,6 +14,7 @@ import {
     sendVSCodeCommand,
     sendVSCodeKeys,
     wait,
+    waitForCondition,
 } from "./integrationUtils";
 
 function findOutputChannel(): TextEditor | undefined {
@@ -24,11 +25,14 @@ function findOutputChannel(): TextEditor | undefined {
     });
 }
 
-// On Windows, VSCode uses \r\n as the line break in output documents.
-function assertOutputContent(expected: string) {
-    const outputEditor = findOutputChannel();
-    const content = outputEditor?.document.getText();
-    assert.equal(content != null ? content.replace(/\r\n/g, "\n") : content, expected);
+// Windows uses \r\n as the line break in output documents, and Nvim right-pads a search
+// command with the room it reserves for the search count, so normalize both away.
+async function assertOutputContent(expected: string) {
+    await waitForCondition(() => {
+        const content = findOutputChannel()?.document.getText();
+        const normalize = (text: string) => text.replace(/\r\n/g, "\n").replace(/ +$/gm, "");
+        assert.equal(content != null ? normalize(content) : content, expected);
+    });
 }
 
 async function sendCommandLine(command: string) {
@@ -66,18 +70,23 @@ describe("Message output", () => {
 
     it("should reveal output panel with contents", async () => {
         await sendCommandLine("echo 1 | echom 2 | echo 3 | echom 4");
-        await wait();
-        assertOutputContent("1\n2\n3\n4\n");
+        await assertOutputContent("1\n2\n3\n4\n");
         await hideOutputPanel();
 
         await sendCommandLine("messages");
-        await wait();
-        assertOutputContent("echomsg: 2\nechomsg: 4\n");
+        await assertOutputContent("echomsg: 2\nechomsg: 4\n");
         await hideOutputPanel();
 
         await sendCommandLine("echo 5 | echo 6 | echo 7");
-        await wait();
-        assertOutputContent("5\n6\n7\n");
+        await assertOutputContent("5\n6\n7\n");
+
+        // An `empty` message alone clears the output, but not the messages beside it.
+        // The panel stays open from above: an empty message reveals nothing by itself.
+        await sendCommandLine('echo ""');
+        await assertOutputContent("");
+
+        await sendCommandLine('echo "" | echo 8');
+        await assertOutputContent("8\n");
     });
 
     it("should reveal after first line", async () => {
@@ -87,38 +96,30 @@ describe("Message output", () => {
         const outputEditor = findOutputChannel();
         assert.equal(outputEditor, undefined);
 
-        await wait(1400);
-        assertOutputContent("1\n2\n3\n");
+        await assertOutputContent("1\n2\n3\n");
         await hideOutputPanel();
 
         await sendCommandLine("messages");
-        await wait();
-        assertOutputContent("echomsg: 1\nechomsg: 2\nechomsg: 3\n");
+        await assertOutputContent("echomsg: 1\nechomsg: 2\nechomsg: 3\n");
     });
 
     it("should clear history", async () => {
         await sendCommandLine("echom 1 | echom 2 | echom 3");
-        await wait();
         await sendCommandLine("messages");
-        await wait();
-        assertOutputContent("echomsg: 1\nechomsg: 2\nechomsg: 3\n");
+        await assertOutputContent("echomsg: 1\nechomsg: 2\nechomsg: 3\n");
 
         await sendCommandLine("messages clear");
-        await wait();
         await sendCommandLine("messages");
-        await wait();
-        assertOutputContent("");
+        await assertOutputContent("");
     });
 
     it("should reveal for 'pattern not found' for cmdheight=1", async () => {
         await client.setOption("cmdheight", 1);
         await sendNeovimKeys(client, "/foobar\n");
-        await wait();
-        assertOutputContent("/foobar             \nE486: Pattern not found: foobar\n");
+        await assertOutputContent("/foobar\nE486: Pattern not found: foobar\n");
 
         await sendCommandLine("messages");
-        await wait();
-        assertOutputContent("emsg: E486: Pattern not found: foobar\n");
+        await assertOutputContent("emsg: E486: Pattern not found: foobar\n");
     });
 
     it("should suppress 'pattern not found' with cmdheight=2", async () => {
@@ -128,7 +129,6 @@ describe("Message output", () => {
         assert.equal(outputEditor, undefined);
 
         await sendCommandLine("messages");
-        await wait();
-        assertOutputContent("emsg: E486: Pattern not found: foobar\n");
+        await assertOutputContent("emsg: E486: Pattern not found: foobar\n");
     });
 });


### PR DESCRIPTION
Problem:
- Nvim no longer sends `msg_clear`, and `msg_history_clear` was dropped
  from the UI protocol: https://github.com/neovim/neovim/commit/2b4c1127ad1c8cff38f562d71f411c35ec6ba8d6
  , so the message buffer is reset on every flush instead. Messages
  from one command can span flushes (`:echom 1 | sleep 1 | echom 2 | echom 3`
  arrives as "1", then "2","3"), so the output was split and never
  reached `cmdheight` lines to be revealed.
- `:messages` on an empty history emits nothing, so the panel kept stale
  text after `:messages clear`.

Solution:
- End a message batch on a flush that has no message events.
- Rewrite the output on `cmdline_hide`, so a command that emits nothing
  clears the panel.

Tests:
- `:w !cmd` waits at the hit-enter prompt, send CR to continue.
- Nvim pads the search command to 24 columns now, not 20. Ignore trailing
  space instead of hardcoding it.
- Bump `@vscode/test-electron` to fix the macOS CI.


partial #2613 (that PR still has some improvements that can be rebased onto this one)
close #2507