### PR TITLE
fix(dotrepeat): replay clobbers the insert session

### DIFF
--- a/runtime/lua/vscode/internal.lua
+++ b/runtime/lua/vscode/internal.lua
@@ -135,11 +135,33 @@ end
 do
   --- Replay changes for dotrepeat ---
 
-  local _curr_win, _temp_buf, _temp_win
+  local _curr_win, _temp_buf, _temp_win, _replaying
+
+  -- Insert entered from blockwise visual: Nvim replicates the insert across the selection
+  -- on <Esc>, and the replay's window switch loses that pending state.
+  local _block_insert = false
+  local group = api.nvim_create_augroup("vscode.dotrepeat", { clear = true })
+  api.nvim_create_autocmd("ModeChanged", {
+    group = group,
+    pattern = "*:i*",
+    callback = function()
+      _block_insert = vim.v.event.old_mode == "\22"
+    end,
+  })
+  api.nvim_create_autocmd("InsertLeave", {
+    group = group,
+    callback = function()
+      _block_insert = false
+    end,
+  })
 
   ---@param edits string
   ---@param deletes number
   function M.dotrepeat_sync(edits, deletes)
+    if _block_insert then
+      return
+    end
+    _replaying = true
     local ei = vim.opt.ei:get()
     vim.opt.ei = "all"
 
@@ -160,6 +182,10 @@ do
   end
 
   function M.dotrepeat_restore()
+    if not _replaying then
+      return
+    end
+    _replaying = false
     local ei = vim.opt.ei:get()
     vim.opt.ei = "all"
 

--- a/src/test/integ/buffer-write-cmd.test.ts
+++ b/src/test/integ/buffer-write-cmd.test.ts
@@ -3,12 +3,13 @@ import path from "path";
 import { symlink } from "fs/promises";
 
 import { NeovimClient } from "neovim";
-import { TextDocument, Uri, commands, window, workspace } from "vscode";
+import { TextDocument, Uri, window, workspace } from "vscode";
 
 import {
     attachTestNvimClient,
     closeAllActiveEditors,
     closeNvimClient,
+    hideOutputPanel,
     sendEscapeKey,
     sendNeovimKeys,
     sendVSCodeKeys,
@@ -126,7 +127,7 @@ describe("BufWriteCmd integration", () => {
         await sendNeovimKeys(client, "<CR>");
         await write;
         await wait(200);
-        await commands.executeCommand("workbench.action.closePanel");
+        await hideOutputPanel();
         assert.equal(doc.isDirty, true);
         assert.equal(doc.getText(), "aaa");
         assert.equal(await readFile(doc.uri), "hello world");

--- a/src/test/integ/integrationUtils.ts
+++ b/src/test/integ/integrationUtils.ts
@@ -162,6 +162,17 @@ export async function sendVSCodeCommand(command: string, args: unknown = "", wai
     await wait(waitTimeout);
 }
 
+/** Closes the panel, waiting until no output editor is left visible. */
+export async function hideOutputPanel(): Promise<void> {
+    await commands.executeCommand("workbench.action.closePanel");
+    await waitForCondition(() =>
+        assert.ok(
+            !window.visibleTextEditors.some((e) => e.document.uri.scheme === "output"),
+            "output panel should be hidden",
+        ),
+    );
+}
+
 export async function sendVSCodeKeysAtomic(keys: string, waitTimeout = 250): Promise<void> {
     await sendVSCodeCommand("type", { text: keys }, waitTimeout);
 }

--- a/src/test/integ/messages.test.ts
+++ b/src/test/integ/messages.test.ts
@@ -7,6 +7,7 @@ import { EXT_ID } from "../../constants";
 
 import {
     attachTestNvimClient,
+    hideOutputPanel,
     closeAllActiveEditors,
     closeNvimClient,
     openTextDocument,
@@ -39,11 +40,6 @@ async function sendCommandLine(command: string) {
     await sendVSCodeKeys(":");
     await sendVSCodeCommand("vscode-neovim.test-cmdline", command);
     await sendVSCodeCommand("vscode-neovim.commit-cmdline");
-}
-
-async function hideOutputPanel() {
-    await sendVSCodeCommand("workbench.action.closePanel");
-    await wait();
 }
 
 describe("Message output", () => {

--- a/src/test/integ/window-changed.test.ts
+++ b/src/test/integ/window-changed.test.ts
@@ -4,22 +4,30 @@ import path from "path";
 import { NeovimClient } from "neovim";
 import vscode, { Uri, ViewColumn, commands, window, workspace } from "vscode";
 
-import { attachTestNvimClient, closeAllActiveEditors, closeNvimClient, wait } from "./integrationUtils";
+import {
+    attachTestNvimClient,
+    closeAllActiveEditors,
+    closeNvimClient,
+    hideOutputPanel,
+    wait,
+    waitForCondition,
+} from "./integrationUtils";
 
 describe("handle window changed event", () => {
     let client: NeovimClient;
 
-    const winIdTextMap = new Map<number, string>();
-
-    const findWinId = (text: string) => {
-        for (const [winId, winText] of winIdTextMap.entries()) {
-            if (winText.includes(text)) return winId;
+    // Windows are looked up per switch: an editor that stops being visible loses its Nvim
+    // window, and gets a new one when it is shown again.
+    const findWinId = async (text: string) => {
+        for (const win of await client.getWindows()) {
+            const lines = await win.buffer.lines;
+            if (lines.join("\n").includes(text)) return win.id;
         }
-        return 0; // should not happen
+        throw new Error(`no Nvim window showing ${JSON.stringify(text)}`);
     };
 
-    async function setWin(winId: number) {
-        await client.request("nvim_set_current_win", [winId]);
+    async function setWin(text: string) {
+        await client.request("nvim_set_current_win", [await findWinId(text)]);
     }
 
     let textEditor1: vscode.TextEditor;
@@ -55,11 +63,7 @@ describe("handle window changed event", () => {
         await commands.executeCommand("workbench.panel.output.focus");
         await wait(400); // don't change
 
-        const wins = await client.getWindows();
-        for (const win of wins) {
-            const lines = await win.buffer.lines;
-            winIdTextMap.set(win.id, lines.join("\n"));
-        }
+        await hideOutputPanel();
     });
     after(async () => {
         await closeNvimClient(client);
@@ -68,38 +72,41 @@ describe("handle window changed event", () => {
     });
 
     it("text editor", async () => {
-        setWin(findWinId("text 1"));
-        await wait(800);
-        assert.equal(window.activeTextEditor, textEditor1);
+        await setWin("text 1");
+        await waitForCondition(() => assert.equal(window.activeTextEditor, textEditor1), 8000);
 
-        setWin(findWinId("text 2"));
-        await wait(400);
-        assert.equal(window.activeTextEditor, textEditor2);
+        await setWin("text 2");
+        await waitForCondition(() => assert.equal(window.activeTextEditor, textEditor2), 8000);
     });
 
     it("notebook", async () => {
-        setWin(findWinId("cell 1"));
-        await wait(1000);
-        assert.equal(window.activeNotebookEditor, notebookEditor);
-        assert.equal(window.activeTextEditor!.document.getText(), "cell 1");
+        await setWin("cell 1");
+        await waitForCondition(() => {
+            assert.equal(window.activeNotebookEditor, notebookEditor);
+            assert.equal(window.activeTextEditor?.document.getText(), "cell 1");
+        }, 8000);
 
-        setWin(findWinId("cell 2"));
-        await wait(1000);
-        assert.equal(window.activeNotebookEditor, notebookEditor);
-        assert.equal(window.activeTextEditor!.document.getText(), "cell 2");
+        await setWin("cell 2");
+        await waitForCondition(() => {
+            assert.equal(window.activeNotebookEditor, notebookEditor);
+            assert.equal(window.activeTextEditor?.document.getText(), "cell 2");
+        }, 8000);
     });
 
     it("output", async () => {
-        setWin(findWinId("output"));
+        // Give the channel a window again: the setup closed the panel.
+        outputChannel.show(true);
         await wait(400);
-        assert.notEqual(window.activeTextEditor, undefined);
-        assert.equal(window.activeTextEditor!.document.getText(), "output");
+
+        await setWin("output");
+        await waitForCondition(() => assert.equal(window.activeTextEditor?.document.getText(), "output"), 8000);
     });
 
     it("should ignore window change event when it isn't from neovim", async () => {
         await commands.executeCommand("workbench.action.openGlobalKeybindings");
-        await wait(400);
-        assert.equal(window.activeTextEditor, undefined);
-        assert.equal(window.activeNotebookEditor, undefined);
+        await waitForCondition(() => {
+            assert.equal(window.activeTextEditor, undefined);
+            assert.equal(window.activeNotebookEditor, undefined);
+        }, 8000);
     });
 });

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -301,7 +301,9 @@ export class TypingManager implements Disposable {
                     window.activeTextEditor.selection.active,
                     false,
                 );
-            await this.main.changeManager.syncDotRepeatWithNeovim();
+            if (this.isExitingInsertMode) {
+                await this.main.changeManager.syncDotRepeatWithNeovim();
+            }
             const keys = normalizeInputString(this.pendingKeysAfterExit);
             logger.debug(`Pending keys sent with ${key}: ${keys}`);
             this.pendingKeysAfterExit = "";


### PR DESCRIPTION
## Problem
`Ctrl-u` deletes the whole line instead of the text entered in this insert session, and `A` in visual block mode replicates the wrong text. `syncDotRepeatWithNeovim()` replays the change by typing into a temporary window while the caller's insert session is still live.

Since https://github.com/neovim/neovim/commit/2445fab6fb8c , `stop_arrow()` refreshes `Insstart` after syncing undo, so the replay re-anchors the session at cursor instead of where the insert began.

vscode-neovim depends on `Insstart` (Nvim-internal state) having "stale" state, which was fixed by that patch, but happens to "break" the hacky mechanism that vscode-neovim uses to support dot-repeat: text typed in VSCode reaches Nvim as an API edit, so Nvim has no insert to repeat, and the extension replays that text as keystrokes in a scratch window. The replay only worked while `Insstart` stayed (accidentally) anchored across it.

## Solution
- Replay only when the insert session is ending anyway. A key that stays in insert mode leaves the change pending for the `<Esc>` that ends it.
- Skip the replay while a blockwise insert is pending.

## Upstream issue

- https://github.com/neovim/neovim/issues/41757