### PR TITLE
ci: least-privilege workflow permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,8 +3,7 @@ name: Code Check & Test
 on: [pull_request, push]
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read
 
 jobs:
     build:
@@ -72,6 +71,10 @@ jobs:
         name: release-please
         if: ${{ github.ref == 'refs/heads/master' }}
         runs-on: ubuntu-latest
+        permissions:
+            # Create the release commit, tag and GitHub release, and open the release PR.
+            contents: write
+            pull-requests: write
         steps:
             # Configured by release-please-config.json: setting `release-type` here would
             # switch the action to its no-config mode and ignore that file.

--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
     contents: read
+    # webiny/action-conventional-commits reads the PR's commits.
+    pull-requests: read
 
 jobs:
     build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Check Style and Quality
 on: [pull_request, push]
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
     lint:


### PR DESCRIPTION
Problem:
Every job in `build_test.yml` runs with `contents: write` and
`pull-requests: write`, including the matrix jobs that check out and
execute PR code.

Solution:
Default all three workflows to `contents: read`, and narrow the write
scopes to the `release-please` job.
