### PR TITLE
fix: hide internal commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -443,10 +443,6 @@
                 "title": "Neovim: Accept cmdline"
             },
             {
-                "command": "vscode-neovim.complete-selection-cmdline",
-                "title": "Neovim: Complete selection cmdline"
-            },
-            {
                 "command": "vscode-neovim.send-cmdline",
                 "title": "Neovim: Send key in cmdline"
             },
@@ -475,6 +471,42 @@
                 "title": "Neovim: ctrl-y"
             }
         ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "vscode-neovim.commit-cmdline",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.send-cmdline",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.ctrl-b",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.ctrl-d",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.ctrl-e",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.ctrl-f",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.ctrl-u",
+                    "when": "false"
+                },
+                {
+                    "command": "vscode-neovim.ctrl-y",
+                    "when": "false"
+                }
+            ]
+        },
         "keybindings": [
             {
                 "command": "vscode-neovim.escape",


### PR DESCRIPTION
Problem:
Commands meant to be driven by keybindings show up in the command palette,
where they do nothing useful.

Solution:
Hide them with a `menus.commandPalette` menu entry.

Note: Removing them from `contributes.commands` would also hide them,
but would drop their titles from the Keyboard Shortcuts UI.

Also delete `complete-selection-cmdline`, which is registered nowhere.


close https://github.com/vscode-neovim/vscode-neovim/pull/2537
close https://github.com/vscode-neovim/vscode-neovim/issues/2536
