### PR TITLE
test: skip focus-dependent tests on macOS

### DIFF
--- a/src/test/integ/integrationUtils.ts
+++ b/src/test/integ/integrationUtils.ts
@@ -63,6 +63,14 @@ export async function waitForCondition(
     }
 }
 
+/**
+ * Mocha's `describe`/`it` for tests that need the VSCode window to hold focus. It does not on
+ * macOS: neither `workbench.action.focus*EditorGroup` nor `window.showTextDocument()` moves
+ * `activeTextEditor` there.
+ */
+export const describeSkipMacos = process.platform === "darwin" ? describe.skip : describe;
+export const itSkipMacos = process.platform === "darwin" ? it.skip : it;
+
 export async function attachTestNvimClient(): Promise<NeovimClient> {
     const NV_HOST = process.env.NEOVIM_DEBUG_HOST || "127.0.0.1";
     const NV_PORT = process.env.NEOVIM_DEBUG_PORT || 4000;

--- a/src/test/integ/vscode-integration-specific.test.ts
+++ b/src/test/integ/vscode-integration-specific.test.ts
@@ -21,6 +21,7 @@ import {
     sendInsertKey,
     sendVSCodeCommand,
     sendNeovimKeys,
+    itSkipMacos,
 } from "./integrationUtils";
 
 describe("VSCode integration specific stuff", () => {
@@ -172,7 +173,7 @@ describe("VSCode integration specific stuff", () => {
         );
     });
 
-    it("Current mode is canceled when switching between editor panes", async () => {
+    itSkipMacos("Current mode is canceled when switching between editor panes", async () => {
         await openTextDocument({
             content: "blah1",
         });
@@ -314,7 +315,7 @@ describe("VSCode integration specific stuff", () => {
     });
 
     // !Passes only when the runner is in foreground
-    it("Cursor is preserved if same doc is opened in two editor columns", async () => {
+    itSkipMacos("Cursor is preserved if same doc is opened in two editor columns", async () => {
         const doc = (
             await openTextDocument(path.join(__dirname, "../../../test_fixtures/cursor-preserved-between-columns.txt"))
         ).document;

--- a/src/test/integ/window-changed.test.ts
+++ b/src/test/integ/window-changed.test.ts
@@ -6,6 +6,7 @@ import vscode, { Uri, ViewColumn, commands, window, workspace } from "vscode";
 
 import {
     attachTestNvimClient,
+    describeSkipMacos,
     closeAllActiveEditors,
     closeNvimClient,
     hideOutputPanel,
@@ -13,7 +14,7 @@ import {
     waitForCondition,
 } from "./integrationUtils";
 
-describe("handle window changed event", () => {
+describeSkipMacos("handle window changed event", () => {
     let client: NeovimClient;
 
     // Windows are looked up per switch: an editor that stops being visible loses its Nvim


### PR DESCRIPTION
Problem:
"handle window changed event" and two editor-group tests fail on macOS. They
need the VSCode window to hold focus, which it does not have there: neither
`workbench.action.focus*EditorGroup` nor `window.showTextDocument()` moves
`activeTextEditor`, in normal or insert mode. One of the two is already marked:

    // !Passes only when the runner is in foreground.

They only became visible when macOS started running the integration tests again
(@vscode/test-electron 3.1.0); before that the job died at launch.

Solution:
Skip the tests on macos, for now...
