### PR TITLE
fix(window): stale window-changed event steals focus back

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -401,12 +401,10 @@ export class BufferManager implements Disposable {
             if (e) await window.showTextDocument(e.document, e.viewColumn);
         };
 
-        let targetEditor = this.getEditorFromWinId(winId);
-        if (!targetEditor) {
-            logger.debug(`target editor not found <check 1>, return to active editor`);
-            return returnToActiveEditor();
+        // `winId` is from the event, which can be stale by the time this debounced handler runs.
+        if (window.activeTextEditor && window.activeTextEditor === this.getEditorFromWinId(winId)) {
+            return;
         }
-        if (window.activeTextEditor === targetEditor) return;
 
         // since the event could be triggered by vscode side operations
         // we need to wait a bit to let vscode finish its internal operations
@@ -431,7 +429,7 @@ export class BufferManager implements Disposable {
         await this.main.cursorManager.waitForCursorUpdate(window.activeTextEditor);
 
         const { id: curwin } = await this.client.getWindow();
-        targetEditor = this.getEditorFromWinId(curwin);
+        const targetEditor = this.getEditorFromWinId(curwin);
         if (!targetEditor) {
             logger.debug(`target editor not found <check 2>, return to active editor`);
             return returnToActiveEditor();

--- a/src/test/integ/window-changed.test.ts
+++ b/src/test/integ/window-changed.test.ts
@@ -27,8 +27,19 @@ describeSkipMacos("handle window changed event", () => {
         throw new Error(`no Nvim window showing ${JSON.stringify(text)}`);
     };
 
-    async function setWin(text: string) {
-        await client.request("nvim_set_current_win", [await findWinId(text)]);
+    /**
+     * Focuses the Nvim window showing `text`, until `assertion` confirms VSCode settled.
+     */
+    async function setWin(text: string, assertion: () => void) {
+        // Use a for-loop because retrying in `waitForCondition` polls faster than the extension's debounce.
+        for (let attempts = 3; ; attempts--) {
+            await client.request("nvim_set_current_win", [await findWinId(text)]);
+            try {
+                return await waitForCondition(assertion, 3000);
+            } catch (e) {
+                if (attempts === 1) throw e;
+            }
+        }
     }
 
     let textEditor1: vscode.TextEditor;
@@ -73,25 +84,20 @@ describeSkipMacos("handle window changed event", () => {
     });
 
     it("text editor", async () => {
-        await setWin("text 1");
-        await waitForCondition(() => assert.equal(window.activeTextEditor, textEditor1), 8000);
-
-        await setWin("text 2");
-        await waitForCondition(() => assert.equal(window.activeTextEditor, textEditor2), 8000);
+        await setWin("text 1", () => assert.equal(window.activeTextEditor, textEditor1));
+        await setWin("text 2", () => assert.equal(window.activeTextEditor, textEditor2));
     });
 
     it("notebook", async () => {
-        await setWin("cell 1");
-        await waitForCondition(() => {
+        await setWin("cell 1", () => {
             assert.equal(window.activeNotebookEditor, notebookEditor);
             assert.equal(window.activeTextEditor?.document.getText(), "cell 1");
-        }, 8000);
+        });
 
-        await setWin("cell 2");
-        await waitForCondition(() => {
+        await setWin("cell 2", () => {
             assert.equal(window.activeNotebookEditor, notebookEditor);
             assert.equal(window.activeTextEditor?.document.getText(), "cell 2");
-        }, 8000);
+        });
     });
 
     it("output", async () => {
@@ -99,8 +105,7 @@ describeSkipMacos("handle window changed event", () => {
         outputChannel.show(true);
         await wait(400);
 
-        await setWin("output");
-        await waitForCondition(() => assert.equal(window.activeTextEditor?.document.getText(), "output"), 8000);
+        await setWin("output", () => assert.equal(window.activeTextEditor?.document.getText(), "output"));
     });
 
     it("should ignore window change event when it isn't from neovim", async () => {


### PR DESCRIPTION
Problem:
Test `handle window changed event > notebook` is flaky: focus stays on
cell 1 after switching to cell 2.

`buffer_manager.ts:handleWindowChanged()` resolves the editor from the
event-data winId, which can go stale during the 100ms debounce. A failed
lookup then calls `returnToActiveEditor()`, which reverts the switch
that superseded it. It also runs before the `CancellationToken` check.

Solution:
Let Nvim's current window be the authority: a failed lookup falls
through to the curwin re-read below.
