### PR TITLE
feat(startup): improve find-Nvim logic + failure handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,9 @@ How to build (and install) from source:
         ```
 4. From VSCode, use the `Extensions: Install from VSIX` command to install the package.
 
-### Develop
+## Develop
+
+### Run the extension in the VSCode debugger
 
 1. Open the repo in VSCode.
 2. Go to debug view and click `Run Extension` (F5).
@@ -58,7 +60,7 @@ You can view the extension logs in one of these ways:
 Unit tests run in node only (not vscode), and can call code directly (unlike the integration tests). You can run unit
 tests independently by doing `npm run test:unit`.
 
-### Run Integration Tests
+### Run Integration Tests from VSCode
 
 Integration tests exercise a vscode instance which runs the vscode-neovim extension in a separate "extension host"
 process. These tests call the vscode API which indirectly exercises the extension; they cannot access the memory of the
@@ -76,6 +78,32 @@ by:
   run `npx husky` to install them.
 - run `npm run format` to automatically format typescript and lua code.
 - run `npm run lint` to check for errors in typescript code.
+
+The test scripts set `$NEOVIM_DEBUG` which has these effects:
+
+- Starts `nvim` with `--listen` argument, so Nvim listens on localhost TCP port.
+
+### Run Tests from CLI
+
+Build the extension (the `test` task only builds the test code, not the application code). Run this in a separate
+terminal:
+
+    npm run webpack-dev
+
+Run the tests in another terminal:
+
+    npm run test
+
+### Write Tests
+
+Tests can access the `vscode` API but cannot import modules from the extension codebase. For example this will not work:
+
+    // Cannot do this in tests.
+    import { MainController } from "../../main_controller";
+
+Instead, tests can invoke a vscode command which calls into the extension.
+
+    await commands.executeCommand("vscode-neovim.foo");
 
 ## Design Principles
 

--- a/README.md
+++ b/README.md
@@ -67,23 +67,19 @@ mode and VSCode commands, making the best use of both editors.
 
 ### Installation
 
-Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) extension.
+- Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) extension.
+- Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.10.0** or newer.
+    - (Optional) Set the Nvim path in the extension settings. You must specify the full path to Neovim, like
+      `C:\Neovim\bin\nvim.exe` or `/usr/local/bin/nvim`.
+    - Choose one of the following platform-specific settings:
+        - `vscode-neovim.neovimExecutablePaths.win32`
+        - `vscode-neovim.neovimExecutablePaths.linux`
+        - `vscode-neovim.neovimExecutablePaths.darwin`
+- If you want to use Neovim from WSL, set the `useWSL` configuration toggle and specify the Linux path to the nvim
+  binary. `wsl.exe` Windows binary and `wslpath` Linux binary are required for this. `wslpath` must be available through
+  `$PATH` Linux env setting. Use `wsl --list` to check for the correct default Linux distribution.
+- Assign [affinity](#affinity) value for performance improvement.
 
-Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.10.0** or greater.
-
-> **Note:** Though the extension strives to be as compatible as possible with older versions of Neovim, some older
-> versions may have quirks that are not present anymore. In light of this, certain configuration settings are
-> recommended in some older versions for the best experience. These can be found
-> [on the wiki](https://github.com/vscode-neovim/vscode-neovim/wiki/Version-Compatibility-Notes).
-
-\[Optional\] Set the Neovim path in the extension settings under
-"`vscode-neovim.neovimExecutablePaths.win32/linux/darwin`", respective to your system. For example,
-"`C:\Neovim\bin\nvim.exe`" or "`/usr/local/bin/nvim`".
-
-> **WSL Users:** If you want to use Neovim from WSL, set the `useWSL` configuration toggle and specify the Linux path to
-> the nvim binary. `wsl.exe` Windows binary and `wslpath` Linux binary are required for this. `wslpath` must be
-> available through `$PATH` Linux env setting. Use `wsl --list` to check for the correct default Linux distribution.
->
 > **Snap Users:** If you want to use Neovim from Snap, the Neovim path must be resolved to the snap binary location. On
 > some systems it might be "`/snap/nvim/current/usr/bin/nvim`". To check if you're running as a snap package, see if
 > `which nvim` resolves to `/usr/bin/snap`.
@@ -96,13 +92,13 @@ which types of plugins are supported, see [troubleshooting](#troubleshooting).
 Before creating an issue on Github, make sure you can reproduce the problem with an empty `init.vim` and no VSCode
 extensions.
 
-To determine if Neovim is running in VSCode, add to your `init.vim`:
+To detect if Nvim is running in VSCode, add to your `init.vim`:
 
 ```vim
 if exists('g:vscode')
     " VSCode extension
 else
-    " ordinary Neovim
+    " ordinary Nvim
 endif
 ```
 
@@ -112,7 +108,7 @@ In lua:
 if vim.g.vscode then
     -- VSCode extension
 else
-    -- ordinary Neovim
+    -- ordinary Nvim
 end
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "fast-myers-diff": "^3.2.0",
                 "grapheme-splitter": "^1.0.4",
                 "lodash": "^4.17.21",
-                "neovim": "^5.4.0",
+                "neovim": "^5.5.0",
                 "ts-wcwidth": "^2.0.3"
             },
             "devDependencies": {
@@ -561,11 +561,12 @@
             }
         },
         "node_modules/@msgpack/msgpack": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
-            "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+            "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+            "license": "ISC",
             "engines": {
-                "node": ">= 10"
+                "node": ">= 18"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -5768,19 +5769,19 @@
             "dev": true
         },
         "node_modules/neovim": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/neovim/-/neovim-5.4.0.tgz",
-            "integrity": "sha512-95YXs6d5p8M0k8xrmJHQ9aVLv9ebpM3ZQnmTaSpbJtPSdxFaKq7szCP1Ou+S8K++rEsh7BvTPwqdtdlwQfT0pw==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/neovim/-/neovim-5.5.0.tgz",
+            "integrity": "sha512-B68xdr5OUwLuUgD73aDa3yCg10Lg7gqroIDrSadvDpCJFC52pOD22iOI+omzQi+sgixTl5UyOHqnAd73E5RlEA==",
             "license": "MIT",
             "dependencies": {
-                "@msgpack/msgpack": "^2.8.0",
+                "@msgpack/msgpack": "^3.1.3",
                 "winston": "3.15.0"
             },
             "bin": {
                 "neovim-node-host": "bin/cli.js"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
             }
         },
         "node_modules/node-abi": {

--- a/package.json
+++ b/package.json
@@ -415,6 +415,10 @@
         },
         "commands": [
             {
+                "command": "vscode-neovim.viewLogs",
+                "title": "Neovim: View Extension Logs"
+            },
+            {
                 "command": "vscode-neovim.restart",
                 "title": "Neovim: Restart Extension"
             },
@@ -2252,7 +2256,7 @@
         "fast-myers-diff": "^3.2.0",
         "grapheme-splitter": "^1.0.4",
         "lodash": "^4.17.21",
-        "neovim": "^5.4.0",
+        "neovim": "^5.5.0",
         "ts-wcwidth": "^2.0.3"
     }
 }

--- a/runtime/vscode-neovim.vim
+++ b/runtime/vscode-neovim.vim
@@ -20,40 +20,6 @@ end
 vim.opt.rtp:prepend(vim.g.vscode_neovim_runtime)
 EOF
 
-" Check version
-lua << EOF
-local MIN_VERSION = vim.g.vscode_nvim_min_version
-
-local cmp = -1 ---@type -1|0|1
-local prerelease = false
-if vim.version and vim.version.parse then
-  local v = vim.version()
-  local curr = { v.major, v.minor, v.patch }
-  local min = vim.version.parse(MIN_VERSION)
-  cmp = vim.version.cmp(curr, min)
-  prerelease = not not v.prerelease
-end
-
-local warn = true
-local msgs = {
-  ("vscode-neovim requires nvim version %s or higher."):format(MIN_VERSION),
-  "Install the [latest stable version](https://github.com/neovim/neovim/releases/latest).",
-}
-if cmp < 0 then
-  -- nothing
-elseif cmp == 0 and prerelease then
-  table.insert(msgs, 2, ("Current version is a **prerelease** of %s.").format(MIN_VERSION))
-else
-  warn = false
-end
-
-if warn then
-  vim.rpcnotify(vim.g.vscode_channel, "vscode-action", "eval", {
-    args = { "vscode.window.showErrorMessage(args)", table.concat(msgs, " ") },
-  })
-end
-EOF
-
 " Load altercmd
 " {{{
 " altercmd - Alter built-in Ex commands by your own ones

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,16 @@ type SettingPrefix = "neovimExecutablePaths" | "neovimInitVimPaths"; //this need
 
 export type CompositeKeys = { [key: string]: { command: string; args?: any[] } };
 
+/** Opens the vscode settings UI at the given setting id. */
+export async function openSettingsId(key: string): Promise<void> {
+    await commands.executeCommand("workbench.action.openSettings", `@id:${key}`);
+}
+
+/** Opens the vscode settings UI at the given settings name/prefix. */
+export async function openSettings(name: string): Promise<void> {
+    await commands.executeCommand("workbench.action.openSettings", name);
+}
+
 export class Config implements Disposable {
     private disposables: Disposable[] = [];
     private readonly root = EXT_NAME;

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -223,7 +223,7 @@ export class CursorManager implements Disposable {
             logger.debug(`Received cursor update from neovim, gridId: ${gridId}`);
             const editor = this.main.bufferManager.getEditorFromGridId(gridId);
             if (!editor) {
-                logger.warn(`No editor for gridId: ${gridId}`);
+                logger.debug(`No editor for gridId: ${gridId}`);
                 continue;
             }
             // lock typing in editor until cursor update is complete

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,9 +2,9 @@ import * as vscode from "vscode";
 
 import actions from "./actions";
 import { config } from "./config";
-import { EXT_ID } from "./constants";
+import { EXT_ID, EXT_NAME } from "./constants";
 import { eventBus } from "./eventBus";
-import { createLogger, logger as rootLogger } from "./logger";
+import { createLogger, getLogs, logger as rootLogger } from "./logger";
 import { MainController } from "./main_controller";
 import { VSCodeContext, disposeAll } from "./utils";
 
@@ -13,9 +13,14 @@ const logger = createLogger(EXT_ID);
 // Store the disposables that need to be disposed of when the extension
 // deactivates and are not affected by the restart command.
 const disposables: vscode.Disposable[] = [];
+// Created once, with `disposables`: "vscode-neovim.restart" re-runs activate() without disposing either.
+let outputChannel: vscode.LogOutputChannel;
+
 export async function activate(context: vscode.ExtensionContext, isRestart = false): Promise<void> {
     if (!isRestart) {
+        outputChannel = vscode.window.createOutputChannel(EXT_NAME, { log: true });
         disposables.push(
+            outputChannel,
             vscode.commands.registerCommand("vscode-neovim.restart", async () => {
                 deactivate(true);
                 disposeAll(context.subscriptions);
@@ -25,12 +30,17 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
                 deactivate(true);
                 disposeAll(context.subscriptions);
             }),
+            vscode.commands.registerCommand("vscode-neovim.viewLogs", () => outputChannel.show()),
         );
+        if (process.env.NEOVIM_DEBUG) {
+            // Lets tests inspect log messages (see `getLogs`).
+            disposables.push(vscode.commands.registerCommand("_vscodeneovim._test", () => getLogs()));
+        }
         verifyExperimentalAffinity();
     }
 
     config.init();
-    rootLogger.init(config.logPath, config.outputToConsole);
+    rootLogger.init(config.logPath, config.outputToConsole, outputChannel);
     eventBus.init();
     actions.init();
     context.subscriptions.push(
@@ -47,10 +57,12 @@ export async function activate(context: vscode.ExtensionContext, isRestart = fal
         await plugin.init();
     } catch (e) {
         vscode.window
-            .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart")
+            .showErrorMessage(`[Failed to start nvim] ${e instanceof Error ? e.message : e}`, "Restart", "View Logs")
             .then((value) => {
                 if (value === "Restart") {
                     vscode.commands.executeCommand("vscode-neovim.restart");
+                } else if (value === "View Logs") {
+                    outputChannel.show();
                 }
             });
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,7 +5,6 @@ import { Disposable, window } from "vscode";
 import * as vscode from "vscode";
 
 import { disposeAll } from "./utils";
-import { EXT_NAME } from "./constants";
 
 export interface ILogger {
     trace(...args: any[]): void;
@@ -26,8 +25,11 @@ export interface ILogger {
     log(uri: vscode.Uri | undefined, level: vscode.LogLevel, ...logArgs: any[]): void;
 }
 
-function getTimestamp(): string {
-    return new Date().toISOString();
+/** Last 10000 log messages, recorded only with $NEOVIM_DEBUG (see `assertLogs`). */
+const debugLogs: string[] = [];
+
+export function getLogs(): readonly string[] {
+    return debugLogs;
 }
 
 export class Logger implements Disposable {
@@ -45,12 +47,10 @@ export class Logger implements Disposable {
      * @param filePath Write messages to this file.
      * @param logToConsole Write messages to the `console` (Hint: run the "Developer: Toggle Developer Tools" vscode command to see the console).
      */
-    public init(filePath: string, logToConsole = false) {
-        this.outputChannel = window.createOutputChannel(`${EXT_NAME} logs`, { log: true });
-        this.disposables.push(
-            this.outputChannel,
-            this.outputChannel.onDidChangeLogLevel((level) => this.onLogLevelChanged(level)),
-        );
+    /** @param outputChannel Owned by the caller, which also disposes it. */
+    public init(filePath: string, logToConsole: boolean, outputChannel: vscode.LogOutputChannel) {
+        this.outputChannel = outputChannel;
+        this.disposables.push(this.outputChannel.onDidChangeLogLevel((level) => this.onLogLevelChanged(level)));
 
         this.level = this.outputChannel.logLevel;
         this.logToConsole = logToConsole;
@@ -102,7 +102,9 @@ export class Logger implements Disposable {
     }
 
     private log(level: vscode.LogLevel, scope: string, logToOutputChannel: boolean, args: any[]): void {
-        const msg = args.reduce((p, c, i) => {
+        const timestamp = new Date().toISOString();
+
+        const msg = args.reduce<string>((p, c, i) => {
             if (typeof c === "object") {
                 try {
                     c = inspect(c, false, 2, false);
@@ -110,11 +112,18 @@ export class Logger implements Disposable {
                     // ignore
                 }
             }
-            return p + (i > 0 ? " " : "") + c;
+            return `${p}${i > 0 ? " " : ""}${c}`;
         }, "");
 
+        if (process.env.NEOVIM_DEBUG) {
+            debugLogs.push(msg);
+            if (debugLogs.length > 10000) {
+                debugLogs.shift();
+            }
+        }
+
         if (this.fd || this.logToConsole) {
-            const logMsg = `${getTimestamp()} ${scope}: ${msg}`;
+            const logMsg = `${timestamp} ${scope}: ${msg}`;
             if (this.fd) {
                 fs.appendFileSync(this.fd, logMsg + "\n");
             }
@@ -128,7 +137,7 @@ export class Logger implements Disposable {
         const activeDoc = window.activeTextEditor?.document; // "output:asvetliakov.vscode-neovim.vscode-neovim"
         const outputFocused = activeDoc?.uri.scheme === "output" || activeDoc?.fileName?.startsWith("output:");
         if (logToOutputChannel && this.outputChannel && activeDoc && !outputFocused) {
-            const fullMsg = `${scope}: ${msg}`;
+            const fullMsg = `${scope}: ${msg.trim()}`;
             switch (level) {
                 case vscode.LogLevel.Error:
                     this.outputChannel.error(fullMsg);

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -10,7 +10,7 @@ import actions from "./actions";
 import { BufferManager } from "./buffer_manager";
 import { CommandLineManager } from "./cmdline_manager";
 import { CommandsController } from "./commands_controller";
-import { config } from "./config";
+import { config, openSettings } from "./config";
 import { isWindows, NVIM_MIN_VERSION } from "./constants";
 import { CursorManager } from "./cursor_manager";
 import { DocumentChangeManager } from "./document_change_manager";
@@ -63,7 +63,7 @@ export class MainController implements vscode.Disposable {
 
     public async init(): Promise<void> {
         const [cmd, args] = this.buildSpawnArgs();
-        logger.info(`Starting nvim: ${cmd} ${args.join(" ")}`);
+        logger.info(`Starting: ${cmd} ${args.join(" ")}`);
         this.nvimProc = spawn(cmd, args);
         this.disposables.push(
             new Disposable(() => {
@@ -104,7 +104,6 @@ export class MainController implements vscode.Disposable {
         this.setClientInfo();
         await this.setCurrentDir();
         await this.client.setVar("vscode_channel", await this.client.channelId);
-        await this.client.setVar("vscode_nvim_min_version", NVIM_MIN_VERSION);
 
         // This is an exception. Should avoid doing this.
         Object.defineProperty(actions, "client", { get: () => this.client, configurable: true });
@@ -159,9 +158,56 @@ export class MainController implements vscode.Disposable {
 
     private _stop(msg: string) {
         vscode.commands.executeCommand("vscode-neovim.stop");
-        vscode.window.showErrorMessage(msg, "Restart").then((value) => {
-            if (value === "Restart") vscode.commands.executeCommand("vscode-neovim.restart");
+        vscode.window.showErrorMessage(msg, "Restart", "View Logs").then((value) => {
+            if (value === "Restart") {
+                vscode.commands.executeCommand("vscode-neovim.restart");
+            } else if (value === "View Logs") {
+                vscode.commands.executeCommand("vscode-neovim.viewLogs");
+            }
         });
+    }
+
+    /**
+     * The command that runs Nvim, or shows a message w/ buttons if there is a problem.
+     */
+    private resolveNvimCmd(minVersion: string): string[] {
+        // The user-configured command (checked, never substituted), else search.
+        const distro = config.wslDistribution.length ? ["-d", config.wslDistribution] : [];
+        const cmds = config.useWsl
+            ? [[wslExe, ...distro, config.neovimPath]]
+            : config.neovimPath !== "nvim"
+              ? [[config.neovimPath]]
+              : undefined;
+
+        const r = findNvim({ minVersion, orderBy: "desc", cmds });
+        logger.debug("Find nvim result: ", r);
+        const match = r.matches[0];
+        if (match) {
+            logger.info(`Found Nvim${cmds ? " (user-configured)" : ""}:`, match.cmd.join(" "));
+            return match.cmd;
+        }
+
+        // The details go to the log, which "View Logs" opens.
+        const tooOld = r.invalid.filter((v) => !v.error);
+        let msg = "";
+        if (tooOld.length > 0) {
+            msg = `Nvim ${minVersion} or newer is required (found ${tooOld[0].nvimVersion}).`;
+            logger.info(`${msg} Too old:`, tooOld.map((v) => `${v.cmd.join(" ")} : ${v.nvimVersion}`).join(", "));
+        } else {
+            msg = "Nvim not found. Install it, or set its path in settings.";
+            logger.info(msg, r.invalid.map((v) => `${v.cmd.join(" ")} : ${v.error?.message}`).join(", "));
+        }
+
+        vscode.window.showErrorMessage(msg, "Update Nvim", "Set Path", "View Logs").then((value) => {
+            if (value === "Update Nvim") {
+                vscode.env.openExternal(vscode.Uri.parse("https://neovim.io/doc/install/"));
+            } else if (value === "Set Path") {
+                openSettings("vscode-neovim.neovimExecutablePaths");
+            } else if (value === "View Logs") {
+                vscode.commands.executeCommand("vscode-neovim.viewLogs");
+            }
+        });
+        throw new Error(msg);
     }
 
     private buildSpawnArgs(): [string, string[]] {
@@ -176,36 +222,14 @@ export class MainController implements vscode.Disposable {
         // These paths get called inside WSL, they must be POSIX paths (forward slashes)
         const neovimPreScriptPath = path.posix.join(extensionPath, "runtime", "vscode-neovim.vim");
 
-        const args = [];
-
-        if (config.useWsl) {
-            args.push(wslExe);
-            if (config.wslDistribution.length) {
-                args.push("-d", config.wslDistribution);
-            }
-        }
-
-        let neovimPath = config.neovimPath;
-        // Only try to find nvim if the path is the default one
-        // And if we are not using WSL
-        if (neovimPath === "nvim" && !config.useWsl) {
-            const nvimResult = findNvim({ minVersion: NVIM_MIN_VERSION });
-            logger.debug("Find nvim result: ", nvimResult);
-            const matched = nvimResult.matches.find((match) => !match.error);
-            if (!matched) {
-                throw new Error("Unable to find a suitable neovim executable. Please check your neovim installation.");
-            }
-            neovimPath = matched.path;
-        }
-
-        args.push(
-            neovimPath,
+        const args: string[] = [
+            ...this.resolveNvimCmd(NVIM_MIN_VERSION),
             "-N",
             "--embed",
-            // Initialize vscode neovim modules
+            // Initialize vscode-neovim modules
             "--cmd",
             `execute 'source' fnameescape('${neovimPreScriptPath.replace(/'/g, "''")}')`,
-        );
+        ];
 
         if (parseInt(process.env.NEOVIM_DEBUG || "", 10) === 1) {
             args.push(

--- a/src/test/integ/integrationUtils.ts
+++ b/src/test/integ/integrationUtils.ts
@@ -358,6 +358,28 @@ async function assertContentOnce(
 }
 
 /**
+ * Asserts that the extension logged a message matching the pattern(s) in `expect`.
+ */
+export async function assertLogs(expect: RegExp[], timeout = 3000, stack = new Error().stack): Promise<void> {
+    // Registered only when NEOVIM_DEBUG is set (see extension.ts).
+    const getMsgs = async () => (await commands.executeCommand<string[]>("_vscodeneovim._test")) ?? [];
+
+    try {
+        await waitUntil(async () => {
+            const msgs = await getMsgs();
+            const missing = expect.filter((pattern) => !msgs.some((msg) => pattern.test(msg)));
+            assert.ok(
+                missing.length === 0,
+                `No log message matches ${missing.join(", ")}\nLast logged:\n  ${msgs.slice(-100).join("\n  ")}`,
+            );
+        }, timeout);
+    } catch (e) {
+        (e as Error).stack = stack;
+        throw e;
+    }
+}
+
+/**
  * Selects `selection`, waiting for the change to reach Nvim.
  *
  * Assigning a selection queues a sync to Nvim that lands whenever it lands, so a selection that is

--- a/src/test/integ/startup.test.ts
+++ b/src/test/integ/startup.test.ts
@@ -1,0 +1,26 @@
+import { NeovimClient } from "neovim";
+
+import { assertLogs, attachTestNvimClient, closeAllActiveEditors, closeNvimClient } from "./integrationUtils";
+
+describe("startup", () => {
+    let client: NeovimClient;
+    before(async () => {
+        client = await attachTestNvimClient();
+    });
+    after(async () => {
+        await closeNvimClient(client);
+        await closeAllActiveEditors();
+    });
+
+    it("logs the Nvim it resolved", async () => {
+        await assertLogs([/Found Nvim( \(user-configured\))?:/]);
+    });
+
+    it("logs the command line it spawned", async () => {
+        await assertLogs([/Starting: .*nvim/, /--embed/, /--cmd .*vscode-neovim\.vim/]);
+    });
+
+    it("logs the Nvim version it connected to", async () => {
+        await assertLogs([/Nvim info/, /nvimVersion:/, /configDir:/]);
+    });
+});

--- a/src/typing_manager.ts
+++ b/src/typing_manager.ts
@@ -2,7 +2,7 @@
 // Learn more: https://github.com/microsoft/vscode-extension-samples/tree/main/vim-sample
 import { commands, Disposable, TextEditor, TextEditorEdit, window, workspace } from "vscode";
 
-import { CompositeKeys, config } from "./config";
+import { CompositeKeys, config, openSettingsId } from "./config";
 import { createLogger } from "./logger";
 import { MainController } from "./main_controller";
 import { disposeAll, normalizeInputString } from "./utils";
@@ -170,9 +170,16 @@ export class TypingManager implements Disposable {
         this.compositeSecondKeysForFirstKey = new Map();
         Object.keys(this.compositeKeys).forEach((key) => {
             if (!/^[ -~]{2}$/.test(key)) {
-                window.showErrorMessage(
-                    `Invalid composite key: ${key}. Composite key must be exactly 2 ASCII characters long.`,
-                );
+                window
+                    .showErrorMessage(
+                        `Invalid composite key: ${key}. Composite key must be exactly 2 ASCII characters long.`,
+                        "Configure",
+                    )
+                    .then((value) => {
+                        if (value === "Configure") {
+                            openSettingsId("vscode-neovim.compositeKeys");
+                        }
+                    });
                 return;
             }
             const [first, second] = key.split("");


### PR DESCRIPTION
Problem:
- A user-configured Nvim path (or WSL command) is used without checking
  that it runs or meets the minimum version.
- If no Nvim is found, the error ("Unable to find a suitable neovim
  executable") doesn't say whether Nvim is missing or too old, or how
  to fix it.
- No test coverage for startup.

ref https://github.com/vscode-neovim/vscode-neovim/issues/2234

Solution:
- Use the new `findNvim({ cmds })` feature of node-client.
- Show msg w/ `Install`, `Set Path` and `View Logs` buttons.
- Add `Neovim: View Extension Logs` command.
- Composite-key errors get a "Configure" button.
- Test: `assertLogs()` reads recent log messages via the
  `_vscodeneovim._test` command (only with `$NEOVIM_DEBUG`).

Example log messages:

    MainController: Found Nvim (user-configured): /usr/local/bin/nvim
    MainController: Nvim 0.10.0 or newer is required. Found: /usr/local/bin/nvim : 0.9.5

fix #2607
fix #2234
