### PR TITLE
fix(ci): broken release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
         ".": {
             "release-type": "node",
             "package-name": "vscode-neovim",
+            "include-component-in-tag": false,
             "changelog-sections": [
                 { "type": "feat", "section": "Features", "hidden": false },
                 { "type": "fix", "section": "Bug Fixes", "hidden": false },


### PR DESCRIPTION
Problem:
https://github.com/vscode-neovim/vscode-neovim/pull/2646 792593e687914dc077984458b837cbfa623c07df broke the release-please config.

Analysis:
`package-name` makes the package a component, and `include-component-in-tag`
defaults to true, so release-please looked for `vscode-neovim-v1.19.1` tags.
Our tags are `v1.19.1`, so it found no release, then proposed 1.18.7
with a nonsense CHANGELOG.

Solution:
Set `include-component-in-tag: false`.
