### PR TITLE
fix: "Right-hand side of 'instanceof' is not an object"

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,5 @@
 import { NeovimClient } from "neovim";
-import { VimValue } from "neovim/lib/types/VimValue";
+import type { VimValue } from "neovim/lib/types/VimValue";
 import { ConfigurationTarget, Disposable, Range, commands, window, workspace } from "vscode";
 
 import { eval_for_client } from "./actions_eval";

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -2,7 +2,6 @@ import path from "path";
 
 import { debounce } from "lodash";
 import { Buffer, NeovimClient } from "neovim";
-import { ATTACH } from "neovim/lib/api/Buffer";
 import {
     CancellationToken,
     CancellationTokenSource,
@@ -1017,7 +1016,6 @@ class BufferProvider implements TextDocumentContentProvider {
         }
 
         buf.listen("lines", this.receivedBufferEvent);
-        await buf[ATTACH](true);
 
         return lines.join("\n");
     }


### PR DESCRIPTION
Problem:
Request to Nvim fails in 1.19.2:

    Failed to set current dir: Error: Right-hand side of 'instanceof' is not an object

node-client's `api/Buffer` and `api/types` require each other, and
`types.js` collects the ext-type classes at load time. Entering the package
through `neovim/lib/api/Buffer` (for `ATTACH`) leaves `Buffer` undefined
there, so the msgpack encoder's `instanceof` throws. The production
(webpack) bundle evaluates that import first; CI only tests the
development bundle.

Solution:
Drop the import. `buf[ATTACH](true)` was a no-op anyway: the `listen()`
before it already attaches the buffer, so `ATTACH` returned without sending
`nvim_buf_attach`.

fix https://github.com/vscode-neovim/vscode-neovim/issues/2671

I also have a fix for node-client itself, which would remove the need for this PR, but this PR is still a worthwhile cleanup.