### PR TITLE
fix(visual): wrong selections on nvim 0.13

### DIFF
--- a/runtime/lua/vscode/api.lua
+++ b/runtime/lua/vscode/api.lua
@@ -1,6 +1,8 @@
 local api = vim.api
 local fn = vim.fn
 
+local util = require("vscode.util")
+
 local M = {}
 
 ------------------------
@@ -399,7 +401,7 @@ do
         end_pos = { end_pos[1], #fn.getline(end_pos[1]) }
       end
 
-      local range = vim.lsp.util.make_given_range_params(start_pos, end_pos, 0, "utf-16").range
+      local range = util.lsp_range(0, start_pos[1], start_pos[2], end_pos[1], end_pos[2])
       local is_single_line = range.start.line == range["end"].line
       local is_current_line = is_single_line and range.start.line == fn.line(".") - 1
       ---@type Context
@@ -488,7 +490,7 @@ function M.with_insert(callback, ms)
       end_pos = { end_pos[1], #fn.getline(end_pos[1]) }
     end
 
-    local range = vim.lsp.util.make_given_range_params(start_pos, end_pos, 0, "utf-16").range
+    local range = util.lsp_range(0, start_pos[1], start_pos[2], end_pos[1], end_pos[2])
     local ranges = { range }
 
     api.nvim_win_set_cursor(0, end_pos)

--- a/runtime/lua/vscode/cursor.lua
+++ b/runtime/lua/vscode/cursor.lua
@@ -38,7 +38,7 @@ local function start_multi_cursor(right, skip_empty)
           e_col = math.min(#line, end_pos[2])
           s_col = math.min(e_col, start_pos[2])
         end
-        local range = vim.lsp.util.make_given_range_params({ row, s_col }, { row, e_col }, 0, "utf-16").range
+        local range = util.lsp_range(0, row, s_col, row, e_col)
         if right then
           range = { start = range["end"], ["end"] = range["end"] }
         else

--- a/runtime/lua/vscode/internal.lua
+++ b/runtime/lua/vscode/internal.lua
@@ -186,7 +186,8 @@ function M.get_selections(win)
   -- normal
 
   if not is_visual then
-    local pos = vim.lsp.util.make_position_params(win, "utf-16").position
+    local cursor = api.nvim_win_get_cursor(win)
+    local pos = util.lsp_position(buf, cursor[1], cursor[2])
     return { { start = pos, ["end"] = pos } }
   end
 
@@ -210,7 +211,7 @@ function M.get_selections(win)
       end_pos = { end_pos[1], #(fn.getbufline(buf, end_pos[1])[1] or "") }
     end
 
-    local range = vim.lsp.util.make_given_range_params(start_pos, end_pos, buf, "utf-16").range
+    local range = util.lsp_range(buf, start_pos[1], start_pos[2], end_pos[1], end_pos[2])
     if not start_from_left then
       range = { start = range["end"], ["end"] = range.start }
     end
@@ -248,7 +249,7 @@ function M.get_selections(win)
     end)
     if start_vcol > line_diswidth then
       if line_1 == curr_line_1 then
-        local pos = { line = line_0, character = ({ vim.str_utfindex(line_text) })[2] }
+        local pos = { line = line_0, character = util.utf16_col(line_text, #line_text) }
         table.insert(ranges, { start = pos, ["end"] = pos })
       else
         -- ignore
@@ -258,12 +259,13 @@ function M.get_selections(win)
       local end_col = util.virtcol2col(win, line_1, end_vcol)
       local start_col_offset = fn.strlen(util.get_char_at(line_1, start_col, buf) or "")
       local end_col_offset = fn.strlen(util.get_char_at(line_1, end_col, buf) or "")
-      local range = vim.lsp.util.make_given_range_params(
-        { line_1, math.max(0, start_col - start_col_offset) },
-        { line_1, math.max(0, end_col - end_col_offset) },
+      local range = util.lsp_range(
         buf,
-        "utf-16"
-      ).range
+        line_1,
+        math.max(0, start_col - start_col_offset),
+        line_1,
+        math.max(0, end_col - end_col_offset)
+      )
       if not start_from_left then
         range = { start = range["end"], ["end"] = range.start }
       end
@@ -273,7 +275,8 @@ function M.get_selections(win)
 
   if #ranges == 0 then
     -- impossible
-    local pos = vim.lsp.util.make_position_params(win, "utf-16").position
+    local cursor = api.nvim_win_get_cursor(win)
+    local pos = util.lsp_position(buf, cursor[1], cursor[2])
     return { { start = pos, ["end"] = pos } }
   end
 

--- a/runtime/lua/vscode/util.lua
+++ b/runtime/lua/vscode/util.lua
@@ -45,6 +45,55 @@ function M.get_line(bufnr, row)
   return M.get_lines(bufnr, { row })[row]
 end
 
+local str_utf16index = fn.has("nvim-0.11") == 1
+    and function(text, byte_col)
+      return vim.str_utfindex(text, "utf-16", byte_col)
+    end
+  or function(text, byte_col)
+    return select(2, vim.str_utfindex(text, byte_col))
+  end
+
+--- VSCode counts a position in UTF-16 code units, Nvim counts bytes.
+---
+---@param text string the line the column belongs to
+---@param byte_col integer zero-indexed byte column, clamped to `text`
+---@return integer zero-indexed UTF-16 column
+function M.utf16_col(text, byte_col)
+  byte_col = math.max(0, math.min(byte_col, #text))
+  return byte_col == 0 and 0 or str_utf16index(text, byte_col)
+end
+
+---@param buf integer
+---@param line integer one-indexed line
+---@param byte_col integer zero-indexed byte column
+---@return lsp.Position
+function M.lsp_position(buf, line, byte_col)
+  return { line = line - 1, character = M.utf16_col(M.get_line(buf, line - 1) or "", byte_col) }
+end
+
+--- Converts an inclusive Nvim byte range to an exclusive LSP range.
+---
+--- The end stops at the line end, so that a linewise range - which passes the whole
+--- line length as its end column - stays a valid position instead of running past it.
+---
+---@param buf integer
+---@param start_line integer one-indexed
+---@param start_col integer zero-indexed byte column
+---@param end_line integer one-indexed
+---@param end_col integer zero-indexed byte column, inclusive
+---@return lsp.Range
+function M.lsp_range(buf, start_line, start_col, end_line, end_col)
+  local end_text = M.get_line(buf, end_line - 1) or ""
+  local end_char = M.utf16_col(end_text, end_col)
+  if vim.o.selection ~= "exclusive" then
+    end_char = math.min(end_char + 1, M.utf16_col(end_text, #end_text))
+  end
+  return {
+    start = M.lsp_position(buf, start_line, start_col),
+    ["end"] = { line = end_line - 1, character = end_char },
+  }
+end
+
 --- Compare two positions
 ---@param a lsp.Position
 ---@param b lsp.Position

--- a/src/test/integ/external-buffers.test.ts
+++ b/src/test/integ/external-buffers.test.ts
@@ -15,7 +15,16 @@ import {
     openTextDocument,
     sendVSCodeKeysAtomic,
     wait,
+    waitForCondition,
 } from "./integrationUtils";
+
+// The help buffer reaches VSCode a moment after the Ex command returns.
+async function assertActiveEditorMatches(banner: RegExp, what: string): Promise<void> {
+    await waitForCondition(() => {
+        const text = vscode.window.activeTextEditor?.document.getText() ?? "";
+        assert.ok(banner.test(text), `${what} missing expected banner, got: ${text.slice(0, 200)}`);
+    });
+}
 
 describe("Neovim external buffers", () => {
     let client: NeovimClient;
@@ -38,21 +47,13 @@ describe("Neovim external buffers", () => {
         await sendVSCodeCommand("vscode-neovim.test-cmdline", "help");
         await sendVSCodeCommand("vscode-neovim.commit-cmdline", "", 1000);
 
-        const text = vscode.window.activeTextEditor!.document.getText();
-        assert.ok(
-            /NVIM DOCUMENTATION|Nvim documentation|MAIN HELP FILE/i.test(text),
-            `help index missing expected banner, got: ${text.slice(0, 200)}`,
-        );
+        await assertActiveEditorMatches(/NVIM DOCUMENTATION|Nvim documentation|MAIN HELP FILE/i, "help index");
 
         await sendVSCodeKeys(":");
         await sendVSCodeCommand("vscode-neovim.test-cmdline", "help options");
         await sendVSCodeCommand("vscode-neovim.commit-cmdline", "", 1000);
 
-        const text2 = vscode.window.activeTextEditor!.document.getText();
-        assert.ok(
-            /VIM REFERENCE MANUAL|REFERENCE MANUAL|options\.txt/i.test(text2),
-            `help options missing expected banner, got: ${text2.slice(0, 200)}`,
-        );
+        await assertActiveEditorMatches(/VIM REFERENCE MANUAL|REFERENCE MANUAL|options\.txt/i, "help options");
 
         await closeActiveEditor();
     });

--- a/src/test/integ/insert-mode-additions.test.ts
+++ b/src/test/integ/insert-mode-additions.test.ts
@@ -1,3 +1,5 @@
+import { strict as assert } from "assert";
+
 import vscode from "vscode";
 import { NeovimClient } from "neovim";
 
@@ -13,6 +15,8 @@ import {
     openTextDocument,
     sendInsertKey,
     sendVSCodeCommand,
+    getCurrentBufferContents,
+    waitForCondition,
 } from "./integrationUtils";
 
 describe("Simulated insert keys", () => {
@@ -149,6 +153,11 @@ describe("Simulated insert keys", () => {
 
         await sendVSCodeKeys("wi");
         await sendVSCodeKeys("blah blah");
+        // `<C-u>` deletes the characters entered in this insert session, so it must not
+        // overtake them on their way to Nvim: it would delete the whole line instead.
+        await waitForCondition(async () =>
+            assert.deepEqual(await getCurrentBufferContents(client), ["blah blah blahblah"]),
+        );
         await sendVSCodeCommand("vscode-neovim.send", "<C-u>");
 
         await sendEscapeKey();


### PR DESCRIPTION
Problem:
Linewise visual selections and (VScode) multicursor insert-points are
off-by-one on Nvim 0.13: `V` on a 14-char line yields (0,0)-(1,0)
instead of (0,0)-(0,14), and `V`+`A` inserts at the start of the next
line.

Analysis:
Nvim 0.13 `vim.lsp.util.make_given_range_params` was [reimplemented](https://github.com/neovim/neovim/commit/ff43f1950e1fd3b5ae37924bc8f9c6c3e9d54908) on
top of `vim.range.mark():to_lsp()`. The old version blindly did
`B[2] = B[2] + 1` to convert Nvim's inclusive end to LSP's exclusive end,
which VSCode clamped back to the line-end (thus it happened to work).

Solution:
- Convert byte columns to UTF-16, stopping the exclusive end at EOL.
- Drop the deprecated `make_given_range_params`, `make_position_params` and
  legacy `str_utfindex` calls.

Tests:
- Poll for the help buffer instead of waiting a fixed 1s.
- `Ctrl-u`: wait for the typed text to reach Nvim before sending it. Still
  fails on 0.13, but deterministically: Nvim has the text and does not
  treat it as entered in the current insert session.
